### PR TITLE
feat(highcharts): read four series types the adapter drew nothing for

### DIFF
--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -302,7 +302,17 @@ export function buildSubplot(
   // already takes, and the centred offsets live on `stackY` where nothing
   // needs them. No radial variant exists, so `radialType` keeps its empty set.
   const areaTypes = new Set(radialType ? [] : ['area', 'areaspline', 'streamgraph']);
-  const barTypes = new Set(['bar', 'column']);
+  // `columnpyramid` and `pictorial` are a column drawn differently -- a
+  // tapered outline, and a repeated icon -- and carry the same `point.y` per
+  // category that `column` does. Highcharts registers each as its own series
+  // type, so both fell past every bucket and their charts came out with no
+  // layers at all, the same way `streamgraph` did (#1138).
+  const barTypes = new Set([
+    'bar',
+    'column',
+    'columnpyramid',
+    'pictorial',
+  ]);
 
   const lineSeries = convertible.filter(s => lineTypes.has(resolveSeriesType(s, chart)));
   const areaSeries = convertible.filter(s => areaTypes.has(resolveSeriesType(s, chart)));
@@ -1547,6 +1557,20 @@ function convertSeries(
       return isCategoryScatter(series)
         ? convertDotSeries(series, containerId)
         : convertScatterSeries(series, containerId);
+    // A scatter whose markers carry a third quantity in their size.
+    // `ScatterPoint.z` already holds it and already drives `zIntensityFor()`,
+    // so the trace side needed nothing -- this adapter simply never reached
+    // it, and a bubble chart came out silent (#1138). The same gap Chart.js
+    // had in #826, one step worse.
+    //
+    // Read as a scatter even on a category axis, where a plain scatter reads
+    // as a dot plot instead. That branch exists because a scatter pinned to
+    // ticks really is one value per category -- which a bubble is not: it has
+    // two, and `convertDotSeries` emits `BarPoint`s, which have nowhere to
+    // put the second. The category name is not lost either way; it travels as
+    // `xLabel`.
+    case 'bubble':
+      return convertScatterSeries(series, containerId);
     case 'lollipop':
       return convertLollipopSeries(series, containerId);
     case 'funnel':
@@ -1584,8 +1608,14 @@ function convertSeries(
     // is why these emitted no layer at all until `ErrorBarPoint.y` became
     // optional (#1047). `areasplinerange` is `arearange` with a smoothed
     // outline; the curve between the samples is drawing, not data.
+    //
+    // `columnrange` draws the same band as bars rather than as a filled
+    // ribbon, and carries the same two fields, so it reads through the same
+    // converter. It was silent for the same reason the other two were, and
+    // stayed silent after #1047 only because nothing dispatched it (#1138).
     case 'arearange':
     case 'areasplinerange':
+    case 'columnrange':
       return convertRangeSeries(series, chart, containerId);
     case 'dumbbell':
       return convertDumbbellSeries(series, containerId, options);
@@ -3585,15 +3615,40 @@ function stampGanttIndices(laneSources: HighchartsPoint[][]): void {
   stampPointIndices(laneSources, 'data-maidr-task-index');
 }
 
+/**
+ * A scatter, or a bubble chart -- a scatter whose markers carry a size.
+ *
+ * `z` is kept where the series has one, because it is a third measured
+ * quantity and not decoration: `ScatterTrace` reads it through
+ * `zIntensityFor()`, so the size becomes audible as well as readable. Dropping
+ * it is what #826 fixed for Chart.js, and what this adapter did to every
+ * `bubble` series until #1138 -- though there the size was the lesser loss,
+ * since the series reached no converter at all and the chart was silent.
+ *
+ * A `bubble` point without a `z` is still a point: it is filtered on `y`
+ * alone, so a series that mixes sized and unsized markers keeps both, and the
+ * unsized ones simply carry no third quantity.
+ *
+ * @param series - The scatter or bubble series
+ * @param containerId - The chart's container, for the selector
+ * @returns The layer
+ */
 function convertScatterSeries(
   series: HighchartsSeries,
   containerId: string,
 ): MaidrLayer {
+  // A category axis names the slot each point sits in, and `xLabel` is the
+  // field for that -- "this position on x is called Norway", as against
+  // `label`, which names the point itself. A continuous axis has no such name,
+  // so nothing is invented where there is none.
+  const named = isCategoryScatter(series);
   const data: ScatterPoint[] = series.data
     .filter(p => p.y !== null)
     .map(p => ({
       x: p.x,
       y: p.y as number,
+      ...(typeof p.z === 'number' ? { z: p.z } : {}),
+      ...(named ? { xLabel: String(pointLabel(p)) } : {}),
     }));
 
   return {

--- a/src/adapters/highcharts/types.ts
+++ b/src/adapters/highcharts/types.ts
@@ -255,6 +255,14 @@ export interface HighchartsPoint {
    * read the same way.
    */
   x2?: number;
+  /**
+   * A bubble's size, as the third quantity the marker's area encodes.
+   *
+   * Highcharts names it `z` and so does `ScatterPoint`, which reads it through
+   * `zIntensityFor()` -- so a bubble's size is a measurement to be announced
+   * and sonified rather than a drawing parameter (#1138).
+   */
+  z?: number;
   /** Boxplot / candlestick high value, error bar upper bound, dumbbell high. */
   high?: number;
   /** Boxplot / candlestick low value, error bar lower bound, dumbbell low. */

--- a/test/adapters/highcharts/unreachedSeries.test.ts
+++ b/test/adapters/highcharts/unreachedSeries.test.ts
@@ -1,0 +1,155 @@
+import type { ErrorBarPoint, ScatterPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { TraceType } from '@type/grammar';
+import { fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+/**
+ * Series types the adapter drew nothing for (#1138).
+ *
+ * `convertSeries` dispatches on the series type and its `default:` warns and
+ * returns `null`, so a series it does not name contributes no layer and the
+ * chart reads as though it were not there. On a single-series chart that is
+ * silence. Sixteen of Highcharts' types were in that position; these four
+ * needed no new trace type, no new point shape and no convention decision --
+ * each is a chart MAIDR already reads, drawn under a name this adapter did
+ * not know.
+ *
+ * The other twelve are recorded on #1138 rather than here: four want a
+ * judgement written down first (`bellcurve`, `pareto`, `timeline`,
+ * `organization`), three have no honest reading at all (`venn`, `polygon`,
+ * `vector`/`windbarb`/`flags`), and `variwide` is a mosaic, which is more
+ * than a dispatch line.
+ */
+
+const CATEGORIES = ['a', 'b', 'c'];
+
+/**
+ * A one-series chart of the given type.
+ *
+ * @param type - The Highcharts series type to draw
+ * @param data - The series' points
+ * @returns The chart
+ */
+function chartOf(type: string, data: unknown[]): ReturnType<typeof fakeChart> {
+  return fakeChart({
+    title: 'Measured',
+    renderToId: 'chart',
+    series: [fakeSeries({
+      index: 0,
+      type,
+      name: type,
+      xAxis: fakeAxis({ categories: CATEGORIES }),
+      yAxis: fakeAxis({ options: { title: { text: 'Value' } } }),
+      data: data as never,
+    })],
+  });
+}
+
+/**
+ * The layers a chart of the given type produces.
+ *
+ * @param type - The Highcharts series type to draw
+ * @param data - The series' points
+ * @returns The layers, which was an empty list for every type here
+ */
+function layersOf(type: string, data: unknown[]): { type: string; data: unknown }[] {
+  const maidr = highchartsToMaidr(chartOf(type, data));
+  return (maidr?.subplots?.[0]?.[0]?.layers ?? []) as never;
+}
+
+const SIZED = CATEGORIES.map((category, i) => ({
+  x: i,
+  category,
+  y: (i + 1) * 10,
+  z: i + 2,
+}));
+const BANDS = CATEGORIES.map((category, i) => ({
+  x: i,
+  category,
+  low: i * 5,
+  high: i * 5 + 8,
+}));
+const PLAIN = CATEGORIES.map((category, i) => ({
+  x: i,
+  category,
+  y: (i + 1) * 10,
+}));
+
+describe('highcharts series the adapter did not reach', () => {
+  it('reads a bubble as the scatter it is, keeping the marker size', () => {
+    const [layer] = layersOf('bubble', SIZED);
+
+    expect(layer.type).toBe(TraceType.SCATTER);
+    // `z` is a third measured quantity, not decoration: `ScatterTrace` reads
+    // it through `zIntensityFor()`, so the size is audible as well as
+    // readable. Dropping it is the defect #826 fixed for Chart.js.
+    expect((layer.data as ScatterPoint[]).map(p => p.z)).toEqual([2, 3, 4]);
+    expect((layer.data as ScatterPoint[]).map(p => p.y)).toEqual([10, 20, 30]);
+  });
+
+  it('keeps an unsized bubble point rather than dropping it', () => {
+    // A series that mixes sized and unsized markers keeps both; the unsized
+    // one simply carries no third quantity. Filtering on `z` instead would
+    // silently lose a drawn point.
+    const mixed = [
+      { x: 0, category: 'a', y: 10, z: 4 },
+      { x: 1, category: 'b', y: 20 },
+    ];
+    const [layer] = layersOf('bubble', mixed);
+
+    expect((layer.data as ScatterPoint[])).toHaveLength(2);
+    expect((layer.data as ScatterPoint[])[1].z).toBeUndefined();
+  });
+
+  it('keeps a bubble on a category axis a scatter, and keeps the name', () => {
+    // A plain scatter pinned to ticks reads as a dot plot, because it really
+    // is one value per category. A bubble is not: it has two, and
+    // `convertDotSeries` emits `BarPoint`s, which have nowhere to put the
+    // second -- so a categorical bubble read as a dot would lose its size
+    // silently, which is #826's defect wearing a different name.
+    const [layer] = layersOf('bubble', SIZED);
+
+    expect(layer.type).toBe(TraceType.SCATTER);
+    // The category name is not the price of that: it travels as `xLabel`,
+    // which is the field for "this position on x is called a".
+    expect((layer.data as ScatterPoint[]).map(p => p.xLabel))
+      .toEqual(CATEGORIES);
+  });
+
+  it('leaves a plain categorical scatter reading as the dot plot it is', () => {
+    // The guard on the branch above: only `bubble` changed.
+    const [layer] = layersOf('scatter', PLAIN);
+
+    expect(layer.type).toBe(TraceType.DOT);
+  });
+
+  it('reads a columnrange as the band it draws', () => {
+    const [layer] = layersOf('columnrange', BANDS);
+
+    expect(layer.type).toBe(TraceType.ERROR_BAR);
+    const points = layer.data as ErrorBarPoint[];
+    expect(points.map(p => [p.yMin, p.yMax])).toEqual([[0, 8], [5, 13], [10, 18]]);
+    // No estimate to invent: a column drawn from low to high has no centre,
+    // which is exactly what #1047 made expressible.
+    expect(points.every(p => p.y === undefined)).toBe(true);
+  });
+
+  it.each(['columnpyramid', 'pictorial'])(
+    'reads %s as the column it carries the data of',
+    (type) => {
+      // Same `point.y` per category as `column`; only the painting differs.
+      const [layer] = layersOf(type, PLAIN);
+
+      expect(layer.type).toBe(TraceType.BAR);
+      expect((layer.data as { y: number }[]).map(p => p.y)).toEqual([10, 20, 30]);
+    },
+  );
+
+  it('still declines a series with no statistical reading', () => {
+    // The guard on the change: dispatching more types must not turn into
+    // dispatching every type. A `venn` has no axis and a `polygon` has no
+    // reading, so both stay declined rather than being forced into a shape.
+    expect(layersOf('venn', PLAIN)).toHaveLength(0);
+    expect(layersOf('polygon', PLAIN)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Refs #1138 — the first group from that sweep, the one that needs no decisions.

## The measurement

#814's trace roadmap is closed, so the question is no longer what MAIDR can express but which of it each adapter reaches. Driving every Highcharts series type through `highchartsToMaidr` and counting the layers found **sixteen** that produce none. `convertSeries`'s `default:` warns and returns `null`, so on a single-series chart the result is silence.

```
bubble           — no layer      columnpyramid    — no layer
packedbubble     — no layer      variwide         — no layer
columnrange      — no layer      bellcurve        — no layer
pareto           — no layer      timeline         — no layer
item             — no layer      organization     — no layer
venn             — no layer      polygon          — no layer
vector           — no layer      windbarb         — no layer
flags            — no layer      pictorial        — no layer

spline             line                     ← control
areaspline         area                     ← control
```

## What this PR takes

The four that are charts MAIDR already reads, drawn under a name this adapter did not know — no new trace type, no new point shape, no convention decision:

| series | reads as |
|---|---|
| `bubble` | `scatter`, with the marker's size in `z` |
| `columnrange` | `error_bar` — the band `arearange` already reads |
| `columnpyramid` | `bar` |
| `pictorial` | `bar` |

`columnrange` is worth a note: it is the same `low`/`high` band the area range types draw, painted as bars. It could not have been read at all before #1047 made `ErrorBarPoint.y` optional, and after #1047 it stayed silent only because nothing dispatched it.

## One judgement inside it

`convertScatterSeries` dropped `z`, which `ScatterPoint` has held and `zIntensityFor()` has read since #826 — so a bubble's size is a measurement, not decoration, and it is now carried.

That forced a second choice. **A bubble is read as a scatter even on a category axis**, where a plain scatter reads as a dot plot instead. That branch is right for a scatter — it really is one value per category — and wrong for a bubble, which has two: `convertDotSeries` emits `BarPoint`s, which have nowhere to put the second, so a categorical bubble read as a dot would lose its size silently. That is #826's defect wearing a different name.

The category name is not the price of that. It travels as `xLabel`, the field for "this position on x is called *a*", which `ScatterTrace` already reads. A test pins that a plain categorical scatter still reads as a dot plot, so only `bubble` moved.

## What it deliberately leaves

Recorded on #1138 rather than guessed at here: four want a judgement written down first (`bellcurve`, `pareto`, `timeline`, `organization`), `variwide` is a mosaic and more than a dispatch line, and the rest have no honest statistical reading. A test asserts `venn` and `polygon` are **still declined** — the guard that dispatching more types does not drift into dispatching every type.

## Verification

Eight tests in `test/adapters/highcharts/unreachedSeries.test.ts`. Mutation-tested, each part reverted alone; all five killed:

| mutation | tests failed |
|---|---|
| bubble's size dropped | 1 |
| categorical bubble reads as a dot | 2 |
| category name not carried | 1 |
| `columnrange` undispatched | 1 |
| the two bar spellings undispatched | 2 |

`npm run lint:fix`, `npm run type-check` and `npm run build` clean. `npm test` → 5453 passed (392 suites) + 137 passed (10 ESM suites).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_