### PR TITLE
feat(contour): outline a whole level when its curves cannot be told apart

### DIFF
--- a/src/model/contour.ts
+++ b/src/model/contour.ts
@@ -1,5 +1,6 @@
 import type { ContourPoint, MaidrLayer } from '@type/grammar';
 import type { DescriptionState, TextState } from '@type/state';
+import { Svg } from '@util/svg';
 import { LineTrace } from './line';
 
 /** Trims binary floating-point noise from a derived magnitude. */
@@ -76,6 +77,98 @@ export class ContourTrace extends LineTrace {
       }
     }
     return Number.NaN;
+  }
+
+  /**
+   * Where a level's highlight lands.
+   *
+   * A contour is the one line-shaped trace whose series is not reliably one
+   * drawn element. Plotly writes one `<path>` per **curve** under one
+   * `g.contourlevel` per **level**, and only the level is dependably
+   * addressable. Measured for xability/py-maidr#643 across 33 fields and 207
+   * levels -- random sums of gaussians, a saddle, a monkey saddle, ripples, a
+   * staircase, noise -- against what `contourpy` traces from the same grid:
+   *
+   * ```
+   * levels where the counts disagreed        0 / 207
+   * levels where the order within one did   18 / 207
+   * ```
+   *
+   * Five of the eighteen were ordinary two-peaked gaussian fields, so
+   * `g.contourlevel:nth-of-type(k)` is dependable and `... path:nth-of-type(j)`
+   * is not. Inherited, that left a producer two options: a per-curve selector
+   * that resolves to a real element and the wrong one, or no selector at all
+   * and no highlight (xability/maidr#1142).
+   *
+   * So a selector resolving to **several** elements is read as a level rather
+   * than a curve, and every point of that series outlines all of them. That is
+   * the reading matplotlib's contour has always given -- it draws one `<path>`
+   * per level, so naming the level names an element -- and a reader on one
+   * island of the 0.5 contour sees the 0.5 contour outlined.
+   *
+   * Decided per level rather than per layer, because a field usually has
+   * islands at some levels and not others, and a reader on a single-curve
+   * level keeps the per-point highlight that walks with them.
+   *
+   * Naming the `g.contourlevel` itself instead does not work, and is why the
+   * selector resolves to the paths: `Svg.createHighlightElement` sets `stroke`
+   * on the *clone*, and `stroke` is inherited only by a child that declares
+   * none -- plotly stamps one on every contour path, so the clone comes out
+   * colourless.
+   *
+   * @param selectors - One selector per level, as the layer declared them
+   * @returns The elements to outline, point by point
+   */
+  protected override mapToSvgElements(
+    selectors?: string[],
+  ): (SVGElement[] | SVGElement)[][] | null {
+    const perCurve = super.mapToSvgElements(selectors);
+    // The parent answers null when the selectors are unusable at all -- there
+    // are not one per series -- and that is a different answer from "one per
+    // series, resolving to nothing", so it is passed through rather than
+    // turned into a row of empties.
+    if (!selectors || perCurve === null) {
+      return perCurve;
+    }
+
+    // Resolved without cloning, the way `mapViaDomElements` does and for the
+    // same reason: a hidden copy beside each match shifts the positional
+    // selectors of every level after it (#1004).
+    const levels = selectors.map(selector =>
+      Svg.selectAllElements<SVGElement>(selector, false),
+    );
+
+    return levels.map((elements, row) => {
+      if (elements.length < 2) {
+        return perCurve[row];
+      }
+      // The parent has already synthesised a marker per point along whichever
+      // island it happened to resolve first -- the wrong-element highlight
+      // this override exists to replace. They are appended to the chart, so
+      // dropping the reference would leave them in it.
+      ContourTrace.discard(perCurve[row]);
+      // `lineValues` rather than `curves`: this runs from the parent's
+      // constructor, before this class's own fields are assigned.
+      return this.lineValues[row].map(() => elements);
+    });
+  }
+
+  /**
+   * Remove markers MAIDR synthesised and is about to stop referencing.
+   *
+   * Only MAIDR's own: the chart's live elements are highlighted in place and
+   * removing one would erase part of the drawing.
+   *
+   * @param cells - One series' worth of mapped highlight elements
+   */
+  private static discard(cells?: (SVGElement[] | SVGElement)[]): void {
+    for (const cell of cells ?? []) {
+      for (const element of Array.isArray(cell) ? cell : [cell]) {
+        if (Svg.isOwned(element)) {
+          element.remove();
+        }
+      }
+    }
   }
 
   protected override get groupFallbackLabel(): string {

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -95,7 +95,14 @@ export class LineTrace extends AbstractTrace {
 
   protected readonly points: LinePoint[][];
   protected readonly lineValues: number[][];
-  protected readonly highlightValues: SVGElement[][] | null;
+  /**
+   * One entry per point, or -- where a series is drawn as several elements
+   * with no way to tell which is which -- the whole set behind every point of
+   * it, outlined together. {@link ContourTrace} is the case: a level with
+   * islands has one `<path>` per island and no dependable order among them
+   * (xability/maidr#1142).
+   */
+  protected readonly highlightValues: (SVGElement[] | SVGElement)[][] | null;
   protected highlightCenters:
     | { x: number; y: number; row: number; col: number; element: SVGElement }[]
     | null;
@@ -785,7 +792,9 @@ export class LineTrace extends AbstractTrace {
     return this.points[row].findIndex(point => point.x === xValue);
   }
 
-  protected mapToSvgElements(selectors?: string[]): SVGElement[][] | null {
+  protected mapToSvgElements(
+    selectors?: string[],
+  ): (SVGElement[] | SVGElement)[][] | null {
     if (!selectors || selectors.length !== this.lineValues.length) {
       return null;
     }

--- a/test/model/contourHighlight.test.ts
+++ b/test/model/contourHighlight.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { ContourPoint, MaidrLayer } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { ContourTrace } from '@model/contour';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Two levels of a field. The second one has two islands, which is the case
+ * the whole file is about: plotly draws one `<path>` per **curve** under one
+ * `g.contourlevel` per **level**, and a producer can name the level
+ * dependably and the curve within it not at all.
+ *
+ * Measured for xability/py-maidr#643 across 33 fields and 207 levels -- random
+ * sums of gaussians, a saddle, a monkey saddle, ripples, a staircase, noise --
+ * comparing plotly.js against `contourpy` on the same grid:
+ *
+ * ```
+ * levels where the counts disagreed          0 / 207
+ * levels where the order within one did     18 / 207
+ * ```
+ *
+ * Five of the eighteen were ordinary two-peaked gaussian fields. So a
+ * per-curve selector resolves to a real element and, one level in twelve, the
+ * wrong one -- and the producer's only honest options were the level or
+ * nothing.
+ */
+const ONE_CURVE: ContourPoint[] = [
+  { x: 0, y: 0, level: 0.1 },
+  { x: 5, y: 0, level: 0.1 },
+];
+
+const ISLAND_A: ContourPoint[] = [
+  { x: 0, y: 1, level: 0.2 },
+  { x: 2, y: 1, level: 0.2 },
+];
+
+const ISLAND_B: ContourPoint[] = [
+  { x: 8, y: 1, level: 0.2 },
+  { x: 10, y: 1, level: 0.2 },
+];
+
+/** The two islands of level 0.2, as one series the way a producer emits it. */
+const ISLANDS: ContourPoint[] = [...ISLAND_A, ...ISLAND_B];
+
+/** Where each level's paths are drawn, in SVG coordinates. */
+const DRAWN = {
+  first: 'M 10 100 L 60 100',
+  islandA: 'M 10 200 L 30 200',
+  islandB: 'M 90 200 L 110 200',
+};
+
+/**
+ * Create a contour layer whose selectors resolve against the document.
+ * @param selectors - One selector per level
+ * @param data - The curves the layer carries
+ * @returns Contour layer definition
+ */
+function createLayer(selectors: string[], data: ContourPoint[][]): MaidrLayer {
+  return {
+    id: 'test-contour-highlight',
+    type: TraceType.CONTOUR,
+    title: 'Density field',
+    axes: { x: { label: 'X' }, y: { label: 'Y' }, z: { label: 'Density' } },
+    selectors,
+    data,
+  };
+}
+
+/**
+ * Put a rendered contour in the document, one group per level.
+ *
+ * The nesting is plotly's, measured in Chromium: a `g.contourlevel` per
+ * level, holding one `<path>` per disjoint curve.
+ * @param levels - The `d` attribute of every path, grouped by level
+ */
+function renderContour(levels: string[][]): void {
+  const groups = levels
+    .map((paths, i) => {
+      const drawn = paths.map(d => `<path d="${d}"></path>`).join('');
+      return `<g class="contourlevel" id="level-${i}">${drawn}</g>`;
+    })
+    .join('');
+  document.body.innerHTML = `
+      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
+        <g class="contourlayer">${groups}</g>
+      </svg>`;
+}
+
+/**
+ * jsdom implements `SVGElement` but none of the per-tag SVG interfaces, so
+ * `element instanceof SVGPathElement` -- the branch `LineTrace` uses to decide
+ * it is looking at a path -- throws. Define it here so the branch is
+ * reachable, matching a browser rather than changing it.
+ */
+function defineSvgPathElement(): void {
+  if ('SVGPathElement' in globalThis) {
+    return;
+  }
+  Object.defineProperty(globalThis, 'SVGPathElement', {
+    configurable: true,
+    writable: true,
+    value: class SVGPathElementShim {
+      public static [Symbol.hasInstance](value: unknown): boolean {
+        return value instanceof SVGElement && value.tagName === 'path';
+      }
+    },
+  });
+}
+
+/**
+ * The `d` of every element the trace would outline, in order.
+ *
+ * Flat rather than grouped by point, because what is being asserted is which
+ * elements a walk of the level touches and in what order -- a synthesised
+ * circle has no `d` and comes back as an empty string.
+ * @param trace - The trace to read
+ * @returns One entry per highlight element
+ */
+function outlined(trace: ContourTrace): string[] {
+  return trace
+    .getAllHighlightElements()
+    .map(element => element.getAttribute('d') ?? '');
+}
+
+/** Every synthesised highlight circle in the document, in order. */
+function circles(): { x: number; y: number }[] {
+  return Array.from(document.querySelectorAll('circle')).map(circle => ({
+    x: Number(circle.getAttribute('cx')),
+    y: Number(circle.getAttribute('cy')),
+  }));
+}
+
+describe('contour highlight mapping', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  test('a level drawn as one curve keeps its per-point highlight', () => {
+    // Unchanged, and it is the case py-maidr#643 ships today: when every
+    // drawn level draws a single curve the count agreement above forces one
+    // mapping, so the curve is addressable and the reader gets a highlight
+    // that walks with them.
+    renderContour([[DRAWN.first]]);
+    // eslint-disable-next-line no-new
+    new ContourTrace(createLayer(['g#level-0 path'], [ONE_CURVE]));
+
+    expect(circles()).toEqual([
+      { x: 10, y: 100 },
+      { x: 60, y: 100 },
+    ]);
+  });
+
+  test('a level drawn as islands outlines the whole level', () => {
+    // The change. A selector resolving to several paths is a level rather
+    // than a curve, and every point of that series outlines all of them --
+    // which is the reading matplotlib's contour has always given, since it
+    // draws one <path> per level and naming the level names an element.
+    renderContour([[DRAWN.islandA, DRAWN.islandB]]);
+    const trace = new ContourTrace(
+      createLayer(['g#level-0 path'], [ISLANDS]),
+    );
+
+    expect(outlined(trace)).toEqual(
+      ISLANDS.flatMap(() => [DRAWN.islandA, DRAWN.islandB]),
+    );
+  });
+
+  test('an island level does not synthesise circles from one island', () => {
+    // What it did before, and the reason a level outline is the honest
+    // answer rather than a lesser one: `mapViaPathParsing` takes the FIRST
+    // match and parses its `d`, so every point of the level -- including the
+    // two on the far island -- was marked along island A.
+    renderContour([[DRAWN.islandA, DRAWN.islandB]]);
+    // eslint-disable-next-line no-new
+    new ContourTrace(createLayer(['g#level-0 path'], [ISLANDS]));
+
+    expect(circles()).toEqual([]);
+  });
+
+  test('one level of islands does not cost the others their points', () => {
+    // Decided per level rather than per layer. A field usually has islands
+    // at some levels and not others, and a reader on a single-curve level
+    // keeps the better highlight.
+    renderContour([[DRAWN.first], [DRAWN.islandA, DRAWN.islandB]]);
+    const trace = new ContourTrace(
+      createLayer(
+        ['g#level-0 path', 'g#level-1 path'],
+        [ONE_CURVE, ISLANDS],
+      ),
+    );
+
+    expect(circles()).toEqual([
+      { x: 10, y: 100 },
+      { x: 60, y: 100 },
+    ]);
+    expect(outlined(trace).slice(ONE_CURVE.length)).toEqual(
+      ISLANDS.flatMap(() => [DRAWN.islandA, DRAWN.islandB]),
+    );
+  });
+
+  test('resolving one level does not shift the next one', () => {
+    // The levels are resolved without cloning, which is not incidental:
+    // `Svg.selectAllElements` otherwise inserts a hidden copy beside every
+    // match, and a positional selector resolved afterwards counts siblings
+    // the chart never drew and answers with the copy of an earlier one
+    // (#1004). Plotly's own contour selectors are positional
+    // (`g.contourlevel:nth-of-type(k)`), so this is the shape that arrives.
+    renderContour([[DRAWN.islandA, DRAWN.islandB], [DRAWN.first]]);
+    const trace = new ContourTrace(
+      createLayer(
+        [
+          'g.contourlevel:nth-of-type(1) path',
+          'g.contourlevel:nth-of-type(2) path',
+        ],
+        [ISLANDS, ONE_CURVE],
+      ),
+    );
+
+    // The elements outlined are the chart's own live paths, by identity --
+    // a hidden copy has the same `d` and shows nothing when highlighted, so
+    // comparing attributes would pass either way.
+    const drawn = Array.from(document.querySelectorAll('#level-0 path'));
+    const outlinedPaths = trace
+      .getAllHighlightElements()
+      .filter(element => element.tagName === 'path');
+    expect(new Set(outlinedPaths)).toEqual(new Set(drawn));
+
+    // Level 2 draws one curve, so it keeps its per-point markers -- and they
+    // are placed along the curve level 2 actually draws.
+    expect(circles()).toEqual([
+      { x: 10, y: 100 },
+      { x: 60, y: 100 },
+    ]);
+  });
+
+  test('a layer with the wrong number of selectors highlights nothing', () => {
+    // "One selector per level, resolving to nothing" and "not one selector
+    // per level" are different answers, and the parent already gives the
+    // second one: `null`, which every reader of `highlightValues` treats as
+    // "this trace has no highlight". Turning it into a row of empties instead
+    // leaves the cursor indexing a row that is not there.
+    renderContour([[DRAWN.islandA, DRAWN.islandB], [DRAWN.first]]);
+    const trace = new ContourTrace(
+      createLayer(['g#level-0 path'], [ISLANDS, ONE_CURVE]),
+    );
+
+    trace.moveToIndex(1, 0);
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    if (!state.empty) {
+      expect(state.highlight.empty).toBe(true);
+    }
+  });
+
+  test('a level whose selector finds nothing highlights nothing', () => {
+    renderContour([[DRAWN.first]]);
+    const trace = new ContourTrace(
+      createLayer(['g#no-such-level path'], [ONE_CURVE]),
+    );
+
+    expect(trace.getAllHighlightElements()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1142.

`ContourTrace` inherited `LineTrace`'s highlight mapping, which needs **one `<path>` or `<polyline>` per series** and parses that path's `d` to place the per-point markers. A producer that cannot say which of a level's paths is which curve therefore had to emit no selectors at all, and the layer lost its highlight entirely.

## Why the level is the only reliable handle

Plotly writes one `<path>` per **curve** under one `g.contourlevel` per **level**. Measured for xability/py-maidr#643 across 33 fields and 207 levels — random sums of gaussians, a saddle, a monkey saddle, ripples, a staircase, noise — comparing what plotly.js draws against what `contourpy` traces from the same grid:

| | result |
|---|---|
| levels where the **counts** disagreed | **0 / 207** |
| levels where the **order within a level** disagreed | **18 / 207** |

Five of the eighteen were ordinary two-peaked gaussian fields. So `g.contourlevel:nth-of-type(k)` is dependable and `… path:nth-of-type(j)` is not.

## What changed

A contour series' selector resolving to **several** elements is read as a level rather than a curve, and every point of that series outlines all of them. That is the reading matplotlib's contour has always given — it draws one `<path>` per level, so naming the level names an element — and a reader on one island of the 0.5 contour sees the 0.5 contour outlined.

Decided **per level**, not per layer: a field usually has islands at some levels and not others, and a reader on a single-curve level keeps the per-point highlight that walks with them.

The selector resolves to the level's *paths* rather than to the `g.contourlevel` itself, and the issue is why: `Svg.createHighlightElement` sets `stroke` on the **clone**, `stroke` is inherited only by a child that declares none, and plotly stamps one on every contour path — so a cloned group comes out colourless.

`LineTrace.highlightValues` and `mapToSvgElements` widen from `SVGElement[][]` to `(SVGElement[] | SVGElement)[][]`, which every consumer already handled: `mapSvgElementsToCenters`, `AbstractTrace.highlight`, `getAllHighlightElements` and `dispose` all branch on `Array.isArray` today. No other `LineTrace` subclass reads the field.

Reproduced before fixing, in jsdom: a two-island level had four markers synthesised **along island A**, including the two points that are on island B — a highlight that resolves to a real element and the wrong one. Those markers are now removed rather than dropped, because `Svg.createCircleElement` appends them to the chart.

## What this does not do

It does not make any producer emit the level selector — this is the capability that was missing. py-maidr#643 ships the plotly contour with a per-curve highlight when every drawn level draws a single curve (forced by the count agreement above) and without one otherwise; that second case can now be a level outline once this is released.

## Testing

- 7 new tests in `test/model/contourHighlight.test.ts`: a single-curve level keeping its per-point markers, an island level outlining the whole level, no markers synthesised from one island, a mixed layer keeping both readings, the live paths outlined **by identity** (a hidden clone has the same `d` and shows nothing), a positional-selector layer not shifted by resolving the level before it (#1004), a mismatched selector count still answering `null`, and an unresolvable selector highlighting nothing.
- Five mutations killed: a single element treated as a level, the parent's markers not discarded, one cell instead of one per point, cloning while resolving, and `null` turned into a row of empties.
- `npx tsc --noEmit` clean, `eslint` clean, `npm run build` complete, `npm test` 394 suites / 5,468 tests and the ESM project 10 / 137 — all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_