### PR TITLE
fix(highcharts): read a category axis' labels from where Highcharts put them

### DIFF
--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -556,8 +556,68 @@ function getAxisLabel(series: HighchartsSeries, axis: 'x' | 'y'): AxisConfig {
   return { label };
 }
 
+/**
+ * The labels an axis calls its slots by, from wherever Highcharts put them.
+ *
+ * There are two places, and which one is filled depends only on how the
+ * author spelled the axis. Measured on Highcharts 11.4.8 in Chromium, the
+ * same two-bar chart drawn twice:
+ *
+ *     declaration                  axis.categories   axis.names   drawn ticks
+ *     xAxis: { categories: [...] } ['A', 'B']        []           A, B
+ *     xAxis: { type: 'category' }  []                ['A', 'B']   A, B
+ *
+ * The second is the spelling Highcharts' own documentation uses for a chart
+ * of named tuples, and `categories` is an **empty array** there -- truthy,
+ * so `axis.categories?.[i]` reads as `undefined` rather than falling through
+ * a nullish check, and every label was lost (#1146).
+ *
+ * @param axis - The axis to ask, if there is one
+ * @returns Its category labels, or an empty array when it has none
+ */
+function declaredCategories(axis: HighchartsAxis | undefined): string[] {
+  const declared = axis?.categories;
+  if (declared !== undefined && declared.length > 0) {
+    return declared;
+  }
+  return axis?.names ?? [];
+}
+
+/**
+ * What an axis calls one of its slots.
+ *
+ * @param axis - The axis to ask, if there is one
+ * @param index - Which slot
+ * @returns The label, or undefined when the axis names no such slot
+ */
+function axisCategoryAt(
+  axis: HighchartsAxis | undefined,
+  index: number,
+): string | undefined {
+  const label = declaredCategories(axis)[Math.round(index)];
+  // A blank label names nothing, and announcing it would replace a position
+  // a reader can at least count with silence.
+  return typeof label === 'string' && label !== '' ? label : undefined;
+}
+
+/**
+ * What a point is called.
+ *
+ * The axis is asked first, because a category axis' labels are what the
+ * chart prints under the marks -- and because `point.category` is the label
+ * only on one of the two spellings. On the other it holds the point's
+ * **index**, which `??` will not fall through: `0` is neither null nor
+ * undefined, so the fallbacks below it were unreachable and every category
+ * came out as its own subscript (#1146).
+ *
+ * @param point - The point to name
+ * @returns Its label, or its `x` when nothing names it
+ */
 function pointLabel(point: HighchartsPoint): string | number {
-  return point.category ?? point.name ?? point.x;
+  return axisCategoryAt(point.series?.xAxis, point.x)
+    ?? point.category
+    ?? point.name
+    ?? point.x;
 }
 
 /**
@@ -879,8 +939,7 @@ function barAxes(
  * @returns A function from a point's `x` to its category index, or -1
  */
 function categoryIndexer(seriesList: HighchartsSeries[]): (x: number) => number {
-  const axisCategories = seriesList[0]?.xAxis?.categories;
-  if (axisCategories) {
+  if (declaredCategories(seriesList[0]?.xAxis).length > 0) {
     return (x: number) => Math.round(x);
   }
 
@@ -910,7 +969,7 @@ function buildSegmentedRows(
 
   // Build the shared category-label list (index → label), preferring the axis
   // categories, then per-point category/name, then the x value itself.
-  const axisCategories = seriesList[0]?.xAxis?.categories;
+  const axisCategories = declaredCategories(seriesList[0]?.xAxis);
   const indexForX = categoryIndexer(seriesList);
 
   const categoryLabels: (string | number)[] = [];
@@ -920,14 +979,16 @@ function buildSegmentedRows(
       if (index < 0)
         continue;
       if (categoryLabels[index] === undefined) {
-        categoryLabels[index] = axisCategories?.[index] ?? p.category ?? p.name ?? Math.round(p.x);
+        categoryLabels[index]
+          = axisCategoryAt(seriesList[0]?.xAxis, index)
+            ?? p.category ?? p.name ?? Math.round(p.x);
       }
     }
   }
-  const categoryCount = Math.max(axisCategories?.length ?? 0, categoryLabels.length);
+  const categoryCount = Math.max(axisCategories.length, categoryLabels.length);
   for (let j = 0; j < categoryCount; j++) {
     if (categoryLabels[j] === undefined) {
-      categoryLabels[j] = axisCategories?.[j] ?? j;
+      categoryLabels[j] = axisCategoryAt(seriesList[0]?.xAxis, j) ?? j;
     }
   }
 
@@ -2296,8 +2357,9 @@ function parallelColumnLabel(
   point: HighchartsPoint,
   chart: HighchartsChart,
 ): string | number {
-  if (point.category !== undefined) {
-    return point.category;
+  const declared = axisCategoryAt(point.series?.xAxis, point.x) ?? point.category;
+  if (declared !== undefined) {
+    return declared;
   }
   const axisTitle = chart.yAxis?.[Math.round(point.x)]?.options?.title?.text;
   return axisTitle || pointLabel(point);
@@ -2366,7 +2428,7 @@ function convertParallelSeries(
  * {@link BarPoint}s, whose `x` is that label.
  */
 function isCategoryScatter(series: HighchartsSeries): boolean {
-  return (series.xAxis?.categories?.length ?? 0) > 0;
+  return declaredCategories(series.xAxis).length > 0;
 }
 
 /**

--- a/src/adapters/highcharts/types.ts
+++ b/src/adapters/highcharts/types.ts
@@ -338,6 +338,19 @@ export interface HighchartsPoint {
  */
 export interface HighchartsAxis {
   categories?: string[];
+  /**
+   * The other place Highcharts keeps a category axis' labels.
+   *
+   * An axis declared `categories: [...]` fills `categories` and leaves this
+   * empty. An axis declared `type: 'category'` -- the spelling Highcharts'
+   * own documentation uses for a chart of named tuples -- does the reverse:
+   * it collects the point names here and leaves `categories` an **empty
+   * array**, which is truthy and indexes to `undefined` (#1146).
+   *
+   * Read through `declaredCategories()` rather than directly, so that
+   * "what does the axis call slot 2" has one answer.
+   */
+  names?: string[];
   getExtremes: () => { min: number; max: number };
   isDatetimeAxis?: boolean;
   /**

--- a/test/adapters/highcharts/categoryLabels.test.ts
+++ b/test/adapters/highcharts/categoryLabels.test.ts
@@ -1,0 +1,216 @@
+/**
+ * A Highcharts chart declared `xAxis: { type: 'category' }` announced its
+ * categories as their own subscripts (#1146).
+ *
+ * Every converter names its points through one helper:
+ *
+ *     function pointLabel(point) {
+ *       return point.category ?? point.name ?? point.x;
+ *     }
+ *
+ * and Highcharts fills `point.category` differently depending only on how the
+ * author spelled the axis. Measured on Highcharts 11.4.8 in Chromium, reading
+ * the rendered tick labels off the SVG beside a transcription of the helper:
+ *
+ *   declaration                     drawn ticks     point.category  pointLabel
+ *   xAxis: { categories: [...] }    Norway, Germany Norway, Germany Norway, …
+ *   xAxis: { type: 'category' }     Norway, Germany 0, 1            0, 1
+ *
+ * The same chart, drawn identically, announced two different things. `??`
+ * only falls through null and undefined, and `0` is neither, so the fallback
+ * to `point.name` -- which does hold the label -- was unreachable.
+ *
+ * The labels are not lost, only elsewhere: a `type: 'category'` axis collects
+ * them in `axis.names` and leaves `axis.categories` an **empty array**, which
+ * is truthy and indexes to `undefined`. So the fix is to ask the axis, from
+ * whichever of the two places Highcharts filled -- which is what the chart
+ * itself prints under the marks.
+ *
+ * Measured too, and the reason nothing else moves: a heatmap or an xrange on
+ * a `type: 'category'` axis fills **neither** list, because nothing named its
+ * points, and the chart draws "0", "1" on the ticks as well. There is no
+ * label to recover there and none is invented.
+ */
+import type { BarPoint, SegmentedPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+const LABELS = ['Norway', 'Germany'];
+
+/**
+ * The x axis as each of Highcharts' two spellings leaves it.
+ *
+ * @param spelling - Which declaration the author used
+ * @returns The axis
+ */
+function categoryAxis(spelling: 'categories' | 'type'): ReturnType<typeof fakeAxis> {
+  return spelling === 'categories'
+    // `categories: [...]` — the labels are in `categories`, `names` is empty.
+    ? fakeAxis({ categories: [...LABELS], names: [] })
+    // `type: 'category'` — the reverse, and `categories` is an EMPTY ARRAY
+    // rather than absent, which is the whole trap.
+    : fakeAxis({ categories: [], names: [...LABELS] });
+}
+
+/**
+ * A one-series column chart on one of the two spellings.
+ *
+ * The points carry what Highcharts gives them under that spelling: a label in
+ * `category` when the axis declared them, and the point's **index** there
+ * plus the label on `name` when the axis derived them.
+ *
+ * @param spelling - Which declaration the author used
+ * @param type - The series type
+ * @returns The fake chart
+ */
+function chartOn(
+  spelling: 'categories' | 'type',
+  type = 'column',
+): ReturnType<typeof fakeChart> {
+  const axis = categoryAxis(spelling);
+  return fakeChart({
+    type,
+    renderToId: 'labels-chart',
+    series: [fakeSeries({
+      index: 0,
+      type,
+      name: 'GDP',
+      xAxis: axis,
+      data: [42, 39].map((y, i) => (spelling === 'categories'
+        ? { x: i, y, category: LABELS[i] }
+        : { x: i, y, category: i as unknown as string, name: LABELS[i] })),
+    })],
+  });
+}
+
+/**
+ * The x of every point of the chart's first layer.
+ *
+ * @param chart - The chart to convert
+ * @returns The announced labels
+ */
+function labels(chart: ReturnType<typeof fakeChart>): (string | number)[] {
+  const layer = highchartsToMaidr(chart).subplots[0][0].layers[0];
+  return (layer.data as BarPoint[]).map(point => point.x);
+}
+
+describe('highcharts category labels', () => {
+  it('announces the labels a type: category axis derived', () => {
+    expect(labels(chartOn('type'))).toEqual(LABELS);
+  });
+
+  it('announces the labels a declared categories axis carries', () => {
+    // The spelling that already worked, asserted so the fix cannot cost it.
+    expect(labels(chartOn('categories'))).toEqual(LABELS);
+  });
+
+  it('does not let a point index outrank the name the axis drew', () => {
+    // The exact shape of the bug: `point.category` is `0`, which `??` will
+    // not fall through, so every fallback below it was dead. Pinned on the
+    // first point, whose index is the falsy one.
+    expect(labels(chartOn('type'))[0]).not.toBe(0);
+  });
+
+  it('reaches every type that names a point the same way', () => {
+    // `pointLabel` is the naming path for a dozen series types, so the fix
+    // is asserted somewhere other than a bar as well -- a lollipop, whose
+    // converter does nothing of its own about labels.
+    expect(labels(chartOn('type', 'lollipop'))).toEqual(LABELS);
+  });
+
+  it('reads a scatter on a derived category axis as a dot plot', () => {
+    // The same empty-array trap in a second place: a scatter pinned to
+    // category ticks is a dot plot, and the test for one was
+    // `xAxis.categories.length > 0` -- false on an axis whose labels are in
+    // `names`. A `ScatterPoint.x` is strictly numeric, so the chart came out
+    // announcing the tick index and dropping the label under it.
+    const layer = highchartsToMaidr(chartOn('type', 'scatter'))
+      .subplots[0][0]
+      .layers[0];
+
+    expect(layer.type).toBe(TraceType.DOT);
+    expect((layer.data as BarPoint[]).map(point => point.x)).toEqual(LABELS);
+  });
+
+  it('names the categories of a stacked bar', () => {
+    // A segmented group builds its own shared label list rather than calling
+    // `pointLabel`, and had the same hole: `axisCategories?.[index]` on an
+    // empty array is `undefined`, so it fell to `p.category` -- the index.
+    const axis = categoryAxis('type');
+    const chart = fakeChart({
+      type: 'column',
+      renderToId: 'stacked-chart',
+      plotOptions: { column: { stacking: 'normal' } },
+      series: [
+        // `category` carries the INDEX, which is what a real chart puts
+        // there under this spelling -- measured on a stacked column of the
+        // same shape. Without it the row builder's `?? p.name` fallback
+        // recovers the label by accident and the test proves nothing.
+        fakeSeries({
+          index: 0,
+          name: 'one',
+          xAxis: axis,
+          data: [3, 5].map((y, i) => ({
+            x: i,
+            y,
+            category: i as unknown as string,
+            name: LABELS[i],
+          })),
+        }),
+        fakeSeries({
+          index: 1,
+          name: 'two',
+          xAxis: axis,
+          data: [1, 2].map((y, i) => ({
+            x: i,
+            y,
+            category: i as unknown as string,
+            name: LABELS[i],
+          })),
+        }),
+      ],
+    });
+
+    const layer = highchartsToMaidr(chart).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.STACKED);
+    expect((layer.data as SegmentedPoint[][])[0].map(cell => cell.x))
+      .toEqual(LABELS);
+  });
+
+  it('falls back to the point when the axis names nothing', () => {
+    // A heatmap or an xrange declared `type: 'category'` fills neither list,
+    // because nothing named its points -- measured, and the chart draws the
+    // numbers on its ticks too. Nothing is recovered and nothing invented.
+    const chart = fakeChart({
+      type: 'column',
+      renderToId: 'unnamed-chart',
+      series: [fakeSeries({
+        index: 0,
+        xAxis: fakeAxis({ categories: [], names: [] }),
+        data: [{ x: 0, y: 42, name: 'Norway' }, { x: 1, y: 39 }],
+      })],
+    });
+
+    expect(labels(chart)).toEqual(['Norway', 1]);
+  });
+
+  it('passes over a blank entry rather than announcing nothing', () => {
+    // An axis that names some slots and not others. A blank label names
+    // nothing, and announcing it would replace a position a reader can at
+    // least count with silence.
+    const chart = fakeChart({
+      type: 'column',
+      renderToId: 'gappy-chart',
+      series: [fakeSeries({
+        index: 0,
+        xAxis: fakeAxis({ categories: [], names: ['Norway', ''] }),
+        data: [{ x: 0, y: 42 }, { x: 1, y: 39, name: 'Germany' }],
+      })],
+    });
+
+    expect(labels(chart)).toEqual(['Norway', 'Germany']);
+  });
+});


### PR DESCRIPTION
Closes #1146.

## The same chart, announced two different ways

Measured on Highcharts 11.4.8 in Chromium, reading the rendered tick labels off the SVG beside a transcription of `pointLabel`:

| declaration | drawn ticks | `point.category` | `point.name` | `axis.categories` | `axis.names` | **`pointLabel`** |
|---|---|---|---|---|---|---|
| `xAxis: { categories: [...] }` | Norway, Germany | Norway, Germany | `null` | Norway, Germany | `[]` | Norway, Germany |
| `xAxis: { type: 'category' }` | Norway, Germany | `0`, `1` | Norway, Germany | `[]` | Norway, Germany | **`0`, `1`** |

Same bars, same tick labels on the page, declared the two ways Highcharts documents. One announced its categories and one announced their subscripts.

Two things combined:

- **The labels are not lost, only elsewhere.** A `type: 'category'` axis collects them in `axis.names` and leaves `axis.categories` an **empty array** — truthy, so `axis.categories?.[i]` reads as `undefined` rather than falling through a nullish check.
- **`point.category` holds the index** under that spelling, and `??` will not fall through `0`. So the fallback to `point.name` — which does hold the label — was unreachable, and the failure was silent: nothing in the announcement hints that "0" is standing in for a name.

## The fix

One helper, `declaredCategories(axis)`, returns the label list from whichever of the two places Highcharts filled, and `axisCategoryAt(axis, i)` names one slot. Every category read routes through it, so "what does this axis call slot 2" has one answer.

That lifts every series type at once rather than making one special:

- **`pointLabel`** names `lollipop`, `funnel`/`pyramid`, `bullet`, `waterfall`, `dumbbell`, `boxplot`, `histogram`, the dot-plot branch of `scatter`, the new `variwide` (#1147), and more.
- **`buildSegmentedRows`** builds the shared label list for stacked, dodged, normalized and diverging bars, and had its own copy of the same broken chain.
- **`isCategoryScatter`** decides whether a scatter is read as a dot plot, and tested `xAxis.categories.length > 0` — false on a derived axis. A category scatter therefore came out as a plain `SCATTER`, whose `x` is strictly numeric, announcing the tick index and dropping the label printed under it.
- **`parallelColumnLabel`** and **`categoryIndexer`** had the same shape.

## Nothing else moves

Measured, and this is why the change is narrow: a heatmap or an xrange declared `type: 'category'` fills **neither** list, because nothing named its points — and the chart draws "0", "1" on its ticks too:

```
heatmap, both axes type: 'category'   categories []  names []  drawn ticks 0, 1
heatmap, declared categories          categories [A, B]        drawn ticks A, B
```

There is no label to recover there and none is invented.

## Testing

- 8 new tests in `test/adapters/highcharts/categoryLabels.test.ts`, including the exact `??` trap pinned on the point whose index is the falsy one, the dot-plot branch, the segmented-bar branch, and an axis that names some slots and not others.
- 6 mutations killed: `names` never consulted, an empty `categories` winning over `names`, the axis asked after the point, a blank label announced as a name, the dot-plot test left reading `categories` only, and the segmented rows left reading the raw list.

  The last one **survived the first sweep**, and the reason was the test rather than the code: my stacked-bar fixture set `name` but not `category`, so the old `?? p.name` fallback recovered the label by accident. Re-measured on a real stacked column — `point.category` is `0`, `1` there too — and made the fixture faithful. It then died.
- Full gate green: `eslint`, `tsc --noEmit`, `npm run build`, `npm test` — 396 suites / 5489 tests, plus the ESM project at 10 / 137.

Found while implementing #1138's `variwide`, whose canonical example in Highcharts' documentation is declared this way.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_