### PR TITLE
feat(braille): open the go-to-extrema dialog with g while braille is on

### DIFF
--- a/src/service/goToExtrema.ts
+++ b/src/service/goToExtrema.ts
@@ -31,9 +31,19 @@ export class GoToExtremaService {
     return trace instanceof AbstractTrace && trace.supportsExtremaNavigation();
   }
 
+  /**
+   * Leaves the GO_TO_EXTREMA scope, returning to whichever scope opened the
+   * dialog. `toggleFocus` pops GO_TO_EXTREMA off the focus stack, so the
+   * restored scope is BRAILLE when the dialog was opened from braille mode and
+   * TRACE when it was opened from the chart.
+   *
+   * The guard tests for GO_TO_EXTREMA rather than "not TRACE": the dismissal
+   * paths call this both directly and after `hide()` has already restored the
+   * scope, and a "not TRACE" guard would read the restored BRAILLE scope as
+   * still-open and push GO_TO_EXTREMA back onto the stack.
+   */
   public returnToTraceScope(): void {
-    // Ensure we return to TRACE scope
-    if (this.context.scope !== Scope.TRACE) {
+    if (this.context.scope === Scope.GO_TO_EXTREMA) {
       this.display.toggleFocus(Scope.GO_TO_EXTREMA);
     }
   }

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -75,6 +75,16 @@ const BRAILLE_KEYMAP = {
   // Chart description
   TOGGLE_DESCRIPTION: key(`d`, 'Open Chart Description'),
 
+  // Go To functionality
+  //
+  // Bound here as well as in TRACE so jumping to an extremum does not require
+  // leaving braille first. The dialog opens on top of the braille scope and
+  // GoToExtremaService returns to whichever scope opened it, so braille is
+  // still on — and re-rendered at the new cursor — once the dialog closes.
+  // `preventDefault` in the hotkeys handler keeps the `g` out of the braille
+  // textarea's own value.
+  GO_TO_EXTREMA_TOGGLE: key(`g`, 'Go To Extrema'),
+
   // rotor functionality
   ROTOR_NEXT_NAV: key(`${Platform.alt}+shift+up`, 'Next Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + up` }),
   ROTOR_PREV_NAV: key(`${Platform.alt}+shift+down`, 'Previous Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + down` }),

--- a/test/service/goToExtremaScope.test.ts
+++ b/test/service/goToExtremaScope.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Scope handling for the go-to-extrema dialog.
+ *
+ * The `g` binding exists in both TRACE and BRAILLE scope, so the dialog has to
+ * hand the scope back to whichever one opened it. These tests drive the real
+ * DisplayService focus stack so the restored scope is the one a user would
+ * actually land in.
+ */
+import type { Context } from '@model/context';
+import type { TextService } from '@service/text';
+import type { TraceState } from '@type/state';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { AbstractTrace } from '@model/abstract';
+import { DisplayService } from '@service/display';
+import { GoToExtremaService } from '@service/goToExtrema';
+import { Scope } from '@type/event';
+
+/** Minimal plot element exposing only what DisplayService touches. */
+function createMockPlot(): HTMLElement {
+  return {
+    focus: jest.fn(),
+    setAttribute: jest.fn(),
+    removeAttribute: jest.fn(),
+    tabIndex: 0,
+  } as unknown as HTMLElement;
+}
+
+function createMockTextService(): TextService {
+  return {
+    onChange: jest.fn(() => ({ dispose: jest.fn() })),
+    format: jest.fn(() => ''),
+  } as unknown as TextService;
+}
+
+/**
+ * A trace the service accepts as extrema-navigable. `isExtremaNavigable` is an
+ * `instanceof AbstractTrace` check, so the stub is built on that prototype
+ * rather than as a plain object.
+ */
+function createNavigableTrace(): AbstractTrace {
+  const trace = Object.create(AbstractTrace.prototype) as AbstractTrace;
+  (trace as unknown as { supportsExtremaNavigation: () => boolean }).supportsExtremaNavigation = () => true;
+  return trace;
+}
+
+/** Context stub that applies `toggleScope` to its own `scope`, as the real one does. */
+function createMockContext(scope: Scope): Context {
+  const context = {
+    scope,
+    state: { type: 'trace', empty: false },
+    active: createNavigableTrace(),
+    getInstruction: jest.fn(() => 'test instruction'),
+    toggleScope: jest.fn((next: Scope) => {
+      context.scope = next;
+    }),
+  };
+  return context as unknown as Context;
+}
+
+const TRACE_STATE = { type: 'trace', empty: false } as unknown as TraceState;
+
+describe('goToExtremaService scope restore', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function setup(): { context: Context; display: DisplayService; service: GoToExtremaService } {
+    const context = createMockContext(Scope.TRACE);
+    const display = new DisplayService(context, createMockPlot(), createMockTextService());
+    const service = new GoToExtremaService(context, display);
+    return { context, display, service };
+  }
+
+  test('returns to braille mode when the dialog is opened from braille', () => {
+    const { context, display, service } = setup();
+
+    // Enter braille mode the way ToggleBrailleCommand does.
+    display.toggleFocus(Scope.BRAILLE);
+    jest.runAllTimers();
+    expect(context.scope).toBe(Scope.BRAILLE);
+
+    service.toggle(TRACE_STATE);
+    expect(context.scope).toBe(Scope.GO_TO_EXTREMA);
+
+    service.returnToTraceScope();
+    jest.runAllTimers();
+    expect(context.scope).toBe(Scope.BRAILLE);
+  });
+
+  test('returns to the chart when the dialog is opened from trace scope', () => {
+    const { context, service } = setup();
+
+    service.toggle(TRACE_STATE);
+    expect(context.scope).toBe(Scope.GO_TO_EXTREMA);
+
+    service.returnToTraceScope();
+    jest.runAllTimers();
+    expect(context.scope).toBe(Scope.TRACE);
+  });
+
+  test('does not reopen the dialog scope when the scope was already restored', () => {
+    const { context, display, service } = setup();
+
+    display.toggleFocus(Scope.BRAILLE);
+    jest.runAllTimers();
+
+    service.toggle(TRACE_STATE);
+    service.returnToTraceScope();
+    jest.runAllTimers();
+
+    // The navigation-failure path calls this a second time after hide() has
+    // already restored the scope; it must stay put instead of pushing
+    // GO_TO_EXTREMA back on with no dialog rendered.
+    service.returnToTraceScope();
+    jest.runAllTimers();
+    expect(context.scope).toBe(Scope.BRAILLE);
+  });
+});

--- a/test/service/help.test.ts
+++ b/test/service/help.test.ts
@@ -98,17 +98,18 @@ describe('help menu generation', () => {
     const trace = menuFor(Scope.TRACE).map(item => item.key);
 
     // Bound in TRACE only — braille must not offer them.
-    expect(trace).toContain('g');
     expect(trace.some(key => key.endsWith('shift + p'))).toBe(true);
     expect(trace.some(key => key.endsWith('+ L'))).toBe(true);
 
-    expect(braille).not.toContain('g');
     expect(braille.some(key => key.endsWith('shift + p'))).toBe(false);
     expect(braille.some(key => key.endsWith('+ L'))).toBe(false);
 
-    // Shared bindings still show up, including the `l` label chord.
+    // Shared bindings still show up, including the `l` label chord and the
+    // extrema dialog, which braille mode reaches without leaving braille.
     expect(braille).toContain('b');
+    expect(braille).toContain('g');
     expect(braille).toContain('l x');
+    expect(trace).toContain('g');
   });
 
   it('shows the label chord under the scope it is reached from', () => {


### PR DESCRIPTION
# Pull Request

## Description

`g` (Go To Extrema) was bound in `TRACE` scope only. A user reading a chart on a braille display had to press `b` to leave braille mode, press `g`, jump to the minimum/maximum/intersection, then press `b` again to bring braille back at the new position. This binds `g` in `BRAILLE` scope as well, so the jump happens without leaving braille.

## Related Issues

<!-- none linked -->

## Changes Made

- **`src/service/keybinding.ts`** — added `GO_TO_EXTREMA_TOGGLE: key('g', 'Go To Extrema')` to `BRAILLE_KEYMAP`. The hotkeys filter already allow-lists the braille textarea, and the handler's `preventDefault` keeps the `g` character out of the textarea's own value. Because the entry carries a description, `HelpService` picks it up and the braille help menu now lists it too.

- **`src/service/goToExtrema.ts`** — `returnToTraceScope()` guarded on `scope !== TRACE`, which reads any non-`TRACE` scope as "dialog still open". Opened from braille that is wrong in two ways: the restored `BRAILLE` scope looks unfinished, and the navigation-failure path — which calls the restore a second time after `hide()` has already run it — pushes `GO_TO_EXTREMA` back onto the focus stack with no dialog rendered. The guard now tests for the `GO_TO_EXTREMA` scope itself, so `DisplayService.toggleFocus` pops the dialog off the focus stack and lands on whichever scope opened it (`BRAILLE` or `TRACE`), and a redundant second call is a no-op.

No change to the dialog itself: `GO_TO_EXTREMA` is a modal scope, so `App.tsx` swaps `Braille` for `GoToExtrema` while it is open and remounts `Braille` — at the freshly navigated cursor — on close. `BrailleService.enabled` is untouched throughout, so the braille content keeps tracking navigation while the dialog is up, and the shared menu open/close cues fire once each via `DIALOG_SCOPES`.

## Screenshots (if applicable)

Not applicable — keyboard/scope behaviour only.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — `docs/CONTROLS.md` does not document `g` in any scope, so there was nothing to amend.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

New test file `test/service/goToExtremaScope.test.ts` drives the real `DisplayService` focus stack against the real `GoToExtremaService` and covers: returning to `BRAILLE` when opened from braille, returning to `TRACE` when opened from the chart, and the second restore call staying put. The third case fails against the old `!== TRACE` guard (verified by reverting the guard and re-running).

`test/service/help.test.ts` asserted that the braille menu does **not** offer `g`; that expectation is inverted, while the trace-only assertions for the command palette and `Alt + L` are kept.

Verification run locally:

- `npm run lint:fix` — clean
- `npm run type-check` — clean
- `npm run build` — all 14 builds complete
- `npm test` — 394 suites / 5464 tests and 10 suites / 137 tests, all passing

E2E was not run; the Playwright specs are per-chart-type and none exercise the braille + extrema scope path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxR8VfARmrco8j7D967WD)_