### PR TITLE
feat(highcharts): read a variwide as the mosaic its widths make it

### DIFF
--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -143,8 +143,11 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 | Dodged (Grouped) Bar | `column`/`bar` (default, no stacking) with multiple series | [highcharts-dodged.html](examples/highcharts-dodged.html) |
 | Normalized Bar | `column`/`bar` + `plotOptions.column.stacking: 'percent'` | [highcharts-normalized.html](examples/highcharts-normalized.html) |
 | Pie | `pie` (a doughnut is a `pie` with an `innerSize`) | [highcharts-pie.html](examples/highcharts-pie.html) |
+| Mosaic | `variwide` (requires `modules/variwide.js`) | [highcharts-variwide.html](examples/highcharts-variwide.html) |
 
 > **Pie note:** a pie series is bound to no axis, so `axes.x` and `axes.y` are named `Label` and `Value` rather than read from an axis title. Highcharts renders the wedges in `series.data` order, so slice *k* is wedge *k* and highlighting is index-aligned without any extra configuration. The same holds for funnel and word cloud layers, whose dimensions are named `Stage`/`Count` and `Term`/`Weight`.
+
+> **Variwide note:** a variwide is a column chart whose widths carry a second quantity, so it is read as a mosaic rather than as a bar: `BarPoint` is `{x, y}` and has nowhere to put the width, which is half of what the chart draws. `point.y` is the column's height and `point.z` its width, and the share `MosaicPoint.width` carries is `z / sum(z)` — measured on Highcharts 11 to be the fraction of the plot each column is drawn at, to the pixel. No `count` is emitted: a mosaic is usually drawn from a contingency table, but a variwide's `z` is any measure at all, and declaring one would announce "Count 83.2" for a chart of millions of people. Each series becomes its own mosaic, since two variwide series are drawn side by side and each sizes its columns from its own total.
 
 > **Area note:** every `area`/`areaspline` series in one panel becomes a single area layer, because a stacked band's running total only exists when all the bands share a layer. A stacked area is read as such — each point announces its own height alongside the total it sits in — and a percent stack carries the shares Highcharts computed, which is what the chart draws. `step` is not carried through on an area series: a layer holds one trace type, and announcing a stacked area as a step layer would drop the totals.
 

--- a/examples/highcharts-variwide.html
+++ b/examples/highcharts-variwide.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Highcharts Variwide Chart - MAIDR</title>
+    <script src="https://cdn.jsdelivr.net/npm/highcharts/highcharts.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/highcharts/modules/variwide.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/highcharts.js"></script>
+  </head>
+  <body>
+    <h1>Highcharts Variwide Chart</h1>
+    <p>
+      A Highcharts variwide chart made accessible by the MAIDR Highcharts
+      adapter. Click on the chart and use left and right arrow keys to move
+      between countries. Each column announces two numbers, because the chart
+      draws two: its <em>height</em> is GDP per capita, and its
+      <em>width</em> is the country's share of the whole population shown. A
+      reader given only the heights would have Norway and Germany sounding
+      alike, when one column is a fifteenth of the width of the other.
+    </p>
+
+    <div id="variwide-chart" style="width: 700px; height: 500px"></div>
+
+    <script>
+      const chart = Highcharts.chart('variwide-chart', {
+        chart: { type: 'variwide' },
+        title: { text: 'GDP per Capita, Column Width by Population' },
+        legend: { enabled: false },
+        xAxis: {
+          type: 'category',
+          categories: ['Norway', 'Germany', 'Poland', 'Greece'],
+          title: { text: 'Country' },
+        },
+        yAxis: { title: { text: 'GDP per capita (US$ thousands)' } },
+        series: [{
+          name: 'GDP per capita',
+          // [y, z] per category: the column's height, then its width.
+          data: [[42, 5.4], [39, 83.2], [27, 38.0], [20, 10.7]],
+        }],
+      });
+
+      const maidrData = maidrHighcharts.highchartsToMaidr(chart, { id: 'variwide-chart' });
+      document.getElementById('variwide-chart').setAttribute('maidr-data', JSON.stringify(maidrData));
+      maidrHighcharts.createHighchartsSync(chart);
+    </script>
+  </body>
+</html>

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -45,6 +45,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  MosaicPoint,
   NetworkPoint,
   PiePoint,
   ScatterPoint,
@@ -1573,6 +1574,10 @@ function convertSeries(
       return convertScatterSeries(series, containerId);
     case 'lollipop':
       return convertLollipopSeries(series, containerId);
+    // A column chart whose widths carry a second quantity -- the one shape in
+    // this family a bar layer has nowhere to put.
+    case 'variwide':
+      return convertVariwideSeries(series, chart, containerId);
     case 'funnel':
     case 'pyramid':
       return convertFunnelSeries(series, containerId);
@@ -2423,6 +2428,104 @@ function convertLollipopSeries(
       x: getAxisLabel(series, 'x'),
       y: getAxisLabel(series, 'y'),
     },
+    data,
+  };
+}
+
+/**
+ * Converts a `variwide` series into a mosaic layer.
+ *
+ * A variwide is a column chart whose **widths carry a second quantity**:
+ * `point.y` is how tall a column is drawn and `point.z` is how wide, so the
+ * chart shows a measure against the size of the group it was measured over.
+ * That is the mosaic reading exactly -- a magnitude per category plus the
+ * category's share of the whole -- and it is why `bar` is the wrong home:
+ * `BarPoint` has nowhere to put `z`, so half the chart would be dropped
+ * silently, which is how it reached #1138 in the first place (the type is in
+ * no bucket at all today, so a variwide chart emits **zero layers** and is
+ * not navigable).
+ *
+ * The share is computed rather than read, because Highcharts computes it too.
+ * Measured on Highcharts 11.4.8 in Chromium, four columns over a 726px plot:
+ *
+ *     point      z      z / sum(z)   drawn width
+ *     Norway     5.4    0.0393       28px
+ *     Germany   83.2    0.6060       440px
+ *     Poland    38.0    0.2768       201px
+ *     Greece    10.7    0.0779       57px
+ *
+ * -- so `z / sum(z)` is the fraction each column is drawn at, to the pixel,
+ * and that is the number `MosaicPoint.width` is defined to hold.
+ *
+ * `count` is deliberately not emitted. A mosaic is usually drawn from a
+ * contingency table, but a variwide's `z` is any measure at all -- population,
+ * revenue, hours -- and declaring one would put "Count 83.2" in the
+ * announcement for a chart of millions of people.
+ *
+ * One layer per series rather than one table per chart: two variwide series on
+ * one chart are drawn side by side, each sizing its own columns from its own
+ * `z` total (measured: series totals of 4 and 6 gave each series its own
+ * widths), so folding them into shared mosaic columns would report shares of
+ * a total no column was drawn against.
+ *
+ * @param series - The variwide series to convert
+ * @param chart - The owning chart, for its `inverted` flag
+ * @param containerId - The chart container's id, for the selectors
+ * @returns The mosaic layer
+ */
+function convertVariwideSeries(
+  series: HighchartsSeries,
+  chart: HighchartsChart,
+  containerId: string,
+): MaidrLayer {
+  // A variwide honours `chart.inverted` -- measured, the same four columns
+  // laid across the page -- and a horizontal layer carries its category on
+  // `y` and its magnitude on `x`, which `MosaicTrace` already reads either
+  // way.
+  const isHorizontal = chart.options.chart?.inverted === true;
+  const orientation = isHorizontal ? Orientation.HORIZONTAL : Orientation.VERTICAL;
+
+  // A point with no value draws no column at all (measured: `point.graphic`
+  // is absent), so keeping it would slide every later highlight onto its
+  // neighbour's column.
+  const points = series.data.filter(p => p.y !== null);
+
+  // The shares are taken over EVERY declared point, including the ones with
+  // no value. Measured: dropping the middle of z = 4, 6, 10 left the two
+  // survivors at 145px and 363px of a 726px plot -- exactly the widths they
+  // had when all three were drawn. Highcharts keeps a valueless column's
+  // slice of the axis and simply draws nothing in it, so a share taken over
+  // the survivors alone would report 4/14 for a column drawn at 4/20.
+  const magnitudes = series.data.map(p => p.z);
+  // And a share is reported only when Highcharts sized the columns, which it
+  // does only when every point carries a width. Measured: one point declared
+  // without `z` collapses the whole series -- all three columns rendered at
+  // 0x0, not just the one -- so shares over the rest would describe a chart
+  // nobody was shown. A total of zero is the same case arrived at
+  // differently: every column drew at 0x0, and 0/0 would announce each of
+  // them as NaN% of the chart.
+  const sized = magnitudes.every(z => typeof z === 'number' && Number.isFinite(z));
+  const total = sized
+    ? magnitudes.reduce<number>((sum, z) => sum + (z as number), 0)
+    : 0;
+  const name = series.name || 'Series 1';
+
+  const data: MosaicPoint[][] = [points.map((point) => {
+    const label = pointLabel(point);
+    const value = point.y as number;
+    const share = total > 0 ? { width: (point.z as number) / total } : {};
+    return isHorizontal
+      ? { x: value, y: label, z: name, ...share }
+      : { x: label, y: value, z: name, ...share };
+  })];
+
+  return {
+    id: String(series.index),
+    type: TraceType.MOSAIC,
+    title: series.name || undefined,
+    orientation,
+    selectors: barSelector(containerId, series.index),
+    axes: barAxes(series, isHorizontal),
     data,
   };
 }

--- a/src/model/contour.ts
+++ b/src/model/contour.ts
@@ -1,5 +1,6 @@
 import type { ContourPoint, MaidrLayer } from '@type/grammar';
 import type { DescriptionState, TextState } from '@type/state';
+import { Svg } from '@util/svg';
 import { LineTrace } from './line';
 
 /** Trims binary floating-point noise from a derived magnitude. */
@@ -76,6 +77,98 @@ export class ContourTrace extends LineTrace {
       }
     }
     return Number.NaN;
+  }
+
+  /**
+   * Where a level's highlight lands.
+   *
+   * A contour is the one line-shaped trace whose series is not reliably one
+   * drawn element. Plotly writes one `<path>` per **curve** under one
+   * `g.contourlevel` per **level**, and only the level is dependably
+   * addressable. Measured for xability/py-maidr#643 across 33 fields and 207
+   * levels -- random sums of gaussians, a saddle, a monkey saddle, ripples, a
+   * staircase, noise -- against what `contourpy` traces from the same grid:
+   *
+   * ```
+   * levels where the counts disagreed        0 / 207
+   * levels where the order within one did   18 / 207
+   * ```
+   *
+   * Five of the eighteen were ordinary two-peaked gaussian fields, so
+   * `g.contourlevel:nth-of-type(k)` is dependable and `... path:nth-of-type(j)`
+   * is not. Inherited, that left a producer two options: a per-curve selector
+   * that resolves to a real element and the wrong one, or no selector at all
+   * and no highlight (xability/maidr#1142).
+   *
+   * So a selector resolving to **several** elements is read as a level rather
+   * than a curve, and every point of that series outlines all of them. That is
+   * the reading matplotlib's contour has always given -- it draws one `<path>`
+   * per level, so naming the level names an element -- and a reader on one
+   * island of the 0.5 contour sees the 0.5 contour outlined.
+   *
+   * Decided per level rather than per layer, because a field usually has
+   * islands at some levels and not others, and a reader on a single-curve
+   * level keeps the per-point highlight that walks with them.
+   *
+   * Naming the `g.contourlevel` itself instead does not work, and is why the
+   * selector resolves to the paths: `Svg.createHighlightElement` sets `stroke`
+   * on the *clone*, and `stroke` is inherited only by a child that declares
+   * none -- plotly stamps one on every contour path, so the clone comes out
+   * colourless.
+   *
+   * @param selectors - One selector per level, as the layer declared them
+   * @returns The elements to outline, point by point
+   */
+  protected override mapToSvgElements(
+    selectors?: string[],
+  ): (SVGElement[] | SVGElement)[][] | null {
+    const perCurve = super.mapToSvgElements(selectors);
+    // The parent answers null when the selectors are unusable at all -- there
+    // are not one per series -- and that is a different answer from "one per
+    // series, resolving to nothing", so it is passed through rather than
+    // turned into a row of empties.
+    if (!selectors || perCurve === null) {
+      return perCurve;
+    }
+
+    // Resolved without cloning, the way `mapViaDomElements` does and for the
+    // same reason: a hidden copy beside each match shifts the positional
+    // selectors of every level after it (#1004).
+    const levels = selectors.map(selector =>
+      Svg.selectAllElements<SVGElement>(selector, false),
+    );
+
+    return levels.map((elements, row) => {
+      if (elements.length < 2) {
+        return perCurve[row];
+      }
+      // The parent has already synthesised a marker per point along whichever
+      // island it happened to resolve first -- the wrong-element highlight
+      // this override exists to replace. They are appended to the chart, so
+      // dropping the reference would leave them in it.
+      ContourTrace.discard(perCurve[row]);
+      // `lineValues` rather than `curves`: this runs from the parent's
+      // constructor, before this class's own fields are assigned.
+      return this.lineValues[row].map(() => elements);
+    });
+  }
+
+  /**
+   * Remove markers MAIDR synthesised and is about to stop referencing.
+   *
+   * Only MAIDR's own: the chart's live elements are highlighted in place and
+   * removing one would erase part of the drawing.
+   *
+   * @param cells - One series' worth of mapped highlight elements
+   */
+  private static discard(cells?: (SVGElement[] | SVGElement)[]): void {
+    for (const cell of cells ?? []) {
+      for (const element of Array.isArray(cell) ? cell : [cell]) {
+        if (Svg.isOwned(element)) {
+          element.remove();
+        }
+      }
+    }
   }
 
   protected override get groupFallbackLabel(): string {

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -95,7 +95,14 @@ export class LineTrace extends AbstractTrace {
 
   protected readonly points: LinePoint[][];
   protected readonly lineValues: number[][];
-  protected readonly highlightValues: SVGElement[][] | null;
+  /**
+   * One entry per point, or -- where a series is drawn as several elements
+   * with no way to tell which is which -- the whole set behind every point of
+   * it, outlined together. {@link ContourTrace} is the case: a level with
+   * islands has one `<path>` per island and no dependable order among them
+   * (xability/maidr#1142).
+   */
+  protected readonly highlightValues: (SVGElement[] | SVGElement)[][] | null;
   protected highlightCenters:
     | { x: number; y: number; row: number; col: number; element: SVGElement }[]
     | null;
@@ -785,7 +792,9 @@ export class LineTrace extends AbstractTrace {
     return this.points[row].findIndex(point => point.x === xValue);
   }
 
-  protected mapToSvgElements(selectors?: string[]): SVGElement[][] | null {
+  protected mapToSvgElements(
+    selectors?: string[],
+  ): (SVGElement[] | SVGElement)[][] | null {
     if (!selectors || selectors.length !== this.lineValues.length) {
       return null;
     }

--- a/test/adapters/highcharts/variwide.test.ts
+++ b/test/adapters/highcharts/variwide.test.ts
@@ -1,0 +1,287 @@
+/**
+ * A Highcharts variwide is a column chart whose widths carry data, and used to
+ * be nothing at all (#1138).
+ *
+ * `buildSubplot` sorts series into buckets by type and `barTypes` names only
+ * `bar`, `column`, `columnpyramid` and `pictorial`. Highcharts' variwide
+ * module registers `series.type = 'variwide'`, which fell into no bucket,
+ * reached `convertSeries` as an unsupported type and was declined — so the
+ * chart emitted **zero layers** and was not navigable at all.
+ *
+ * It is read as a mosaic rather than as a bar, because a bar has nowhere to
+ * put the width: `BarPoint` is `{x, y}`, so half of what the chart draws
+ * would be dropped silently. `MosaicPoint.width` is defined as "the fraction
+ * the column is drawn at", which is exactly what a variwide's `z` resolves to.
+ *
+ * Measured on Highcharts 11.4.8 plus `modules/variwide.js` in Chromium, four
+ * columns over a 726px plot:
+ *
+ *   point      z      z / sum(z)   drawn width
+ *   Norway     5.4    0.0393       28px
+ *   Germany   83.2    0.6060       440px
+ *   Poland    38.0    0.2768       201px
+ *   Greece    10.7    0.0779       57px
+ *
+ * — the share to the pixel. The edge cases were measured the same way, three
+ * columns of z = 4, 6, 10:
+ *
+ *   declared                  what Highcharts drew
+ *   all three sized           three columns, 145 / 218 / 363 px wide
+ *   middle point y = 0        three columns, the middle one 0px TALL
+ *   middle point y = null     TWO columns; the null one has no graphic
+ *   middle point z = 0        three columns, the middle one 1px wide
+ *   middle point has no z     three columns at 0x0 — the whole series dies
+ *   every z = 0               every column at 0x0
+ *
+ * The last two are why a share is emitted only when every point carries one:
+ * Highcharts sizes all the columns or none of them, and shares computed over
+ * the survivors would describe a chart nobody was shown.
+ */
+import type { MosaicPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { describe, expect, it } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+import { fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+/** The four columns measured above, as the adapter is handed them. */
+const GDP = [
+  { name: 'Norway', y: 42, z: 5.4 },
+  { name: 'Germany', y: 39, z: 83.2 },
+  { name: 'Poland', y: 27, z: 38.0 },
+  { name: 'Greece', y: 20, z: 10.7 },
+];
+
+/**
+ * A one-series variwide chart.
+ *
+ * @param points - The columns, as `{name, y, z}` triples
+ * @param options - How the chart is drawn
+ * @param options.inverted - Lays the columns across the page
+ * @returns The fake chart
+ */
+function variwideChart(
+  points: { name: string; y: number | null; z?: number }[] = GDP,
+  options: { inverted?: boolean } = {},
+): ReturnType<typeof fakeChart> {
+  return fakeChart({
+    type: 'variwide',
+    renderToId: 'variwide-chart',
+    inverted: options.inverted,
+    series: [fakeSeries({
+      index: 0,
+      type: 'variwide',
+      name: 'GDP',
+      xAxis: fakeAxis({ options: { title: { text: 'Country' } } }),
+      yAxis: fakeAxis({ options: { title: { text: 'GDP per capita' } } }),
+      data: points.map((p, i) => ({ x: i, y: p.y, z: p.z, name: p.name })),
+    })],
+  });
+}
+
+/**
+ * The single row of cells a one-series variwide reads as.
+ *
+ * @param chart - The chart to convert
+ * @returns The cells
+ */
+function cells(chart: ReturnType<typeof fakeChart>): MosaicPoint[] {
+  const layer = highchartsToMaidr(chart).subplots[0][0].layers[0];
+  return (layer.data as MosaicPoint[][])[0];
+}
+
+describe('highcharts variwide', () => {
+  it('reads a variwide as a mosaic rather than declining it', () => {
+    const layer = highchartsToMaidr(variwideChart()).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.MOSAIC);
+    expect(layer.title).toBe('GDP');
+    expect(layer.orientation).toBe(Orientation.VERTICAL);
+  });
+
+  it('carries the height on y and the drawn width as a share', () => {
+    const total = 5.4 + 83.2 + 38.0 + 10.7;
+
+    expect(cells(variwideChart())).toEqual([
+      { x: 'Norway', y: 42, z: 'GDP', width: 5.4 / total },
+      { x: 'Germany', y: 39, z: 'GDP', width: 83.2 / total },
+      { x: 'Poland', y: 27, z: 'GDP', width: 38.0 / total },
+      { x: 'Greece', y: 20, z: 'GDP', width: 10.7 / total },
+    ]);
+  });
+
+  it('reports shares that match the widths Highcharts drew', () => {
+    // The measured table at the top of this file, to three decimal places —
+    // the arithmetic above restated as the pixels a sighted reader saw, so a
+    // converter that quietly changed its definition of "share" fails here
+    // rather than passing on its own terms.
+    const shares = cells(variwideChart()).map(cell =>
+      Number((cell.width as number).toFixed(3)));
+
+    expect(shares).toEqual([0.039, 0.606, 0.277, 0.078]);
+    expect(shares.reduce((sum, share) => sum + share, 0)).toBeCloseTo(1, 2);
+  });
+
+  it('does not announce a width magnitude as a count', () => {
+    // A mosaic is usually drawn from a contingency table, but a variwide's `z`
+    // is any measure at all — population, revenue, hours. "Count 83.2" for a
+    // chart of millions of people is a number the data does not contain.
+    for (const cell of cells(variwideChart())) {
+      expect(cell.count).toBeUndefined();
+    }
+  });
+
+  it('names the axes the chart named them', () => {
+    const layer = highchartsToMaidr(variwideChart()).subplots[0][0].layers[0];
+
+    expect(layer.axes).toEqual({
+      x: { label: 'Country' },
+      y: { label: 'GDP per capita' },
+    });
+  });
+
+  it('highlights each column through the bar selector', () => {
+    // Measured: a variwide column is a `path.highcharts-point` inside its own
+    // `.highcharts-series-0`, one per drawn column, in declaration order —
+    // which is what `barSelector` already resolves.
+    const layer = highchartsToMaidr(variwideChart()).subplots[0][0].layers[0];
+
+    expect(layer.selectors).toBe(
+      '#variwide-chart .highcharts-series-group .highcharts-series-0 .highcharts-point',
+    );
+  });
+
+  it('drops a column the chart did not draw', () => {
+    // Measured: a `y: null` point has no graphic at all, so three declared
+    // columns render two elements. Keeping the gap would hand the third
+    // column the second column's path and highlight the wrong bar.
+    const gappy = cells(variwideChart([
+      { name: 'A', y: 10, z: 4 },
+      { name: 'B', y: null, z: 6 },
+      { name: 'C', y: 30, z: 10 },
+    ]));
+
+    expect(gappy.map(cell => cell.x)).toEqual(['A', 'C']);
+    // The dropped column takes its width out of the total too: the chart
+    // Highcharts drew has two columns in it, and they are 4/20 and 10/20 of
+    // the plot rather than 4/14 and 10/14.
+    expect(gappy.map(cell => cell.width)).toEqual([4 / 20, 10 / 20]);
+  });
+
+  it('keeps a column of zero height, which is drawn', () => {
+    // The other half of the rule above. A `y: 0` column is drawn at full
+    // width and no height — it is on the page, so it is in the reading, and
+    // dropping it would shift every later highlight.
+    const flat = cells(variwideChart([
+      { name: 'A', y: 10, z: 4 },
+      { name: 'B', y: 0, z: 6 },
+      { name: 'C', y: 30, z: 10 },
+    ]));
+
+    expect(flat.map(cell => cell.x)).toEqual(['A', 'B', 'C']);
+    expect(flat[1]).toEqual({ x: 'B', y: 0, z: 'GDP', width: 6 / 20 });
+  });
+
+  it('reports no share when one column declares no width', () => {
+    // Measured: a single point without `z` collapses the WHOLE series to
+    // 0x0 — Highcharts sizes all the columns or none of them. Shares over
+    // the survivors would announce a chart that was never drawn.
+    const unsized = cells(variwideChart([
+      { name: 'A', y: 10, z: 4 },
+      { name: 'B', y: 20 },
+      { name: 'C', y: 30, z: 10 },
+    ]));
+
+    expect(unsized).toEqual([
+      { x: 'A', y: 10, z: 'GDP' },
+      { x: 'B', y: 20, z: 'GDP' },
+      { x: 'C', y: 30, z: 'GDP' },
+    ]);
+  });
+
+  it('reports no share when every width is zero', () => {
+    // Same chart arrived at differently — every column drew at 0x0 — and
+    // 0/0 would announce each of them as NaN% of the whole.
+    expect(cells(variwideChart([
+      { name: 'A', y: 10, z: 0 },
+      { name: 'B', y: 20, z: 0 },
+    ]))).toEqual([
+      { x: 'A', y: 10, z: 'GDP' },
+      { x: 'B', y: 20, z: 'GDP' },
+    ]);
+  });
+
+  it('reads a zero width beside real ones as the nothing it is drawn at', () => {
+    // Not the same as the case above: measured, a lone `z: 0` beside
+    // z = 4 and z = 10 still draws — at 1px, the thinnest mark Highcharts
+    // makes — so the column is on the page and its share really is none of
+    // the chart.
+    const cell = cells(variwideChart([
+      { name: 'A', y: 10, z: 4 },
+      { name: 'B', y: 20, z: 0 },
+      { name: 'C', y: 30, z: 10 },
+    ]))[1];
+
+    expect(cell).toEqual({ x: 'B', y: 20, z: 'GDP', width: 0 });
+  });
+
+  it('lays an inverted variwide across the page', () => {
+    // Measured: variwide honours `chart.inverted`, drawing the same four
+    // columns sideways at the same shares. A horizontal layer carries its
+    // category on `y` and its magnitude on `x`, and the axis labels swap
+    // with them — the reading `MosaicTrace` already has for either drawing.
+    const inverted = highchartsToMaidr(variwideChart(GDP, { inverted: true }));
+    const layer = inverted.subplots[0][0].layers[0];
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.axes).toEqual({
+      x: { label: 'GDP per capita' },
+      y: { label: 'Country' },
+    });
+    expect((layer.data as MosaicPoint[][])[0][1]).toEqual({
+      x: 39,
+      y: 'Germany',
+      z: 'GDP',
+      width: 83.2 / (5.4 + 83.2 + 38.0 + 10.7),
+    });
+  });
+
+  it('gives two variwide series a mosaic each', () => {
+    // Measured: two variwide series on one chart are drawn side by side, each
+    // sizing its own columns from its own `z` total — series totals of 4 and
+    // 6 gave each series its own widths. Folding them into shared mosaic
+    // columns would report shares of a total no column was drawn against.
+    const chart = fakeChart({
+      type: 'variwide',
+      renderToId: 'two-variwide',
+      series: [
+        fakeSeries({
+          index: 0,
+          type: 'variwide',
+          name: 'one',
+          data: [{ x: 0, y: 10, z: 1, name: 'A' }, { x: 1, y: 20, z: 3, name: 'B' }],
+        }),
+        fakeSeries({
+          index: 1,
+          type: 'variwide',
+          name: 'two',
+          data: [{ x: 0, y: 5, z: 2, name: 'A' }, { x: 1, y: 15, z: 4, name: 'B' }],
+        }),
+      ],
+    });
+
+    const layers = highchartsToMaidr(chart).subplots[0][0].layers;
+
+    expect(layers.map(layer => layer.type)).toEqual([
+      TraceType.MOSAIC,
+      TraceType.MOSAIC,
+    ]);
+    expect((layers[0].data as MosaicPoint[][])[0].map(c => c.width))
+      .toEqual([1 / 4, 3 / 4]);
+    expect((layers[1].data as MosaicPoint[][])[0].map(c => c.width))
+      .toEqual([2 / 6, 4 / 6]);
+    expect(layers.map(layer => layer.selectors)).toEqual([
+      '#two-variwide .highcharts-series-group .highcharts-series-0 .highcharts-point',
+      '#two-variwide .highcharts-series-group .highcharts-series-1 .highcharts-point',
+    ]);
+  });
+});

--- a/test/model/contourHighlight.test.ts
+++ b/test/model/contourHighlight.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { ContourPoint, MaidrLayer } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { ContourTrace } from '@model/contour';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Two levels of a field. The second one has two islands, which is the case
+ * the whole file is about: plotly draws one `<path>` per **curve** under one
+ * `g.contourlevel` per **level**, and a producer can name the level
+ * dependably and the curve within it not at all.
+ *
+ * Measured for xability/py-maidr#643 across 33 fields and 207 levels -- random
+ * sums of gaussians, a saddle, a monkey saddle, ripples, a staircase, noise --
+ * comparing plotly.js against `contourpy` on the same grid:
+ *
+ * ```
+ * levels where the counts disagreed          0 / 207
+ * levels where the order within one did     18 / 207
+ * ```
+ *
+ * Five of the eighteen were ordinary two-peaked gaussian fields. So a
+ * per-curve selector resolves to a real element and, one level in twelve, the
+ * wrong one -- and the producer's only honest options were the level or
+ * nothing.
+ */
+const ONE_CURVE: ContourPoint[] = [
+  { x: 0, y: 0, level: 0.1 },
+  { x: 5, y: 0, level: 0.1 },
+];
+
+const ISLAND_A: ContourPoint[] = [
+  { x: 0, y: 1, level: 0.2 },
+  { x: 2, y: 1, level: 0.2 },
+];
+
+const ISLAND_B: ContourPoint[] = [
+  { x: 8, y: 1, level: 0.2 },
+  { x: 10, y: 1, level: 0.2 },
+];
+
+/** The two islands of level 0.2, as one series the way a producer emits it. */
+const ISLANDS: ContourPoint[] = [...ISLAND_A, ...ISLAND_B];
+
+/** Where each level's paths are drawn, in SVG coordinates. */
+const DRAWN = {
+  first: 'M 10 100 L 60 100',
+  islandA: 'M 10 200 L 30 200',
+  islandB: 'M 90 200 L 110 200',
+};
+
+/**
+ * Create a contour layer whose selectors resolve against the document.
+ * @param selectors - One selector per level
+ * @param data - The curves the layer carries
+ * @returns Contour layer definition
+ */
+function createLayer(selectors: string[], data: ContourPoint[][]): MaidrLayer {
+  return {
+    id: 'test-contour-highlight',
+    type: TraceType.CONTOUR,
+    title: 'Density field',
+    axes: { x: { label: 'X' }, y: { label: 'Y' }, z: { label: 'Density' } },
+    selectors,
+    data,
+  };
+}
+
+/**
+ * Put a rendered contour in the document, one group per level.
+ *
+ * The nesting is plotly's, measured in Chromium: a `g.contourlevel` per
+ * level, holding one `<path>` per disjoint curve.
+ * @param levels - The `d` attribute of every path, grouped by level
+ */
+function renderContour(levels: string[][]): void {
+  const groups = levels
+    .map((paths, i) => {
+      const drawn = paths.map(d => `<path d="${d}"></path>`).join('');
+      return `<g class="contourlevel" id="level-${i}">${drawn}</g>`;
+    })
+    .join('');
+  document.body.innerHTML = `
+      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
+        <g class="contourlayer">${groups}</g>
+      </svg>`;
+}
+
+/**
+ * jsdom implements `SVGElement` but none of the per-tag SVG interfaces, so
+ * `element instanceof SVGPathElement` -- the branch `LineTrace` uses to decide
+ * it is looking at a path -- throws. Define it here so the branch is
+ * reachable, matching a browser rather than changing it.
+ */
+function defineSvgPathElement(): void {
+  if ('SVGPathElement' in globalThis) {
+    return;
+  }
+  Object.defineProperty(globalThis, 'SVGPathElement', {
+    configurable: true,
+    writable: true,
+    value: class SVGPathElementShim {
+      public static [Symbol.hasInstance](value: unknown): boolean {
+        return value instanceof SVGElement && value.tagName === 'path';
+      }
+    },
+  });
+}
+
+/**
+ * The `d` of every element the trace would outline, in order.
+ *
+ * Flat rather than grouped by point, because what is being asserted is which
+ * elements a walk of the level touches and in what order -- a synthesised
+ * circle has no `d` and comes back as an empty string.
+ * @param trace - The trace to read
+ * @returns One entry per highlight element
+ */
+function outlined(trace: ContourTrace): string[] {
+  return trace
+    .getAllHighlightElements()
+    .map(element => element.getAttribute('d') ?? '');
+}
+
+/** Every synthesised highlight circle in the document, in order. */
+function circles(): { x: number; y: number }[] {
+  return Array.from(document.querySelectorAll('circle')).map(circle => ({
+    x: Number(circle.getAttribute('cx')),
+    y: Number(circle.getAttribute('cy')),
+  }));
+}
+
+describe('contour highlight mapping', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  test('a level drawn as one curve keeps its per-point highlight', () => {
+    // Unchanged, and it is the case py-maidr#643 ships today: when every
+    // drawn level draws a single curve the count agreement above forces one
+    // mapping, so the curve is addressable and the reader gets a highlight
+    // that walks with them.
+    renderContour([[DRAWN.first]]);
+    // eslint-disable-next-line no-new
+    new ContourTrace(createLayer(['g#level-0 path'], [ONE_CURVE]));
+
+    expect(circles()).toEqual([
+      { x: 10, y: 100 },
+      { x: 60, y: 100 },
+    ]);
+  });
+
+  test('a level drawn as islands outlines the whole level', () => {
+    // The change. A selector resolving to several paths is a level rather
+    // than a curve, and every point of that series outlines all of them --
+    // which is the reading matplotlib's contour has always given, since it
+    // draws one <path> per level and naming the level names an element.
+    renderContour([[DRAWN.islandA, DRAWN.islandB]]);
+    const trace = new ContourTrace(
+      createLayer(['g#level-0 path'], [ISLANDS]),
+    );
+
+    expect(outlined(trace)).toEqual(
+      ISLANDS.flatMap(() => [DRAWN.islandA, DRAWN.islandB]),
+    );
+  });
+
+  test('an island level does not synthesise circles from one island', () => {
+    // What it did before, and the reason a level outline is the honest
+    // answer rather than a lesser one: `mapViaPathParsing` takes the FIRST
+    // match and parses its `d`, so every point of the level -- including the
+    // two on the far island -- was marked along island A.
+    renderContour([[DRAWN.islandA, DRAWN.islandB]]);
+    // eslint-disable-next-line no-new
+    new ContourTrace(createLayer(['g#level-0 path'], [ISLANDS]));
+
+    expect(circles()).toEqual([]);
+  });
+
+  test('one level of islands does not cost the others their points', () => {
+    // Decided per level rather than per layer. A field usually has islands
+    // at some levels and not others, and a reader on a single-curve level
+    // keeps the better highlight.
+    renderContour([[DRAWN.first], [DRAWN.islandA, DRAWN.islandB]]);
+    const trace = new ContourTrace(
+      createLayer(
+        ['g#level-0 path', 'g#level-1 path'],
+        [ONE_CURVE, ISLANDS],
+      ),
+    );
+
+    expect(circles()).toEqual([
+      { x: 10, y: 100 },
+      { x: 60, y: 100 },
+    ]);
+    expect(outlined(trace).slice(ONE_CURVE.length)).toEqual(
+      ISLANDS.flatMap(() => [DRAWN.islandA, DRAWN.islandB]),
+    );
+  });
+
+  test('resolving one level does not shift the next one', () => {
+    // The levels are resolved without cloning, which is not incidental:
+    // `Svg.selectAllElements` otherwise inserts a hidden copy beside every
+    // match, and a positional selector resolved afterwards counts siblings
+    // the chart never drew and answers with the copy of an earlier one
+    // (#1004). Plotly's own contour selectors are positional
+    // (`g.contourlevel:nth-of-type(k)`), so this is the shape that arrives.
+    renderContour([[DRAWN.islandA, DRAWN.islandB], [DRAWN.first]]);
+    const trace = new ContourTrace(
+      createLayer(
+        [
+          'g.contourlevel:nth-of-type(1) path',
+          'g.contourlevel:nth-of-type(2) path',
+        ],
+        [ISLANDS, ONE_CURVE],
+      ),
+    );
+
+    // The elements outlined are the chart's own live paths, by identity --
+    // a hidden copy has the same `d` and shows nothing when highlighted, so
+    // comparing attributes would pass either way.
+    const drawn = Array.from(document.querySelectorAll('#level-0 path'));
+    const outlinedPaths = trace
+      .getAllHighlightElements()
+      .filter(element => element.tagName === 'path');
+    expect(new Set(outlinedPaths)).toEqual(new Set(drawn));
+
+    // Level 2 draws one curve, so it keeps its per-point markers -- and they
+    // are placed along the curve level 2 actually draws.
+    expect(circles()).toEqual([
+      { x: 10, y: 100 },
+      { x: 60, y: 100 },
+    ]);
+  });
+
+  test('a layer with the wrong number of selectors highlights nothing', () => {
+    // "One selector per level, resolving to nothing" and "not one selector
+    // per level" are different answers, and the parent already gives the
+    // second one: `null`, which every reader of `highlightValues` treats as
+    // "this trace has no highlight". Turning it into a row of empties instead
+    // leaves the cursor indexing a row that is not there.
+    renderContour([[DRAWN.islandA, DRAWN.islandB], [DRAWN.first]]);
+    const trace = new ContourTrace(
+      createLayer(['g#level-0 path'], [ISLANDS, ONE_CURVE]),
+    );
+
+    trace.moveToIndex(1, 0);
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    if (!state.empty) {
+      expect(state.highlight.empty).toBe(true);
+    }
+  });
+
+  test('a level whose selector finds nothing highlights nothing', () => {
+    renderContour([[DRAWN.first]]);
+    const trace = new ContourTrace(
+      createLayer(['g#no-such-level path'], [ONE_CURVE]),
+    );
+
+    expect(trace.getAllHighlightElements()).toEqual([]);
+  });
+});


### PR DESCRIPTION
The last of the five exact-home series types in #1138.

`buildSubplot` sorts series into buckets by type, and `variwide` is in none of them — so it reached `convertSeries` as an unsupported type, was declined, and the chart emitted **zero layers**.

## Why mosaic and not bar

`BarPoint` is `{x, y}`. A variwide draws two magnitudes per column — `point.y` is how tall it is and `point.z` is how wide — so reading it as a bar would drop half the chart, silently. `MosaicPoint.width` is already defined as "the fraction the column is drawn at", which is what a variwide's `z` resolves to.

The judgement was recorded on the issue before this was written; it holds unchanged after measuring.

## Measured

Highcharts 11.4.8 plus `modules/variwide.js`, driven in Chromium, four columns over a 726px plot:

| point | `z` | `z / Σz` | drawn width |
|---|---|---|---|
| Norway | 5.4 | 0.0393 | 28px |
| Germany | 83.2 | 0.6060 | 440px |
| Poland | 38.0 | 0.2768 | 201px |
| Greece | 10.7 | 0.0779 | 57px |

The share is the drawn fraction to the pixel, so it is computed rather than approximated.

The edge cases, three columns of `z = 4, 6, 10`:

| declared | what Highcharts drew | what is emitted |
|---|---|---|
| all three sized | 145 / 218 / 363 px wide | three cells, shares 4/20, 6/20, 10/20 |
| middle `y = 0` | three columns, the middle 0px **tall** | three cells, the middle `y: 0` at full share |
| middle `y = null` | **two** columns; no graphic for the third | two cells — and the survivors keep 145px and 363px, so the dropped column's width **stays in the denominator** |
| middle `z = 0` | three columns, the middle 1px wide | three cells, the middle `width: 0` |
| middle has no `z` | three columns at **0×0** — the whole series dies | three cells, **no share on any of them** |
| every `z = 0` | every column at 0×0 | no share on any of them |

The last two are why the share is emitted only when every point carries one: Highcharts sizes all the columns or none, so a share over the survivors would describe a chart nobody was shown. The `y: null` row is why the denominator is taken over every declared point — that one was found by a failing test, having been written the other way first.

## What is not emitted

`count`. A mosaic is usually drawn from a contingency table, but a variwide's `z` is any measure at all — population, revenue, hours — and declaring one would put "Count 83.2" in the announcement for a chart of millions of people. Same call `buildMosaicLayer` makes for AnyChart's marimekko, for the same reason.

## Other decisions

- **One layer per series.** Two variwide series on a chart are drawn side by side, each sizing its columns from its own `z` total (measured: totals of 4 and 6 gave each its own widths), so folding them into shared mosaic columns would report shares of a total no column was drawn against.
- **`chart.inverted` is honoured.** Measured: a variwide lays its columns across the page at the same shares. A horizontal layer carries its category on `y` and its magnitude on `x`, and `MosaicTrace` already reads either drawing — this mirrors what `convertBarGroup` does for the same flag (#997).

## Testing

- 13 new tests in `test/adapters/highcharts/variwide.test.ts`, including the measured share table restated as pixels so a converter that quietly redefined "share" fails on its own terms.
- 8 mutations killed: the denominator over kept points only, a missing `z` coerced to zero, valueless points kept, orientation pinned vertical, the zero-total guard removed, a `count` emitted from the width, read as a `bar`, and a selector not scoped to its own series.
- Full gate green: `eslint`, `tsc --noEmit`, `npm run build`, `npm test` — 395 suites / 5481 tests, plus the ESM project at 10 / 137.
- `docs/highcharts.md` gains the Mosaic row and a note; `examples/highcharts-variwide.html` is a working page, verified in Chromium to render the four columns at the measured widths with the country names on the ticks.

## Found on the way

The canonical variwide in Highcharts' own documentation is declared `xAxis: { type: 'category' }`, and on that declaration every Highcharts layer announces `0, 1, 2, 3` where the chart draws `Norway, Germany, Poland, Greece` — `point.category` holds the index, `??` does not fall through `0`, and the labels are in `xAxis.names`, which nothing reads. Filed separately as #1146, since it is `pointLabel`'s and affects `column`, `lollipop`, `funnel` and the segmented bars alike. This converter uses `pointLabel` like every sibling, so the fix there lifts all of them rather than making variwide special.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_