### PR TITLE
feat(treemap): read a tree that declares no magnitude

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -790,7 +790,7 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       );
     } else {
       const xLabel = text.main.label || 'x';
-      const yLabel = text.cross.label || 'y';
+      const yLabel = text.cross?.label || 'y';
       this.textViewModel.update(
         `${xLabel} is ${xRange.min} through ${xRange.max}, ${yLabel} is ${yRange.min} through ${yRange.max}`,
       );

--- a/src/model/diverging.ts
+++ b/src/model/diverging.ts
@@ -163,11 +163,15 @@ export class DivergingTrace extends SegmentedTrace {
     const magnitude = Math.abs(value);
     // `cross` carries the bar's length in BOTH orientations -- the parent
     // swaps which point field feeds it, not which half of the announcement it
-    // is -- so there is one slot to replace rather than two.
-    const sized = (state: TextState): TextState => ({
-      ...state,
-      cross: { ...state.cross, value: magnitude },
-    });
+    // is -- so there is one slot to replace rather than two. The clause is
+    // optional on `TextState` for the traces that have no cross axis at all
+    // (#1153); a diverging bar always has one, so a state arriving without it
+    // is passed through rather than given a label invented here.
+    const sized = (state: TextState): TextState => (
+      state.cross === undefined
+        ? state
+        : { ...state, cross: { ...state.cross, value: magnitude } }
+    );
 
     if (this.isBalanceRow(this.row)) {
       if (!this.isTwoSided) {

--- a/src/model/treemap.ts
+++ b/src/model/treemap.ts
@@ -119,6 +119,30 @@ export class TreemapTrace extends AbstractTrace {
   private readonly grandTotal: number;
 
   /**
+   * Whether any node declared a magnitude at all.
+   *
+   * `TreemapPoint.y` is optional because an interior node's value is
+   * ordinarily the sum of its children. A tree in which *no* node declares
+   * one is a different thing: a pure hierarchy, which is what an org chart
+   * is, and it has no magnitude to announce anywhere. Measured on a
+   * Highcharts organization chart, every node's `value` and `weight` came
+   * back null and the library's own internal `sum` was 1 for every node
+   * alike, because it assigns one unit per link for layout (#1153).
+   *
+   * Read as an ordinary tree, such a chart announced `0` on every node and
+   * derived shares from it -- and declaring Highcharts' own 1 instead was
+   * strictly worse, because two siblings were then each announced as 100% of
+   * their parent. What a reader actually wants from a pure hierarchy is
+   * already here and already right: the navigation, the `Path` and the
+   * `Children` count.
+   *
+   * A *mixed* tree is untouched. An undeclared interior node summing its
+   * children is the documented ordinary case, and one declared magnitude
+   * anywhere makes this true.
+   */
+  private readonly valued: boolean;
+
+  /**
    * Where each node sits around the dial, in radians, shaped as `nodes` is.
    *
    * A sunburst lays a node's children across its own arc in proportion to
@@ -139,6 +163,9 @@ export class TreemapTrace extends AbstractTrace {
     super(layer);
 
     const points = layer.data as TreemapPoint[];
+    this.valued = points.some(
+      point => typeof point.y === 'number' && Number.isFinite(point.y),
+    );
     this.nodes = TreemapTrace.buildTree(points);
     this.nodeValues = this.nodes.map(level =>
       level.map(node => node?.value ?? Number.NaN));
@@ -333,7 +360,15 @@ export class TreemapTrace extends AbstractTrace {
       freq: {
         min: this.depthMin[this.row] ?? 0,
         max: this.depthMax[this.row] ?? 0,
-        raw: node?.value ?? 0,
+        // A pure hierarchy has nothing to pitch, and this is the contract
+        // that already says so: a non-finite magnitude means "the point
+        // exists to navigate to, it just has no value", and `AudioService`
+        // sounds it with the empty tone rather than interpolating it -- #925,
+        // and deliberately not scoped there to the trace that first needed
+        // it. Leaving the 0 would have been a flat tone at the bottom of the
+        // range, which is a positive claim that every node is equal and
+        // small rather than an absence of one.
+        raw: this.valued ? (node?.value ?? 0) : Number.NaN,
       },
       panning: this.panning,
     };
@@ -437,7 +472,7 @@ export class TreemapTrace extends AbstractTrace {
     if (node === null) {
       return {
         main: { label: this.xAxis, value: '' },
-        cross: { label: this.yAxis, value: 0 },
+        ...(this.valued ? { cross: { label: this.yAxis, value: 0 } } : {}),
         mainAxis: 'x',
         crossAxis: 'y',
       };
@@ -456,6 +491,13 @@ export class TreemapTrace extends AbstractTrace {
       asides.push({ label: 'Path', value: ancestors.join(' > ') });
     }
 
+    // The two share clauses need no `valued` guard of their own, and one was
+    // written and then removed for being unfalsifiable. In a tree that
+    // declares no magnitude every node's value is a sum of zeroes, so both
+    // denominators below are 0 and both branches are already skipped -- and
+    // a tree with a genuine declared 0 in it is a *valued* tree, since one
+    // finite magnitude anywhere makes it one. There is no input the extra
+    // guard would change, so it is stated here rather than coded.
     const parent = node.parent === null
       ? null
       : this.nodes[node.parent.row]?.[node.parent.col] ?? null;
@@ -483,7 +525,9 @@ export class TreemapTrace extends AbstractTrace {
 
     return {
       main: { label: this.xAxis, value: node.name },
-      cross: { label: this.yAxis, value: node.value },
+      // Omitted rather than sent as 0, or as the layout's per-link 1: both
+      // announce a number no rectangle on the page stands for.
+      ...(this.valued ? { cross: { label: this.yAxis, value: node.value } } : {}),
       mainAxis: 'x',
       crossAxis: 'y',
       asides,
@@ -576,15 +620,18 @@ export class TreemapTrace extends AbstractTrace {
     const every = this.nodes.flat().filter((node): node is TreeNode => node !== null);
     const leaves = every.filter(node => node.children.length === 0);
 
+    // The shape of the tree is real whether or not it carries magnitudes;
+    // the total is not. A pure hierarchy keeps the three counts and loses
+    // every stat derived from a value it never declared (#1153).
     const stats: DescriptionState['stats'] = [
       { label: 'Levels', value: this.nodes.length },
       { label: 'Number of nodes', value: every.length },
       { label: 'Number of leaves', value: leaves.length },
-      { label: 'Total', value: this.grandTotal },
+      ...(this.valued ? [{ label: 'Total', value: this.grandTotal }] : []),
     ];
 
     const roots = this.nodes[0] ?? [];
-    if (roots.length > 0 && this.grandTotal !== 0) {
+    if (this.valued && roots.length > 0 && this.grandTotal !== 0) {
       // The top-level breakdown, which is the first thing a sighted reader
       // takes from the layout and the last thing a walk of thirty leaves
       // would assemble.
@@ -601,7 +648,7 @@ export class TreemapTrace extends AbstractTrace {
       (best, node) => (best === null || node.value > best.value ? node : best),
       null,
     );
-    if (largest !== null) {
+    if (this.valued && largest !== null) {
       // Named with its ancestry, because a leaf's name alone does not say
       // which branch it is the largest thing in.
       stats.push({
@@ -616,15 +663,26 @@ export class TreemapTrace extends AbstractTrace {
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: {
-        headers: ['Path', this.xAxis, this.yAxis, 'Share of total'],
-        rows: every.map(node => [
-          this.ancestorsOf(node).join(' > '),
-          node.name,
-          node.value,
-          this.grandTotal === 0 ? '' : asPercent(node.value / this.grandTotal),
-        ]),
-      },
+      dataTable: this.valued
+        ? {
+            headers: ['Path', this.xAxis, this.yAxis, 'Share of total'],
+            rows: every.map(node => [
+              this.ancestorsOf(node).join(' > '),
+              node.name,
+              node.value,
+              this.grandTotal === 0 ? '' : asPercent(node.value / this.grandTotal),
+            ]),
+          }
+        : {
+            // Two columns rather than four, half of them zeroes and blanks:
+            // the ancestry and the name are the whole of what a pure
+            // hierarchy has to tabulate.
+            headers: ['Path', this.xAxis],
+            rows: every.map(node => [
+              this.ancestorsOf(node).join(' > '),
+              node.name,
+            ]),
+          },
     };
   }
 

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -486,6 +486,10 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Use axis identity from TextState, fallback to default mapping
     const mainAxisType = state.mainAxis ?? 'x';
     const crossAxisType = state.crossAxis ?? 'y';
+    // Bound once so the clause narrows for the whole method. Absent means
+    // the chart has no cross axis, not that this point has no reading on one
+    // -- see {@link TextState.cross}.
+    const cross = state.cross;
 
     // Format main-axis values.
     verbose.push(state.main.label, Constant.IS);
@@ -508,11 +512,12 @@ export class TextService implements Observer<PlotState>, Disposable {
       state.section
       && this.announcesSectionBeforeLabel(state)
       && (state.section === BoxplotSection.UPPER_OUTLIER || state.section === BoxplotSection.LOWER_OUTLIER)
-      && Array.isArray(state.cross.value)
+      && cross !== undefined
+      && Array.isArray(cross.value)
     ) {
       // e.g. 'upper outlier(s)' or 'lower outlier(s)' section
-      const label = state.cross.label;
-      const outliers = state.cross.value as (number | string)[];
+      const label = cross.label;
+      const outliers = cross.value as (number | string)[];
       const formattedOutliers = this.formatArrayValue(outliers, crossAxisType);
       const outlierStr = `[${formattedOutliers.join(', ')}]`;
       const formattedMainValue = this.formatSingleValue(state.main.value as number | string, mainAxisType);
@@ -526,47 +531,52 @@ export class TextService implements Observer<PlotState>, Disposable {
       }
     }
 
-    // Format cross-axis label.
-    if (state.section !== undefined) {
-      if (this.announcesSectionBeforeLabel(state)) {
-        const label = state.cross.label;
-        // Verbatim, as terse renders it. Lower-casing here meant the same
-        // point announced two different ways depending on the mode, and the
-        // difference was in a label that came from neither the user nor the
-        // data. It also destroyed case a producer chose: a dumbbell's end
-        // names and a ridgeline's group names are authored strings, so
-        // `Control` became `control` in one mode and stayed `Control` in the
-        // other.
-        verbose.push(Constant.COMMA_SPACE, state.section!, Constant.SPACE, label);
+    // Format cross-axis label. A trace with no cross axis at all skips both
+    // the label and the value: a pure hierarchy has no magnitude to name,
+    // and a bare label with nothing after it would be worse than silence
+    // (#1153).
+    if (cross !== undefined) {
+      if (state.section !== undefined) {
+        if (this.announcesSectionBeforeLabel(state)) {
+          const label = cross.label;
+          // Verbatim, as terse renders it. Lower-casing here meant the same
+          // point announced two different ways depending on the mode, and the
+          // difference was in a label that came from neither the user nor the
+          // data. It also destroyed case a producer chose: a dumbbell's end
+          // names and a ridgeline's group names are authored strings, so
+          // `Control` became `control` in one mode and stayed `Control` in
+          // the other.
+          verbose.push(Constant.COMMA_SPACE, state.section, Constant.SPACE, label);
+        } else {
+          // For candlestick plots: "section cross.label" (e.g., "high Price")
+          verbose.push(Constant.COMMA_SPACE, state.section, Constant.SPACE, cross.label);
+        }
       } else {
-        // For candlestick plots: "section cross.label" (e.g., "high Price")
-        verbose.push(Constant.COMMA_SPACE, state.section!, Constant.SPACE, state.cross.label);
+        verbose.push(Constant.COMMA_SPACE, cross.label);
       }
-    } else {
-      verbose.push(Constant.COMMA_SPACE, state.cross.label);
-    }
 
-    // Format cross-axis values.
-    //
-    // A span on the cross axis replaces the single value, the same way
-    // `state.range` replaces the main one for a histogram bin. A gantt
-    // interval is the case: what the chart draws is a start and an end, and
-    // announcing either alone names one edge of a bar as though it were the
-    // bar. Every trace that carries one value is unaffected -- `crossRange`
-    // is absent on all of them.
-    if (state.crossRange !== undefined) {
-      verbose.push(
-        Constant.IS,
-        this.formatSingleValue(state.crossRange.min, crossAxisType),
-        Constant.THROUGH,
-        this.formatSingleValue(state.crossRange.max, crossAxisType),
-      );
-    } else if (!Array.isArray(state.cross.value)) {
-      verbose.push(Constant.IS, this.formatSingleValue(state.cross.value as number | string, crossAxisType));
-    } else if (state.cross.value.length > 1) {
-      verbose.push(Constant.ARE, this.formatArrayValue(state.cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE));
-    } else if (state.cross.value.length > 0) {
-      verbose.push(Constant.IS, this.formatArrayValue(state.cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE));
+      // Format cross-axis values.
+      //
+      // A span on the cross axis replaces the single value, the same way
+      // `state.range` replaces the main one for a histogram bin. A gantt
+      // interval is the case: what the chart draws is a start and an end, and
+      // announcing either alone names one edge of a bar as though it were the
+      // bar. Every trace that carries one value is unaffected -- `crossRange`
+      // is absent on all of them.
+      if (state.crossRange !== undefined) {
+        verbose.push(
+          Constant.IS,
+          this.formatSingleValue(state.crossRange.min, crossAxisType),
+          Constant.THROUGH,
+          this.formatSingleValue(state.crossRange.max, crossAxisType),
+        );
+      } else if (!Array.isArray(cross.value)) {
+        verbose.push(Constant.IS, this.formatSingleValue(cross.value as number | string, crossAxisType));
+      } else if (cross.value.length > 1) {
+        verbose.push(Constant.ARE, this.formatArrayValue(cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE));
+      } else if (cross.value.length > 0) {
+        verbose.push(Constant.IS, this.formatArrayValue(cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE));
+      }
     }
 
     // Format for the plots that carry a third value: the heatmap's cell value,
@@ -676,6 +686,7 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Use axis identity from state (supports orientation-aware formatting)
     const mainAxisType = state.mainAxis ?? 'x';
     const crossAxisType = state.crossAxis ?? 'y';
+    const cross = state.cross;
 
     if (Array.isArray(state.main.value)) {
       terse.push(Constant.OPEN_BRACKET, this.formatArrayValue(state.main.value as (number | string)[], mainAxisType).join(Constant.COMMA_SPACE), Constant.CLOSE_BRACKET);
@@ -688,9 +699,10 @@ export class TextService implements Observer<PlotState>, Disposable {
       state.section
       && this.announcesSectionBeforeLabel(state)
       && (state.section === BoxplotSection.UPPER_OUTLIER || state.section === BoxplotSection.LOWER_OUTLIER)
-      && Array.isArray(state.cross.value)
+      && cross !== undefined
+      && Array.isArray(cross.value)
     ) {
-      const outliers = state.cross.value as (number | string)[];
+      const outliers = cross.value as (number | string)[];
       const formattedOutliers = this.formatArrayValue(outliers, crossAxisType);
       const outlierStr = `[${formattedOutliers.join(', ')}]`;
       const formattedMainValue = this.formatSingleValue(state.main.value as number | string, mainAxisType);
@@ -718,10 +730,13 @@ export class TextService implements Observer<PlotState>, Disposable {
         Constant.TO_DASH,
         this.formatSingleValue(state.crossRange.max, crossAxisType),
       );
-    } else if (!Array.isArray(state.cross.value)) {
-      terse.push(this.formatSingleValue(state.cross.value as number | string, crossAxisType));
-    } else {
-      terse.push(Constant.OPEN_BRACKET, this.formatArrayValue(state.cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE), Constant.CLOSE_BRACKET);
+    } else if (cross !== undefined) {
+      // Skipped entirely when the chart has no cross axis (#1153).
+      if (!Array.isArray(cross.value)) {
+        terse.push(this.formatSingleValue(cross.value as number | string, crossAxisType));
+      } else {
+        terse.push(Constant.OPEN_BRACKET, this.formatArrayValue(cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE), Constant.CLOSE_BRACKET);
+      }
     }
 
     // Format for heatmap, segmented and pie plots. Terse drops the label, so a
@@ -779,7 +794,7 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Y range
     parts.push(
       Constant.COMMA_SPACE,
-      state.cross.label,
+      state.cross?.label ?? '',
       Constant.IS,
       this.formatSingleValue(state.crossRange!.min, crossAxisType),
       Constant.THROUGH,

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -364,7 +364,22 @@ export interface TextState {
    * shape it has to learn.
    */
   main: { label: string; value: number | number[] | string | string[] };
-  cross: { label: string; value: number | number[] | string | string[] };
+  /**
+   * Optional, because a chart can have no cross axis to speak of.
+   *
+   * A pure hierarchy is the case that exists: `TreemapTrace` reads a tree
+   * whose nodes declare no magnitude at all -- an org chart -- and every
+   * value it could put here would be one the chart does not draw (#1153).
+   * `TextService` already tested for the clause before reading it in the
+   * terse and layer-switch paths; the verbose and grid paths now do too, and
+   * omit both the label and the value rather than announcing a bare label.
+   *
+   * Absent is not the same as empty. A trace that has a cross axis and no
+   * reading at this point sends the axis with a non-finite value, which is
+   * announced as "missing" (#925). Omitting the clause says the axis is not
+   * there at all.
+   */
+  cross?: { label: string; value: number | number[] | string | string[] };
   /**
    * Third-dimension value for heatmaps, segmented bars, pie slices and 3D
    * scatter. `number[]` when one navigation step covers several points that

--- a/test/adapters/chartjs/traceConstruction.test.ts
+++ b/test/adapters/chartjs/traceConstruction.test.ts
@@ -71,7 +71,7 @@ describe('chart.js payloads the core can build a trace from', () => {
     if (state.empty)
       return;
     expect(state.traceType).toBe(TraceType.POLAR_AREA);
-    expect(state.text.cross.value).toBe(20);
+    expect(state.text.cross?.value).toBe(20);
   });
 
   it('builds a gantt trace, empty lane and all', () => {
@@ -150,7 +150,7 @@ describe('chart.js payloads the core can build a trace from', () => {
     if (state.empty)
       return;
     expect(state.traceType).toBe(TraceType.NORMALIZED_AREA);
-    expect(state.text.cross.value).toBe(50);
+    expect(state.text.cross?.value).toBe(50);
   });
 
   it('builds a bump trace', () => {
@@ -206,7 +206,7 @@ describe('chart.js payloads the core can build a trace from', () => {
       return;
     expect(state.traceType).toBe(TraceType.DOT);
     expect(state.text.main.value).toBe('Safari');
-    expect(state.text.cross.value).toBe(19);
+    expect(state.text.cross?.value).toBe(19);
   });
 
   it('builds a dumbbell trace', () => {

--- a/test/model/area.test.ts
+++ b/test/model/area.test.ts
@@ -113,7 +113,7 @@ describe('unstacked area', () => {
     moveToColumn(trace, 1);
 
     const { text } = nonEmptyState(trace);
-    expect(text.cross.value).toBe(20);
+    expect(text.cross?.value).toBe(20);
     // Bands that do not stack have no total to report; announcing one would
     // claim an aggregate the chart never draws.
     expect(text.stack).toBeUndefined();
@@ -142,7 +142,7 @@ describe('stacked area', () => {
     // The regression this trace type exists to prevent: read as a line, the
     // announcement carried 20 alone with nothing to say whether that was the
     // band's height or the stack's top edge.
-    expect(text.cross.value).toBe(20);
+    expect(text.cross?.value).toBe(20);
     expect(text.stack?.value).toBe(TOTALS[1]);
   });
 
@@ -199,7 +199,7 @@ describe('stacked area', () => {
 
     const { text } = nonEmptyState(trace);
     expect(text.main.value).toBe('Q2');
-    expect(text.cross.value).toBe(20);
+    expect(text.cross?.value).toBe(20);
     expect(text.stack?.value).toBe(TOTALS[1]);
     expect(text.stack?.share).toBeCloseTo(20 / 40);
   });

--- a/test/model/boxen.test.ts
+++ b/test/model/boxen.test.ts
@@ -104,7 +104,7 @@ describe('the ladder is walked in value order', () => {
     // move monotonically through the distribution, or the pitch stops meaning
     // "further out".
     const values = [0, 1, 2, 3, 4].map(col =>
-      nonEmptyState(boxen(0, col)).text.cross.value);
+      nonEmptyState(boxen(0, col)).text.cross?.value);
 
     expect(values).toEqual([42, 45, 50, 55, 58]);
   });
@@ -132,7 +132,7 @@ describe('the ladder is walked in value order', () => {
       ],
     }];
     const values = [0, 1, 2, 3, 4].map(col =>
-      nonEmptyState(boxen(0, col, reversed)).text.cross.value);
+      nonEmptyState(boxen(0, col, reversed)).text.cross?.value);
 
     expect(values).toEqual([42, 45, 50, 55, 58]);
   });
@@ -231,7 +231,7 @@ describe('which axis is which follows the orientation', () => {
     const { text } = nonEmptyState(boxen());
 
     expect(text.main.label).toBe('Group');
-    expect(text.cross.label).toBe('Milliseconds');
+    expect(text.cross?.label).toBe('Milliseconds');
   });
 
   test('a chart whose distributions run across the page swaps them', () => {
@@ -240,7 +240,7 @@ describe('which axis is which follows the orientation', () => {
     );
 
     expect(text.main.label).toBe('Milliseconds');
-    expect(text.cross.label).toBe('Group');
+    expect(text.cross?.label).toBe('Group');
   });
 });
 

--- a/test/model/bump.test.ts
+++ b/test/model/bump.test.ts
@@ -166,7 +166,7 @@ describe('the move travels with the rank', () => {
     // Cedar goes 3rd to 1st between R1 and R2.
     const { text } = nonEmptyState(bump(2, 1));
 
-    expect(text.cross.value).toBe(1);
+    expect(text.cross?.value).toBe(1);
     expect(text.stack).toEqual({ label: 'Places gained', value: 2 });
   });
 

--- a/test/model/candlestickDelta.test.ts
+++ b/test/model/candlestickDelta.test.ts
@@ -173,7 +173,7 @@ describe('candlestickDelta state', () => {
     expect(state.empty).toBe(false);
     if (!state.empty) {
       expect(state.text.main.value).toBe('2026-01-01');
-      expect(state.text.cross.value).toBe(2);
+      expect(state.text.cross?.value).toBe(2);
       expect(state.text.section).toBe('close');
       expect(state.text.z?.value).toBe('above line');
     }
@@ -184,12 +184,12 @@ describe('candlestickDelta state', () => {
     trace.setInitialPosition(1);
     const below = trace.state;
     expect(!below.empty && below.text.z?.value).toBe('below line');
-    expect(!below.empty && below.text.cross.value).toBe(1.5);
+    expect(!below.empty && below.text.cross?.value).toBe(1.5);
 
     trace.setInitialPosition(2);
     const onLine = trace.state;
     expect(!onLine.empty && onLine.text.z?.value).toBe('on line');
-    expect(!onLine.empty && onLine.text.cross.value).toBe(0);
+    expect(!onLine.empty && onLine.text.cross?.value).toBe(0);
   });
 
   test('audio encodes |delta| as pitch and glides up for above-line points', () => {

--- a/test/model/candlestickStateAt.test.ts
+++ b/test/model/candlestickStateAt.test.ts
@@ -33,7 +33,7 @@ describe('candlestick.getStateAt', () => {
     expect(state.empty).toBe(false);
     if (!state.empty) {
       expect(state.text.main.value).toBe('2026-01-02');
-      expect(state.text.cross.value).toBe(17);
+      expect(state.text.cross?.value).toBe(17);
       expect(state.text.section).toBe('close');
     }
   });

--- a/test/model/contour.test.ts
+++ b/test/model/contour.test.ts
@@ -98,7 +98,7 @@ describe('contour registration', () => {
 
   test('it walks a curve the way a line layer does', () => {
     expect(nonEmptyState(contour(1, 2)).text.main.value).toBe(10);
-    expect(nonEmptyState(contour(1, 2)).text.cross.value).toBe(8);
+    expect(nonEmptyState(contour(1, 2)).text.cross?.value).toBe(8);
   });
 });
 

--- a/test/model/diverging.test.ts
+++ b/test/model/diverging.test.ts
@@ -131,7 +131,7 @@ describe('the sign is a direction, not a magnitude', () => {
     // are on, which the label beside it already said.
     const { text } = nonEmptyState(diverging(0, 0));
 
-    expect(text.cross.value).toBe(1200);
+    expect(text.cross?.value).toBe(1200);
     expect(text.z).toEqual({ label: 'Sex', value: 'Men' });
   });
 
@@ -181,8 +181,8 @@ describe('a chart drawn with its bands down the page', () => {
     // ordinary case rather than the exotic one.
     const { text } = nonEmptyState(horizontal(0, 0));
 
-    expect(text.cross.label).toBe('People');
-    expect(text.cross.value).toBe(1200);
+    expect(text.cross?.label).toBe('People');
+    expect(text.cross?.value).toBe(1200);
     expect(text.main.value).toBe('0-24');
     expect(text.z?.value).toBe('Men');
   });
@@ -204,7 +204,7 @@ describe('the balance row says which side is ahead', () => {
     // "Sum is 50" invites a reader to hear a total; the number is a lead.
     const { text } = nonEmptyState(diverging(BALANCE_ROW, 1));
 
-    expect(text.cross.value).toBe(50);
+    expect(text.cross?.value).toBe(50);
     expect(text.z).toEqual({ label: 'Balance', value: 'Women ahead' });
   });
 
@@ -248,7 +248,7 @@ describe('the balance row says which side is ahead', () => {
 
     expect(text.z).toEqual({ label: 'Sex', value: 'Sum' });
     // Signed, too: on a sum a minus sign really is a smaller number.
-    expect(text.cross.value).toBe(-300);
+    expect(text.cross?.value).toBe(-300);
   });
 
   test('says level rather than naming a winner at zero', () => {

--- a/test/model/dumbbell.test.ts
+++ b/test/model/dumbbell.test.ts
@@ -136,7 +136,7 @@ describe('navigation', () => {
     const declining = nonEmptyState(dumbbell(1, 1));
 
     expect(declining.text.section).toBe('2020');
-    expect(declining.text.cross.value).toBe(69.5);
+    expect(declining.text.cross?.value).toBe(69.5);
   });
 });
 
@@ -211,7 +211,7 @@ describe('orientation', () => {
     const horizontal = nonEmptyState(dumbbell(0, 0, GAINS, Orientation.HORIZONTAL));
 
     expect(horizontal.text.main.label).toBe('Years');
-    expect(horizontal.text.cross.label).toBe('Country');
+    expect(horizontal.text.cross?.label).toBe('Country');
     // Which real axis each value came from, so the formatter service picks
     // the right per-axis format.
     expect(horizontal.text.mainAxis).toBe('y');

--- a/test/model/errorBar.test.ts
+++ b/test/model/errorBar.test.ts
@@ -86,9 +86,9 @@ describe('sections', () => {
     // Moving up the grid must move up the value axis, or the cursor's
     // direction contradicts the chart's.
     expect(at(MEANS, 0, 0).state).toMatchObject({ empty: false });
-    expect(nonEmptyState(at(MEANS, 0, 0)).text.cross.value).toBe(3.8);
-    expect(nonEmptyState(at(MEANS, 1, 0)).text.cross.value).toBe(4.2);
-    expect(nonEmptyState(at(MEANS, 2, 0)).text.cross.value).toBe(4.6);
+    expect(nonEmptyState(at(MEANS, 0, 0)).text.cross?.value).toBe(3.8);
+    expect(nonEmptyState(at(MEANS, 1, 0)).text.cross?.value).toBe(4.2);
+    expect(nonEmptyState(at(MEANS, 2, 0)).text.cross?.value).toBe(4.6);
   });
 
   test('names which magnitude is being read', () => {
@@ -103,7 +103,7 @@ describe('sections', () => {
     const { text } = nonEmptyState(at(MEANS, 2, 2));
 
     expect(text.main.value).toBe('high dose');
-    expect(text.cross.value).toBe(7.4);
+    expect(text.cross?.value).toBe(7.4);
   });
 
   test('omits a bound the data never carries', () => {
@@ -128,7 +128,7 @@ describe('sections', () => {
 
     const { text } = nonEmptyState(trace);
     expect(text.section).toBe('value');
-    expect(text.cross.value).toBe(2);
+    expect(text.cross?.value).toBe(2);
   });
 
   test('omits the estimate a band never carries', () => {
@@ -140,11 +140,11 @@ describe('sections', () => {
 
     trace.moveToIndex(0, 0);
     expect(nonEmptyState(trace).text.section).toBe('lower bound');
-    expect(nonEmptyState(trace).text.cross.value).toBe(5);
+    expect(nonEmptyState(trace).text.cross?.value).toBe(5);
 
     trace.moveToIndex(1, 0);
     expect(nonEmptyState(trace).text.section).toBe('upper bound');
-    expect(nonEmptyState(trace).text.cross.value).toBe(15);
+    expect(nonEmptyState(trace).text.cross?.value).toBe(15);
   });
 
   test('gives a band two rows, not three', () => {
@@ -200,7 +200,7 @@ describe('horizontal orientation', () => {
     const { text } = nonEmptyState(horizontal(1, 0));
 
     expect(text.main.label).toBe('Response');
-    expect(text.cross.label).toBe('Group');
+    expect(text.cross?.label).toBe('Group');
   });
 
   test('names the real axis each value came from', () => {
@@ -237,8 +237,8 @@ describe('horizontal orientation', () => {
   });
 
   test('reads the same magnitudes as the vertical chart', () => {
-    expect(nonEmptyState(horizontal(0, 0)).text.cross.value).toBe(3.8);
-    expect(nonEmptyState(horizontal(2, 0)).text.cross.value).toBe(4.6);
+    expect(nonEmptyState(horizontal(0, 0)).text.cross?.value).toBe(3.8);
+    expect(nonEmptyState(horizontal(2, 0)).text.cross?.value).toBe(4.6);
     expect(nonEmptyState(horizontal(2, 0)).text.section).toBe('upper bound');
   });
 });
@@ -267,7 +267,7 @@ describe('extrema navigation', () => {
 
     const { text } = nonEmptyState(trace);
     expect(text.section).toBe('value');
-    expect(text.cross.value).toBe(7.3);
+    expect(text.cross?.value).toBe(7.3);
   });
 
   test('ranks a band across both its bounds', () => {
@@ -305,7 +305,7 @@ describe('extrema navigation', () => {
 
     const { text } = nonEmptyState(trace);
     expect(text.section).toBe('upper bound');
-    expect(text.cross.value).toBe(50);
+    expect(text.cross?.value).toBe(50);
   });
 
   test('offers both ends of a one-sample band', () => {

--- a/test/model/forest.test.ts
+++ b/test/model/forest.test.ts
@@ -93,9 +93,9 @@ describe('forest registration', () => {
   test('it reads the interval a bound at a time, as an error bar does', () => {
     // The navigation transfers wholesale: what this type adds is what the
     // figure is read *for*, not a different way through it.
-    expect(nonEmptyState(forest(0, 1)).text.cross.value).toBe(0.98);
-    expect(nonEmptyState(forest(1, 1)).text.cross.value).toBe(1.34);
-    expect(nonEmptyState(forest(2, 1)).text.cross.value).toBe(1.83);
+    expect(nonEmptyState(forest(0, 1)).text.cross?.value).toBe(0.98);
+    expect(nonEmptyState(forest(1, 1)).text.cross?.value).toBe(1.34);
+    expect(nonEmptyState(forest(2, 1)).text.cross?.value).toBe(1.83);
   });
 });
 

--- a/test/model/funnel.test.ts
+++ b/test/model/funnel.test.ts
@@ -139,7 +139,7 @@ describe('the announcement keeps the count', () => {
     const { text } = nonEmptyState(funnel(1));
 
     expect(text.main.value).toBe('Signed up');
-    expect(text.cross.value).toBe(2400);
+    expect(text.cross?.value).toBe(2400);
     expect(text.z).toEqual({ label: 'Retained', value: '24.0%' });
     expect(text.stack?.label).toBe('Entered');
     expect(text.stack?.value).toBe(10000);
@@ -155,7 +155,7 @@ describe('the announcement keeps the count', () => {
     expect(text.z).toBeUndefined();
     expect(text.stack).toBeUndefined();
     // The count itself is still there.
-    expect(text.cross.value).toBe(10000);
+    expect(text.cross?.value).toBe(10000);
   });
 
   test('the description names the entry stage, since the announcement does not', () => {

--- a/test/model/gantt.test.ts
+++ b/test/model/gantt.test.ts
@@ -157,7 +157,7 @@ describe('which axis is which follows the orientation', () => {
     const { text } = nonEmptyState(gantt());
 
     expect(text.main.label).toBe('Task');
-    expect(text.cross.label).toBe('Day');
+    expect(text.cross?.label).toBe('Day');
     expect(text.mainAxis).toBe('x');
     expect(text.crossAxis).toBe('y');
   });
@@ -172,7 +172,7 @@ describe('which axis is which follows the orientation', () => {
     );
 
     expect(text.main.label).toBe('Day');
-    expect(text.cross.label).toBe('Task');
+    expect(text.cross?.label).toBe('Task');
     expect(text.mainAxis).toBe('y');
     expect(text.crossAxis).toBe('x');
   });

--- a/test/model/gauge.test.ts
+++ b/test/model/gauge.test.ts
@@ -110,7 +110,7 @@ describe('the reading is relational', () => {
     // textual equivalent anywhere on the chart.
     const { text } = nonEmptyState(gauge());
 
-    expect(text.cross.value).toBe(73);
+    expect(text.cross?.value).toBe(73);
     expect(text.z).toEqual({ label: 'Range', value: '0 to 100' });
   });
 

--- a/test/model/hexbin.test.ts
+++ b/test/model/hexbin.test.ts
@@ -151,7 +151,7 @@ describe('a bin is announced by its centre', () => {
     const { text } = nonEmptyState(hexbin(1, 1));
 
     expect(text.main.value).toBe(3);
-    expect(text.cross.value).toBe(1);
+    expect(text.cross?.value).toBe(1);
     expect(text.z).toEqual({ label: 'Count', value: 12 });
   });
 });

--- a/test/model/mosaic.test.ts
+++ b/test/model/mosaic.test.ts
@@ -92,7 +92,7 @@ describe('mosaic registration', () => {
     const { text } = nonEmptyState(mosaic(0, 0));
 
     expect(text.main.value).toBe('First');
-    expect(text.cross.value).toBe(0.62);
+    expect(text.cross?.value).toBe(0.62);
     expect(text.z).toEqual({ label: 'Outcome', value: 'Survived' });
   });
 });

--- a/test/model/network.test.ts
+++ b/test/model/network.test.ts
@@ -106,7 +106,7 @@ describe('network registration', () => {
     // distinct collaborators. Reading the links one way would halve every
     // degree on the chart.
     expect(nonEmptyState(network()).text.main.value).toBe('Ada');
-    expect(nonEmptyState(network()).text.cross.value).toBe(4);
+    expect(nonEmptyState(network()).text.cross?.value).toBe(4);
   });
 
   test('a link declared both ways counts once', () => {
@@ -117,7 +117,7 @@ describe('network registration', () => {
       { source: 'B', target: 'A' },
     ];
 
-    expect(nonEmptyState(network(doubled)).text.cross.value).toBe(1);
+    expect(nonEmptyState(network(doubled)).text.cross?.value).toBe(1);
   });
 
   test('a self-link is not a connection to anyone', () => {

--- a/test/model/parallel.test.ts
+++ b/test/model/parallel.test.ts
@@ -321,7 +321,7 @@ describe('navigation is the multi-line model', () => {
     expect(trace.moveOnce('FORWARD')).toBe(true);
     expect(nonEmptyState(trace).text.main.value).toBe('hp');
     expect(trace.moveOnce('UPWARD')).toBe(true);
-    expect(nonEmptyState(trace).text.cross.value).toBe(110);
+    expect(nonEmptyState(trace).text.cross?.value).toBe(110);
   });
 
   test('announces the axis name and the raw value, not the normalized one', () => {
@@ -330,6 +330,6 @@ describe('navigation is the multi-line model', () => {
     const { text } = nonEmptyState(parallel(2, 2));
 
     expect(text.main.value).toBe('weight');
-    expect(text.cross.value).toBe(3200);
+    expect(text.cross?.value).toBe(3200);
   });
 });

--- a/test/model/pie.test.ts
+++ b/test/model/pie.test.ts
@@ -251,7 +251,7 @@ describe('pie slices with a negative value', () => {
 
     const { text } = stateAtSlice(trace, 1);
 
-    expect(text.cross.value).toBe(-40);
+    expect(text.cross?.value).toBe(-40);
   });
 
   it('scales the pitch over a range that includes the negative', () => {

--- a/test/model/radar.test.ts
+++ b/test/model/radar.test.ts
@@ -140,7 +140,7 @@ describe('navigation is the multi-line model', () => {
     expect(trace.moveOnce('DOWNWARD')).toBe(false);
     expect(trace.moveOnce('UPWARD')).toBe(true);
     expect(nonEmptyState(trace).text.main.value).toBe('range');
-    expect(nonEmptyState(trace).text.cross.value).toBe(7);
+    expect(nonEmptyState(trace).text.cross?.value).toBe(7);
   });
 
   test('stops at the last spoke rather than wrapping', () => {
@@ -323,6 +323,6 @@ describe('the rest of the reading is unchanged', () => {
     const { text } = nonEmptyState(radar(1, 2));
 
     expect(text.main.value).toBe('comfort');
-    expect(text.cross.value).toBe(3);
+    expect(text.cross?.value).toBe(3);
   });
 });

--- a/test/model/scatter.test.ts
+++ b/test/model/scatter.test.ts
@@ -208,12 +208,12 @@ describe('ScatterTrace point mode', () => {
     // point of reading order — a per-column walk would bound here instead.
     expect(trace.movePointRight()).toBe(true);
     expect(stateOf(trace).text.main.value).toBe(1);
-    expect(stateOf(trace).text.cross.value).toBe(2);
+    expect(stateOf(trace).text.cross?.value).toBe(2);
 
     // (1,2) -> (0,1): y drops, x wraps back to the leftmost column.
     expect(trace.movePointRight()).toBe(true);
     expect(stateOf(trace).text.main.value).toBe(0);
-    expect(stateOf(trace).text.cross.value).toBe(1);
+    expect(stateOf(trace).text.cross?.value).toBe(1);
 
     // Three points, so the third press has nowhere to go. No wrap.
     expect(trace.movePointRight()).toBe(false);
@@ -233,16 +233,16 @@ describe('ScatterTrace point mode', () => {
 
     expect(trace.movePointDown()).toBe(true);
     expect(stateOf(trace).text.main.value).toBe(0);
-    expect(stateOf(trace).text.cross.value).toBe(2);
+    expect(stateOf(trace).text.cross?.value).toBe(2);
 
     expect(trace.movePointDown()).toBe(true);
-    expect(stateOf(trace).text.cross.value).toBe(1);
+    expect(stateOf(trace).text.cross?.value).toBe(1);
 
     // Back up the same column, in the same order.
     expect(trace.movePointUp()).toBe(true);
-    expect(stateOf(trace).text.cross.value).toBe(2);
+    expect(stateOf(trace).text.cross?.value).toBe(2);
     expect(trace.movePointUp()).toBe(true);
-    expect(stateOf(trace).text.cross.value).toBe(3);
+    expect(stateOf(trace).text.cross?.value).toBe(3);
     expect(trace.movePointUp()).toBe(false);
   });
 
@@ -259,7 +259,7 @@ describe('ScatterTrace point mode', () => {
     trace.setPointMode(true);
 
     expect(stateOf(trace).text.main.value).toBe(5);
-    expect(stateOf(trace).text.cross.value).toBe(8);
+    expect(stateOf(trace).text.cross?.value).toBe(8);
   });
 
   test('setPointMode(true) seeds from the current ROW selection after a nav-mode toggle', () => {
@@ -280,7 +280,7 @@ describe('ScatterTrace point mode', () => {
 
     // A COL-seeded entry would still be sitting at (1,5).
     expect(stateOf(trace).text.main.value).toBe(7);
-    expect(stateOf(trace).text.cross.value).toBe(9);
+    expect(stateOf(trace).text.cross?.value).toBe(9);
   });
 
   test('point navigation is a no-op when point mode is not enabled', () => {
@@ -306,7 +306,7 @@ describe('ScatterTrace point mode', () => {
     trace.setPointMode(true);
 
     expect(stateOf(trace).text.main.value).toBe(0);
-    expect(stateOf(trace).text.cross.value).toBe(2);
+    expect(stateOf(trace).text.cross?.value).toBe(2);
     // Re-seeded to reading position 0, so the first left press should bound.
     expect(trace.movePointLeft()).toBe(false);
   });
@@ -363,7 +363,7 @@ describe('ScatterTrace 3D announcements', () => {
     expect(trace.moveOnce('FORWARD')).toBe(true);
 
     expect(stateOf(trace).text.main.value).toBe(1);
-    expect(stateOf(trace).text.cross.value).toBe(2);
+    expect(stateOf(trace).text.cross?.value).toBe(2);
     expect((trace as unknown as { mode: string }).mode).toBe(modeBefore);
   });
 

--- a/test/model/scatterCategoryLabel.test.ts
+++ b/test/model/scatterCategoryLabel.test.ts
@@ -87,7 +87,7 @@ describe('a scatter whose x axis carries names', () => {
     const trace = new ScatterTrace(layerOf(stripPoints()));
     trace.col = 0;
 
-    expect(stateOf(trace).text.cross.value).toEqual([1, 2]);
+    expect(stateOf(trace).text.cross?.value).toEqual([1, 2]);
   });
 
   test('point mode announces the category too', () => {
@@ -111,7 +111,7 @@ describe('a scatter whose x axis carries names', () => {
     trace.moveOnce('UPWARD'); // Handshake.
     trace.moveOnce('UPWARD'); // Toggle to ROW mode, at the lowest y.
 
-    expect(stateOf(trace).text.cross.value).toEqual(['a', 'b']);
+    expect(stateOf(trace).text.cross?.value).toEqual(['a', 'b']);
   });
 
   test('intersection mode names the anchor category', () => {
@@ -181,7 +181,7 @@ describe('a scatter whose y axis carries names', () => {
     ]));
     trace.col = 0;
 
-    expect(stateOf(trace).text.cross.value).toEqual(['a', 'b']);
+    expect(stateOf(trace).text.cross?.value).toEqual(['a', 'b']);
   });
 
   test('point mode announces it on the cross axis', () => {
@@ -189,7 +189,7 @@ describe('a scatter whose y axis carries names', () => {
     trace.moveOnce('UPWARD');
     trace.setPointMode(true);
 
-    expect(stateOf(trace).text.cross.value).toBe('a');
+    expect(stateOf(trace).text.cross?.value).toBe('a');
   });
 });
 
@@ -202,7 +202,7 @@ describe('what must not change', () => {
     trace.col = 0;
 
     expect(stateOf(trace).text.main.value).toBe(1.5);
-    expect(stateOf(trace).text.cross.value).toEqual([10]);
+    expect(stateOf(trace).text.cross?.value).toEqual([10]);
   });
 
   test('an empty label is treated as absent', () => {
@@ -228,7 +228,7 @@ describe('what must not change', () => {
 
     trace.col = 0;
     expect(stateOf(trace).text.main.value).toBe('a');
-    expect(stateOf(trace).text.cross.value).toEqual([2, 3]);
+    expect(stateOf(trace).text.cross?.value).toEqual([2, 3]);
 
     trace.col = 1;
     expect(stateOf(trace).text.main.value).toBe('c');
@@ -244,6 +244,6 @@ describe('what must not change', () => {
     trace.moveOnce('UPWARD');
     trace.moveOnce('UPWARD');
 
-    expect(stateOf(trace).text.cross.value).toEqual(['a', '1']);
+    expect(stateOf(trace).text.cross?.value).toEqual(['a', '1']);
   });
 });

--- a/test/model/scatterPointIndices.test.ts
+++ b/test/model/scatterPointIndices.test.ts
@@ -132,7 +132,7 @@ describe('a scatter names the points it has highlighted', () => {
       if (state.empty) {
         throw new Error('expected a non-empty state');
       }
-      return { x: state.text.main.value, y: state.text.cross.value };
+      return { x: state.text.main.value, y: state.text.cross?.value };
     };
 
     /** The data point the published index names. */

--- a/test/model/step.test.ts
+++ b/test/model/step.test.ts
@@ -159,12 +159,12 @@ describe('step trace transition navigation', () => {
 
     expect(trace.moveToRotorFilter('transition', 'right')).toBe(true);
     expect(trace.col).toBe(1);
-    expect(nonEmptyState(trace).text.cross.value).toBe('N2');
+    expect(nonEmptyState(trace).text.cross?.value).toBe('N2');
 
     // Column 2 repeats N2, so the next transition is column 3, not column 2.
     expect(trace.moveToRotorFilter('transition', 'right')).toBe(true);
     expect(trace.col).toBe(3);
-    expect(nonEmptyState(trace).text.cross.value).toBe('REM');
+    expect(nonEmptyState(trace).text.cross?.value).toBe('REM');
   });
 
   test('jumps backward to the previous change and reports the boundary', () => {

--- a/test/model/survival.test.ts
+++ b/test/model/survival.test.ts
@@ -93,7 +93,7 @@ describe('survival registration', () => {
 
   test('it reads the curve a time at a time, as a step chart does', () => {
     expect(nonEmptyState(survival(0, 2)).text.main.value).toBe(6);
-    expect(nonEmptyState(survival(0, 2)).text.cross.value).toBe(0.71);
+    expect(nonEmptyState(survival(0, 2)).text.cross?.value).toBe(0.71);
   });
 });
 

--- a/test/model/traceStateAt.test.ts
+++ b/test/model/traceStateAt.test.ts
@@ -29,7 +29,7 @@ describe('abstractTrace.getStateAt', () => {
     expect(state.empty).toBe(false);
     if (!state.empty) {
       expect(state.text.main.value).toBe('C');
-      expect(state.text.cross.value).toBe(3);
+      expect(state.text.cross?.value).toBe(3);
     }
   });
 

--- a/test/model/treemap.test.ts
+++ b/test/model/treemap.test.ts
@@ -112,7 +112,7 @@ describe('the hierarchy is built from the paths', () => {
   });
 
   test('a derived node totals its children', () => {
-    expect(nonEmptyState(treemap()).text.cross.value).toBe(150);
+    expect(nonEmptyState(treemap()).text.cross?.value).toBe(150);
   });
 
   test('a declared total is kept even where the children disagree', () => {
@@ -124,7 +124,7 @@ describe('the hierarchy is built from the paths', () => {
       ...NATIONS,
     ];
 
-    expect(nonEmptyState(treemap(declared)).text.cross.value).toBe(200);
+    expect(nonEmptyState(treemap(declared)).text.cross?.value).toBe(200);
   });
 
   test('a leaf declared with no path is a top-level node', () => {

--- a/test/model/treemap.test.ts
+++ b/test/model/treemap.test.ts
@@ -415,3 +415,88 @@ describe('the level rotor reads the band an icicle is drawn as', () => {
     expect(keys).not.toContain('level');
   });
 });
+
+/**
+ * A tree in which no node declares a magnitude (#1153).
+ *
+ * `TreemapPoint.y` is optional so an interior node can take the sum of its
+ * children, but a tree where *nothing* declares one is a different thing: a
+ * pure hierarchy, which is what an org chart is. Measured on a Highcharts
+ * organization chart, every node's `value` and `weight` came back null and
+ * the library's own internal `sum` was 1 for every node alike, because it
+ * assigns one unit per link for layout.
+ *
+ * Read as an ordinary tree it announced `0` everywhere over a
+ * `freq { min: 0, max: 0 }`, and declaring Highcharts' 1 instead made two
+ * siblings each 100% of their parent. The announcement half of the fix is
+ * covered in `test/service/textValuelessTree.test.ts`; these cover the
+ * sonification and the description.
+ */
+const ORG: TreemapPoint[] = [
+  { x: 'Ada' },
+  { x: 'Bo', path: ['Ada'] },
+  { x: 'Cy', path: ['Ada'] },
+  { x: 'Engineering', path: ['Ada', 'Bo'] },
+  { x: 'Design', path: ['Ada', 'Bo'] },
+  { x: 'Finance', path: ['Ada', 'Cy'] },
+];
+
+describe('a tree that declares no magnitude', () => {
+  test('sounds as a point with no value rather than as a flat zero', () => {
+    // The contract #925 established and deliberately did not scope to the
+    // trace that first needed it: a non-finite magnitude means the point
+    // exists to navigate to and has no value, and `AudioService` answers it
+    // with the empty tone. A 0 would have been a real tone at the bottom of
+    // the range -- a claim that every node is equal and small.
+    const { freq } = nonEmptyState(treemap(ORG)).audio;
+
+    expect(Number.isFinite(freq.raw as number)).toBe(false);
+  });
+
+  test('a tree that does declare magnitudes still pitches by them', () => {
+    const { freq } = nonEmptyState(treemap()).audio;
+
+    expect(freq.raw).toBe(150);
+  });
+
+  test('the description keeps the shape and drops the totals', () => {
+    const labels = treemap(ORG).description.stats.map(entry => entry.label);
+
+    expect(labels).toEqual(['Levels', 'Number of nodes', 'Number of leaves']);
+  });
+
+  test('a valued tree keeps every stat it had', () => {
+    const labels = treemap().description.stats.map(entry => entry.label);
+
+    expect(labels).toContain('Total');
+    expect(labels).toContain('Top level');
+    expect(labels).toContain('Largest leaf');
+  });
+
+  test('the table drops the columns it would fill with zeroes', () => {
+    const { headers, rows } = treemap(ORG).description.dataTable;
+
+    expect(headers).toEqual(['Path', 'Region']);
+    expect(rows[0]).toEqual(['', 'Ada']);
+    expect(rows).toHaveLength(6);
+  });
+
+  test('a valued tree keeps its value and share columns', () => {
+    const { headers } = treemap().description.dataTable;
+
+    expect(headers).toEqual(['Path', 'Region', 'Population', 'Share of total']);
+  });
+
+  test('one declared magnitude anywhere makes the whole tree a valued one', () => {
+    // A mixed tree is the documented ordinary case, and must not be caught.
+    const mixed: TreemapPoint[] = [
+      { x: 'Ada' },
+      { x: 'Bo', y: 4, path: ['Ada'] },
+      { x: 'Cy', path: ['Ada'] },
+    ];
+
+    expect(treemap(mixed).description.stats.map(e => e.label)).toContain('Total');
+    expect(Number.isFinite(nonEmptyState(treemap(mixed)).audio.freq.raw as number))
+      .toBe(true);
+  });
+});

--- a/test/model/waterfall.test.ts
+++ b/test/model/waterfall.test.ts
@@ -83,7 +83,7 @@ describe('reading a step', () => {
     const { text } = nonEmptyState(at(1));
 
     expect(text.main.value).toBe('Marketing');
-    expect(text.cross.value).toBe(-250);
+    expect(text.cross?.value).toBe(-250);
   });
 
   test('carries the running total alongside the contribution', () => {
@@ -107,7 +107,7 @@ describe('reading a step', () => {
     // two: at every step the two must not be the same value.
     for (let col = 1; col < 4; col++) {
       const { text } = nonEmptyState(at(col));
-      expect(text.cross.value).not.toBe(text.stack?.value);
+      expect(text.cross?.value).not.toBe(text.stack?.value);
     }
   });
 });

--- a/test/model/wordCloud.test.ts
+++ b/test/model/wordCloud.test.ts
@@ -89,7 +89,7 @@ describe('reading a term', () => {
     const { text } = nonEmptyState(at(0));
 
     expect(text.main.value).toBe('machine');
-    expect(text.cross.value).toBe(412);
+    expect(text.cross?.value).toBe(412);
   });
 
   test('keeps ties in their authored order', () => {
@@ -120,7 +120,7 @@ describe('string weights', () => {
     const trace = at(0, asText);
 
     expect(nonEmptyState(trace).text.main.value).toBe('large');
-    expect(nonEmptyState(trace).text.cross.value).toBe(10);
+    expect(nonEmptyState(trace).text.cross?.value).toBe(10);
     expect(trace.description.stats).toContainEqual({
       label: 'Total weight',
       value: 12,

--- a/test/service/textValuelessTree.test.ts
+++ b/test/service/textValuelessTree.test.ts
@@ -1,0 +1,170 @@
+import type { NotificationService } from '@service/notification';
+import type { MaidrLayer, TreemapPoint } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { TreemapTrace } from '@model/treemap';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * How a tree with no magnitude anywhere is announced (#1153).
+ *
+ * `TraceType.TREEMAP` is the grammar's only hierarchy, and `TreemapPoint.y`
+ * is optional so that an interior node can take the sum of its children. A
+ * tree in which *no* node declares one was not expressible: the trace
+ * announced a value clause and derived shares from it either way, and both
+ * spellings said something the chart does not draw.
+ *
+ * Measured on a six-node org tree before the fix:
+ *
+ *   omitting y everywhere    every node announced `0`, over a
+ *                            `freq { min: 0, max: 0 }` that leaves no pitch
+ *                            range, so the whole tree sounded flat
+ *   declaring y: 1 everywhere  strictly worse -- Bo announced as 100% of
+ *                            Ada, and so was Cy, two siblings each reported
+ *                            as the whole of their parent
+ *
+ * What a reader wants from a pure hierarchy was already right: the
+ * navigation, the ancestry, and whether there is anything below. The single
+ * thing in the way was that every node also claimed a magnitude.
+ *
+ * These tests cover the announcement rather than the state, because the
+ * state's omission only helps if the service renders around it.
+ */
+
+/** Minimal NotificationService stub whose notify is a jest mock. */
+function createMockNotificationService(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+/** The text a service emits for one trace state, in the current text mode. */
+function announce(text: TextService, state: TraceState): string {
+  const changeListener = jest.fn();
+  const disposable = text.onChange(changeListener);
+
+  text.update(state);
+  disposable.dispose();
+  const event = changeListener.mock.calls[0][0] as { value: string };
+  return event.value;
+}
+
+/**
+ * Ada reports to nobody; Bo and Cy report to Ada; three functions below them.
+ *
+ * No `y` anywhere, which is what a Highcharts organization chart declares:
+ * measured, every node's `value` and `weight` came back null.
+ */
+const ORG: TreemapPoint[] = [
+  { x: 'Ada' },
+  { x: 'Bo', path: ['Ada'] },
+  { x: 'Cy', path: ['Ada'] },
+  { x: 'Engineering', path: ['Ada', 'Bo'] },
+  { x: 'Design', path: ['Ada', 'Bo'] },
+  { x: 'Finance', path: ['Ada', 'Cy'] },
+];
+
+/** The same shape with magnitudes, so the ordinary reading stays visible. */
+const VALUED: TreemapPoint[] = [
+  { x: 'Ada', y: 6 },
+  { x: 'Bo', y: 4, path: ['Ada'] },
+  { x: 'Cy', y: 2, path: ['Ada'] },
+];
+
+/** Builds a treemap layer over the given nodes. */
+function treeLayer(data: TreemapPoint[]): MaidrLayer {
+  return {
+    id: 'org',
+    type: TraceType.TREEMAP,
+    title: 'Reporting lines',
+    axes: { x: { label: 'Person' }, y: { label: 'Headcount' } },
+    data,
+  };
+}
+
+describe('announcing a tree that declares no magnitude', () => {
+  test('names the node and says nothing about a value', () => {
+    const trace = new TreemapTrace(treeLayer(ORG));
+    const text = new TextService(createMockNotificationService());
+
+    const spoken = announce(text, trace.getStateAt(0, 0));
+
+    expect(spoken).toBe('Person is Ada, Children is 2');
+  });
+
+  test('does not announce the axis it has no reading on', () => {
+    // The defect: `Headcount is 0` on every node of a chart that draws no
+    // headcount. The label goes with the value -- a bare "Headcount" with
+    // nothing after it would be worse than silence.
+    const trace = new TreemapTrace(treeLayer(ORG));
+    const text = new TextService(createMockNotificationService());
+
+    const spoken = announce(text, trace.getStateAt(0, 0));
+
+    expect(spoken).not.toContain('Headcount');
+    expect(spoken).not.toContain('0');
+  });
+
+  test('claims no share of a parent that has nothing to share', () => {
+    // The other spelling's failure, and the worse one: declaring the
+    // layout's per-link 1 made Bo 100% of Ada, and Cy 100% of Ada as well.
+    const trace = new TreemapTrace(treeLayer(ORG));
+    const text = new TextService(createMockNotificationService());
+
+    const bo = announce(text, trace.getStateAt(1, 0));
+    const cy = announce(text, trace.getStateAt(1, 1));
+
+    expect(bo).not.toContain('%');
+    expect(cy).not.toContain('%');
+    expect(bo).toContain('Bo');
+    expect(cy).toContain('Cy');
+  });
+
+  test('still gives the reader the ancestry and what is below', () => {
+    // The content that was always correct, and the reason reading an org
+    // chart this way beats the nothing it gets otherwise.
+    const trace = new TreemapTrace(treeLayer(ORG));
+    const text = new TextService(createMockNotificationService());
+
+    const spoken = announce(text, trace.getStateAt(2, 0));
+
+    expect(spoken).toContain('Engineering');
+    expect(spoken).toContain('Ada > Bo');
+  });
+
+  test('says nothing on the axis in terse mode either', () => {
+    const trace = new TreemapTrace(treeLayer(ORG));
+    const text = new TextService(createMockNotificationService());
+    // Verbose is the default; one toggle reaches terse.
+    text.toggle();
+
+    const spoken = announce(text, trace.getStateAt(0, 0));
+
+    expect(spoken).not.toContain('0');
+    expect(spoken).toContain('Ada');
+  });
+
+  test('a tree that does declare magnitudes is untouched', () => {
+    const trace = new TreemapTrace(treeLayer(VALUED));
+    const text = new TextService(createMockNotificationService());
+
+    const spoken = announce(text, trace.getStateAt(1, 0));
+
+    expect(spoken).toContain('Headcount is 4');
+    expect(spoken).toContain('Share of Ada is 66.7%');
+  });
+
+  test('one declared magnitude is enough to make the tree a valued one', () => {
+    // A mixed tree is the documented ordinary case -- an interior node
+    // summing its children -- and must not be caught by this.
+    const partial: TreemapPoint[] = [
+      { x: 'Ada' },
+      { x: 'Bo', y: 4, path: ['Ada'] },
+      { x: 'Cy', path: ['Ada'] },
+    ];
+    const trace = new TreemapTrace(treeLayer(partial));
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, trace.getStateAt(1, 0))).toContain('Headcount is 4');
+    expect(announce(text, trace.getStateAt(0, 0))).toContain('Headcount is 4');
+  });
+});


### PR DESCRIPTION
Closes #1153. Unblocks the `organization` case of #1138.

`TraceType.TREEMAP` is the grammar's only hierarchy, and `TreemapPoint.y` is documented as optional — "omitted for an interior node whose value is the sum of its children, which is the ordinary case". But a tree in which **no** node has a value was not expressible: `TreemapTrace` announced a value clause and computed shares from it either way, and both possible spellings announced something the chart does not draw.

## Measured

A six-node org tree (Ada → Bo, Cy; Bo → Engineering, Design; Cy → Finance), through `TraceFactory.create`:

**Omitting `y` on every node**

```
audio.freq   { min: 0, max: 0, raw: 0 }
text.cross   { label: 'Reports', value: 0 }
text.asides  [ { label: 'Children', value: '2' } ]
```

Every node announces `0` — a number the chart does not draw — and `min === max === 0` leaves no pitch range, so the sonification is flat across the whole tree.

**Declaring `y: 1` on every node** (Highcharts' own per-link unit)

```
text.asides  [ { label: 'Share of Ada', value: '100.0%' }, … ]
```

Strictly worse: **Bo is announced as 100% of Ada — and so is Cy.** Two siblings each reported as the whole of their parent.

## What this does

A pure hierarchy is now a recognised shape: no point declaring a finite `y` makes the tree a valueless one, and it then

- **omits the cross clause** rather than announcing a number. `Person is Ada, Children is 2`, not `Person is Ada, Reports is 0, Children is 2`.
- **sonifies with the empty tone.** This is the contract #925 already established and deliberately did not scope to the trace that first needed it: a non-finite magnitude means "the point exists to navigate to, it just has no value", and `AudioService` answers it without interpolating. Leaving the `0` would have been a real tone at the bottom of the range — a positive claim that every node is equal and small, rather than the absence of a claim.
- **drops `Total`, `Top level` and `Largest leaf`** from the description, keeping `Levels`, `Number of nodes` and `Number of leaves`, which are properties of the shape rather than of a magnitude.
- **tabulates two columns** — `Path` and the node name — rather than four, half of them filled with zeroes and blanks.

What a reader actually wants from a pure hierarchy was always right and is untouched: the navigation up, down and across siblings; `Path` for the ancestry; and `Children`, which is the one thing they cannot discover without pressing down and being told there is nothing there.

## Two commits

**`refactor(text): let a trace say it has no cross axis at all`** — `TextState.cross` becomes optional. `TextService` already tested for the clause before reading it in the terse and layer-switch paths, so the runtime was ahead of the type; the verbose, terse-value and grid-range paths now do too, and skip the label along with the value rather than announcing a bare label with nothing after it. `DescribeCommand` and `DivergingTrace` are the two other readers and neither invents a label to stand in. The rest is 29 test files that read the clause without checking for it, narrowed rather than asserted through, so a clause that went missing fails the expectation instead of throwing. **No behaviour change: 399 suites, 5517 tests, unchanged.**

Absent is not the same as empty, and the type says so: a trace that *has* a cross axis and no reading at this point still sends the axis with a non-finite value, which is announced as "missing".

**`feat(treemap): read a tree that declares no magnitude`** — the trace half above.

## Not changed

A **mixed** tree is the documented ordinary case — an undeclared interior node summing its children — and one declared magnitude anywhere makes the whole tree a valued one. There is a test for exactly that.

The two share clauses need no `valued` guard of their own, and one was written and then deleted for being unfalsifiable: in a tree that declares no magnitude every node's value is a sum of zeroes, so both denominators are 0 and both branches are already skipped, and a tree with a genuine declared `0` in it is a *valued* tree. There is no input the extra guard would change, so it is stated in a comment rather than coded.

## Verification

- 7 announcement tests in `test/service/textValuelessTree.test.ts` (verbose and terse, valueless and valued and mixed) and 7 model tests in `test/model/treemap.test.ts` (audio, description stats, data table).
- Mutation sweep over the flag, the cross omission, the audio value, the stats, the table, and both `TextService` guards: **10 of 10 killed.** One would-be survivor was resolved by deleting the redundant share guard rather than by loosening a test.
- `npx eslint src test` clean · `npx tsc --noEmit` clean · `npm run build` succeeds · `npm test`: **400 suites / 5531 tests, plus the ESM project's 10 / 137**, all passing.

## What this unblocks

`organization` in the Highcharts adapter, which #1138 documented as deliberately declined precisely because a tree with no magnitude could not be expressed. That reading is a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_