### PR TITLE
fix(highcharts): re-pair a bell curve on a reversed axis

### DIFF
--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -1642,7 +1642,7 @@ function convertSeries(
       return convertVariwideSeries(series, chart, containerId);
     // A fitted normal curve, evaluated wherever the renderer chose to.
     case 'bellcurve':
-      return convertBellCurveSeries(series, containerId);
+      return convertBellCurveSeries(series, chart, containerId);
     // The cumulative percentage drawn over a bar chart's columns.
     case 'pareto':
       return convertParetoSeries(series, chart, containerId);
@@ -2698,19 +2698,28 @@ function convertTimelineSeries(
  * drawn: `getAxisLabel` reads `series.xAxis`, so a curve bound to a secondary
  * pair is named by that pair's titles rather than by the base series'.
  *
+ * **A reversed axis is re-paired the same way a line's is** (#1007, #1151).
+ * Nothing about the curve being *generated* exempts it: measured on a
+ * fifteen-value sample with `xAxis.reversed`, the payload came back
+ * 2.46 -> 4.18 while the chart drew it 4.18 -> 2.46, so a reader sweeping
+ * left to right was handed the curve back to front. `SmoothTrace` extends
+ * `LineTrace`, so it consumes `domMapping.pointOrder` unchanged.
+ *
  * @param series - The bellcurve series to convert
+ * @param chart - The chart, read for whether its axis is drawn reversed
  * @param containerId - The chart container's id, for the selectors
  * @returns The smooth layer
  */
 function convertBellCurveSeries(
   series: HighchartsSeries,
+  chart: HighchartsChart,
   containerId: string,
 ): MaidrLayer {
-  const data: LinePoint[][] = [
-    series.data
-      .filter(p => p.y !== null)
-      .map(p => ({ x: p.x, y: p.y as number })),
-  ];
+  const reversed = drawsSeriesReversed(series, chart);
+  const points = series.data
+    .filter(p => p.y !== null)
+    .map(p => ({ x: p.x, y: p.y as number }));
+  const data: LinePoint[][] = [reversed ? points.reverse() : points];
 
   return {
     id: String(series.index),
@@ -2721,6 +2730,7 @@ function convertBellCurveSeries(
       x: getAxisLabel(series, 'x'),
       y: getAxisLabel(series, 'y'),
     },
+    ...(reversed ? { domMapping: { pointOrder: 'reverse' as const } } : {}),
     data,
   };
 }

--- a/test/adapters/highcharts/bellcurve.test.ts
+++ b/test/adapters/highcharts/bellcurve.test.ts
@@ -27,6 +27,17 @@
  * the handle, exactly as for every other line-family layer. The
  * observations are a separate series, reachable as `series.baseSeries`, and
  * the adapter reads that on its own terms.
+ *
+ * **A reversed axis read the curve backwards** — the same defect #1007 fixed
+ * for lines, filed for this one as #1151, and nothing about the curve being
+ * generated* exempted it. Measured on a fifteen-value sample, once plain
+ * and once with `xAxis.reversed`:
+ *
+ *   plain      payload x   2.46 … 4.18    chart draws  2.46 → 4.18
+ *   reversed   payload x   2.46 … 4.18    chart draws  4.18 → 2.46
+ *
+ * The payload did not move; the chart did. `SmoothTrace extends LineTrace`,
+ * so it consumes `domMapping.pointOrder` without anything being added to it.
  */
 import type { LinePoint } from '@type/grammar';
 import { highchartsToMaidr } from '@adapters/highcharts/adapter';
@@ -50,10 +61,17 @@ const CURVE = [
  * are the curve's own rather than the sample's.
  *
  * @param withSample - Whether the base scatter is on the chart as well
+ * @param reversed - Whether the curve's x axis is drawn from its far end
  * @returns The fake chart
  */
-function bellChart(withSample = false): ReturnType<typeof fakeChart> {
-  const curveX = fakeAxis({ options: { title: { text: 'Bell curve' } } });
+function bellChart(
+  withSample = false,
+  reversed = false,
+): ReturnType<typeof fakeChart> {
+  const curveX = fakeAxis({
+    reversed,
+    options: { title: { text: 'Bell curve' } },
+  });
   const curveY = fakeAxis({ options: { title: { text: 'Density' } } });
   const series = [fakeSeries({
     index: 0,
@@ -90,6 +108,25 @@ describe('highcharts bellcurve', () => {
     const layer = highchartsToMaidr(bellChart()).subplots[0][0].layers[0];
 
     expect(layer.data as LinePoint[][]).toEqual([CURVE]);
+  });
+
+  it('reads a reversed axis in the order the curve is drawn', () => {
+    // Measured: the payload came out 2.46 → 4.18 over a chart drawn
+    // 4.18 → 2.46, so a reader sweeping left to right was handed the curve
+    // back to front.
+    const layer = highchartsToMaidr(bellChart(false, true)).subplots[0][0].layers[0];
+
+    expect((layer.data as LinePoint[][])[0]).toEqual([...CURVE].reverse());
+  });
+
+  it('tells the trace to pair the path back up when reversed', () => {
+    // Reversing the payload is half of it: the path's vertices still come out
+    // of Highcharts in the library's order. `SmoothTrace` inherits
+    // `LineTrace`'s handling of this, so nothing in the trace changed.
+    expect(highchartsToMaidr(bellChart(false, true)).subplots[0][0].layers[0].domMapping)
+      .toEqual({ pointOrder: 'reverse' });
+    expect(highchartsToMaidr(bellChart()).subplots[0][0].layers[0].domMapping)
+      .toBeUndefined();
   });
 
   it('is not read as a line', () => {


### PR DESCRIPTION
`convertBellCurveSeries` never applied the reversed-axis handling `convertLineSeries` has carried since #1007, and being a *generated* series exempts it from nothing — the same defect fixed for `pareto` in #1150, found in the same review and filed as #1151.

Closes the `bellcurve` half of #1151. The `scatter` half is deliberately not here; see below.

## Measured

Highcharts 11 in Chromium, a fifteen-value sample, once plain and once with `xAxis.reversed`, read through the adapter itself:

```
plain      payload x   2.46, 2.56, 2.65  …  3.99, 4.08, 4.18   domMapping  null
reversed   payload x   2.46, 2.56, 2.65  …  3.99, 4.08, 4.18   domMapping  null   ← before
reversed   payload x   4.18, 4.08, 3.99  …  2.65, 2.56, 2.46   domMapping  { pointOrder: 'reverse' }   ← after
```

The payload did not move. The chart did: reversed, it draws 4.18 at the left and 2.46 at the right, so a reader sweeping left to right was handed the curve back to front, and the highlighting outlined the mirror image of the step being announced.

`SmoothTrace extends LineTrace`, so it already consumes `domMapping.pointOrder` — the converter simply never set it. **Nothing in the trace changed.**

## Falsification

```
baseline                          19 passed
bellcurve never re-paired          2 failed
bellcurve always re-paired         3 failed
payload reversed, path not told    1 failed
```

## Why the scatter half is not in this PR

I filed #1151 saying the scatter case "needs its own measurement before anything is changed", and the measurement says the adapter cannot fix it.

`ScatterTrace` does not read the payload in declaration order. It builds its navigation from its own sort —

```ts
const sortedByX = [...data].sort((a, b) => a.x - b.x || a.y - b.y);
```

— and its stereo pan from a map over the *sorted* unique x values. It also never reads `domMapping`: grepping `src/model` for `pointOrder` returns `line.ts` and nothing else.

So a scatter is always announced in ascending x, whatever the adapter emits. Reversing the payload would be a no-op for the announcement and would break the positional pairing with the elements — a change that costs something and buys nothing. The real gap is that `ScatterTrace` has no notion of a reversed axis and no field an adapter could tell it through, which is a core change of the same shape as #1153. Recorded on #1151 rather than guessed at here.

## Gate

`npx eslint src test` clean, `tsc --noEmit` clean, `npm run build` complete, `npm test` → **399 suites / 5517 tests**, plus the ESM project at 10 / 137.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_