### PR TITLE
feat(amcharts): read the three hierarchy paintings the binder declined

### DIFF
--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -2006,6 +2006,29 @@ const STANDALONE_KINDS: Record<string, SeriesKind> = {
   Treemap: 'treemap',
   Partition: 'icicle',
   Sunburst: 'sunburst',
+  // Three more paintings of the one hierarchy `extractHierarchyPoints`
+  // already reads: `Tree` draws it as nodes and links, `Pack` as nested
+  // circles, `LinkedHierarchy` as its base class. They carry the same nested
+  // `children` shape the three above do, and reach the same converter -- the
+  // only thing that kept them out was this map, which gates discovery through
+  // `STANDALONE_SERIES_CLASSES`, so the series was never wrapped as a panel
+  // and the binder reported no supported chart (#1140).
+  //
+  // Read under `treemap` rather than a name of their own. The grammar already
+  // treats that as the general one -- `ICICLE` and `SUNBURST` are both
+  // documented as "the same hierarchy as a TREEMAP, drawn as ..." -- and the
+  // navigation is identical, since all three share one branch of the
+  // dispatch. The cost is that a circle-packing or node-link diagram
+  // announces itself as a treemap, which is a fourth and fifth painting
+  // reported under the first's name. Trace types of their own would say it
+  // exactly and are a grammar change; that option is open on #1140.
+  //
+  // `Venn` is deliberately absent. An overlap diagram has no axis and no
+  // per-category magnitude to walk, so declining it is the reading, not a
+  // gap.
+  Tree: 'treemap',
+  Pack: 'treemap',
+  LinkedHierarchy: 'treemap',
   WordCloud: 'wordcloud',
   Sankey: 'sankey',
   ArcDiagram: 'sankey',

--- a/test/adapters/amcharts/hierarchyPaintings.test.ts
+++ b/test/adapters/amcharts/hierarchyPaintings.test.ts
@@ -1,0 +1,97 @@
+import { fromAmCharts } from '@adapters/amcharts/adapter';
+import { classifySeriesKind } from '@adapters/amcharts/extractor';
+import { TraceType } from '@type/grammar';
+import { fakeChart, fakeContainer, fakeRoot, fakeSeries } from './helpers';
+
+/**
+ * amCharts draws one hierarchy five ways, and the adapter read three (#1140).
+ *
+ * `Treemap`, `Partition` and `Sunburst` share a single branch of the dispatch
+ * and a single converter, because they are one hierarchy painted three ways --
+ * the grammar says as much, calling `ICICLE` and `SUNBURST` "the same
+ * hierarchy as a TREEMAP, drawn as ...". `Tree` (nodes and links), `Pack`
+ * (nested circles) and `LinkedHierarchy` (their base) carry the same nested
+ * `children` shape and would have read through the same converter, but
+ * `STANDALONE_SERIES_CLASSES` gates discovery: a class not in it is never
+ * wrapped as a panel, so the binder reported no supported chart at all.
+ *
+ * Measured before the fix, by both routes a series can arrive by:
+ *
+ *     Tree             throws "no XYChart or Pie" / "no supported series"
+ *     Pack             throws "no XYChart or Pie" / "no supported series"
+ *     LinkedHierarchy  throws "no XYChart or Pie" / "no supported series"
+ *     Treemap          treemap                                    <- control
+ *
+ * Both throws are the binder's documented contract, so this was the adapter
+ * declining rather than misreading -- the same shape as #1138's Highcharts
+ * gap, reached through a discovery gate instead of a switch.
+ */
+
+const NODES = [
+  { name: 'root', value: 100 },
+  { name: 'a', value: 60 },
+  { name: 'b', value: 40 },
+];
+
+/**
+ * A hierarchy series of the given amCharts class.
+ *
+ * @param className - The am5hierarchy class to draw as
+ * @returns The series
+ */
+function hierarchy(className: string): ReturnType<typeof fakeSeries> {
+  return fakeSeries({
+    className,
+    name: className,
+    settings: { categoryField: 'name', valueField: 'value' },
+    data: NODES,
+  });
+}
+
+/**
+ * The layer types a root produces.
+ *
+ * @param root - The am5 root to read
+ * @returns One trace type per layer, or `[]` when the binder declined
+ */
+function layerTypes(root: unknown): string[] {
+  const maidr = fromAmCharts(root as never);
+  return (maidr?.subplots?.flat().flatMap(s => s?.layers ?? []) ?? [])
+    .map(layer => layer.type);
+}
+
+const PAINTINGS = ['Tree', 'Pack', 'LinkedHierarchy'] as const;
+
+describe('amCharts hierarchy paintings', () => {
+  it.each(PAINTINGS)('reads a standalone %s as the hierarchy it is', (className) => {
+    // The am5hierarchy pattern: a series pushed straight into a container,
+    // with no chart around it. This threw before the fix.
+    const root = fakeRoot([fakeContainer([hierarchy(className)])]);
+
+    expect(layerTypes(root)).toEqual([TraceType.TREEMAP]);
+  });
+
+  it.each(PAINTINGS)('reads %s inside a chart too', (className) => {
+    const root = fakeRoot([fakeChart({ series: [hierarchy(className)] })]);
+
+    expect(layerTypes(root)).toEqual([TraceType.TREEMAP]);
+  });
+
+  it('reads them the same way it reads a treemap', () => {
+    // The point of the change: these are one hierarchy, so they resolve to
+    // one reading rather than to five near-identical ones.
+    const drawn = PAINTINGS.map(c => classifySeriesKind({ className: c } as never));
+
+    expect(drawn).toEqual(['treemap', 'treemap', 'treemap']);
+    expect(classifySeriesKind({ className: 'Treemap' } as never)).toBe('treemap');
+  });
+
+  it('still declines a Venn', () => {
+    // Not an oversight. An overlap diagram has no axis and no per-category
+    // magnitude to walk, so not reading it is the reading -- the same answer
+    // `polygon` gets in the Highcharts sweep (#1138).
+    const root = fakeRoot([fakeContainer([hierarchy('Venn')])]);
+
+    expect(() => layerTypes(root)).toThrow(/no XYChart or PieChart/);
+  });
+});


### PR DESCRIPTION
Refs #1140.

## First, a correction

I filed #1140 claiming four amCharts classes were **announced as bar charts**. That was wrong, and I have corrected the issue. I measured `classifySeriesKind` in isolation, saw it return `'bar'`, and generalised without checking whether the paths that reach it are reachable. They are not — both entry points filter these classes out first.

Measured properly, by both routes a series can arrive by:

```
                    standalone container         inside an XYChart
Tree                throws "no XYChart or Pie"    throws "no supported series"
Pack                throws "no XYChart or Pie"    throws "no supported series"
LinkedHierarchy     throws "no XYChart or Pie"    throws "no supported series"
Venn                throws "no XYChart or Pie"    throws "no supported series"

Treemap             treemap                       treemap        ← control
```

Both throws are the binder's documented contract (`@throws If no supported chart is found …`), so this is the adapter **declining**, not misreading. Nothing was being announced as a bar chart.

## The gap that is real

amCharts draws one hierarchy five ways, and this adapter read three. `Treemap`, `Partition` and `Sunburst` share a single branch of the dispatch and a single converter, because they are one hierarchy painted three ways — the grammar says so, calling `ICICLE` and `SUNBURST` "the same hierarchy as a `TREEMAP`, drawn as …".

`Tree` (nodes and links), `Pack` (nested circles) and `LinkedHierarchy` (their base) carry the same nested `children` shape and would have read through the same converter. What kept them out was `STANDALONE_KINDS`, whose keys gate discovery through `STANDALONE_SERIES_CLASSES`: a class not in it is never wrapped as a panel, so the series never reaches the converter that could read it.

Same shape as #1138's Highcharts finding — a chart MAIDR already reads, under a name the adapter does not know — reached through a discovery gate instead of a switch. The change is three lines in one map.

## The tradeoff, stated

They read under **`treemap`** rather than names of their own, because the grammar already treats that as the general one and the navigation is identical. **The cost is that a circle-packing or node-link diagram announces itself as a treemap** — a fourth and fifth painting reported under the first's name. `TraceType` entries of their own would say it exactly and are a grammar change; that option stays open on #1140. If you want that instead, this is a three-line map to redirect.

## `Venn` stays out, deliberately

An overlap diagram has no axis and no per-category magnitude to walk, so declining it is the reading rather than a gap — the same answer `polygon` gets in #1138. A test holds it there, so a later pass adding hierarchy classes cannot quietly sweep it in.

## Verification

Eight tests in `test/adapters/amcharts/hierarchyPaintings.test.ts`, covering both arrival routes for each of the three plus the `Venn` decline. Mutation-tested, all three killed:

| mutation | tests failed |
|---|---|
| the three unmapped again | 6 |
| only `Pack` unmapped | 3 |
| `Venn` wrongly mapped | 1 |

`npm run lint:fix`, `npm run type-check` and `npm run build` clean. `npm test` → 5461 passed (393 suites) + 137 passed (10 ESM suites).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_