### PR TITLE
feat(highcharts): read an organization chart as the hierarchy it draws

### DIFF
--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -119,6 +119,7 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 | Network | `networkgraph` (requires `modules/networkgraph.js`) | [highcharts-network.html](examples/highcharts-network.html) |
 | Treemap | `treemap` (requires `modules/treemap.js`) | [highcharts-treemap.html](examples/highcharts-treemap.html) |
 | Sunburst | `sunburst` (requires `modules/sunburst.js`, which ships treemap) | [highcharts-sunburst.html](examples/highcharts-sunburst.html) |
+| Organization | `organization` (requires `modules/sankey.js` and `modules/organization.js`), read as a tree with no magnitude | — |
 | Gauge | `gauge`, `solidgauge` (require `highcharts-more.js`; solid gauge also `modules/solid-gauge.js`), `bullet` (requires `modules/bullet.js`) | [highcharts-gauge.html](examples/highcharts-gauge.html) |
 | Waterfall | `waterfall` (requires `highcharts-more.js`) | [highcharts-waterfall.html](examples/highcharts-waterfall.html) |
 | Error Bar | `errorbar` (requires `highcharts-more.js`), reading its estimates from the series it is `linkedTo`; `arearange`, `areasplinerange`, `columnrange` (require `highcharts-more.js`), each read as the band of intervals it draws | [highcharts-errorbar.html](examples/highcharts-errorbar.html) |
@@ -170,6 +171,12 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 
 > **Hierarchy note:** Highcharts declares a treemap or sunburst with `id`/`parent` pointers, and MAIDR declares one as a path — a node's ancestors, root first, itself excluded — so the adapter walks each node's parent chain to build it. A parent id that was never declared ends the path there, matching how Highcharts attaches such a node to the root, and a cyclic chain is broken with a warning rather than followed. Interior nodes keep whatever value they declared and are otherwise left valueless, since MAIDR derives an interior total from the children the paths give it. Both series file their marks into one DOM group per depth ordered by z-index, so document order says nothing about declaration order; the adapter stamps `data-maidr-node-index` onto each rendered node and the selectors address the stamp. A node Highcharts did not draw leaves MAIDR with fewer elements than nodes, and highlighting is withdrawn for that layer rather than paired with the wrong rectangles.
 
+> **Organization note:** an organization chart is a pure hierarchy and carries no magnitude at all. Measured on a six-node chart in Highcharts 11, every node came back with **no `value` field** and with Highcharts' own internal `sum` at `1` for every node alike, because the layout assigns one unit per link. It is read as a treemap that declares no `y`, which the trace recognises as a tree with nothing to announce on a second axis: no value clause, no shares, no total, and the empty tone rather than a flat one. What a reader gets is the structure — moving up to a manager, down to a report, across to a peer, the ancestry, and how many people report to whoever the cursor is on.
+>
+> The structure comes from `series.nodes` rather than from the links, because that is where Highcharts resolves `linksTo`, the display `name`, the `title` drawn under it, and the box itself. A node's label joins its name and its title, which is what the box says; a name Highcharts fell back to the id for is not repeated. A cyclic chain is cut with a warning, as it is for a treemap.
+>
+> **A node with more than one parent declines the whole series.** `TreemapPoint.path` is one ancestry, so a tree cannot say that someone reports to two managers, and reading it as one would drop a link the chart plainly draws. A silently missing edge is worse than the fallback, which at least says what it is.
+
 > **Gauge note:** a gauge layer's data is a single object rather than an array, because the chart draws exactly one measure; a series declaring several dials is read as its first. The dial's ends come from the value axis' extremes, a bullet chart's target from the point, and the qualitative bands from the axis' `plotBands`, sorted ascending because MAIDR carries only each band's upper edge. Highcharts bands are usually drawn in colour and named nowhere, so a band with neither a `label.text` nor a styled-mode `className` is numbered by its position in the partition. The three series draw the reading differently — a needle carrying no point class, an arc that is an ordinary point, a bar beside a target marker that also carries the point class — so each has its own highlight selector.
 
 > **Waterfall note:** Highcharts declares only what each step contributes, while MAIDR's step also carries the absolute positions its bar floats between, so the adapter accumulates the running total as it walks the series. The two kinds of restating bar are placed the way Highcharts draws them: an `isSum` step spans the baseline to the running total, an `isIntermediateSum` step spans the previous subtotal's edge to the current running total. Both are announced as `total` steps and are left out of "largest contribution", since they restate a number rather than contribute one.
@@ -198,7 +205,7 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 
 ### Series types that are deliberately not read
 
-Every other Highcharts series type either has a reading above or is a spelling of one. These five are drawn, understood, and declined — a chart containing one gets no layer for it. They are listed so that a later sweep finds the reasons rather than re-deriving them.
+Every other Highcharts series type either has a reading above or is a spelling of one. These four are drawn, understood, and declined — a chart containing one gets no layer for it. They are listed so that a later sweep finds the reasons rather than re-deriving them.
 
 | Series | Why it is declined |
 | --- | --- |
@@ -206,13 +213,6 @@ Every other Highcharts series type either has a reading above or is a spelling o
 | `polygon` | An arbitrary closed shape with no statistical reading — already noted in `test/adapters/highcharts/arearange.test.ts`. |
 | `vector`, `windbarb`, `flags` | Direction and annotation rather than a measured series. A vector's payload is an angle and a length at a position; a flag is a note pinned to a date. |
 | `packedbubble` | It has a magnitude, but the positions are a packing rather than data — announcing a bubble's x and y would report where the layout put it. |
-| `organization` | Blocked on the core rather than on the adapter — see below. |
-
-> **Organization note:** an organization chart is a pure hierarchy, and the hierarchy itself is exact and readable: `series.nodes` carries each node's `id`, `name` and `linksTo`, and every node draws its own `path.highcharts-node.highcharts-point` inside the series group in `series.nodes` order. What is missing is a magnitude. Measured on a six-node chart, every node's `value` and `weight` came back `null`, and Highcharts' own internal `sum` was `1` for every node alike because it assigns one unit per link for layout — so there is no number anywhere in the declaration.
->
-> `TraceType.TREEMAP` is the grammar's only hierarchy, and it cannot express that. Driving a valueless tree through `TreemapTrace`, **omitting `y`** announces `value: 0` on every node with `freq { min: 0, max: 0 }` — no pitch range at all — and **declaring `y: 1`** is worse: it announces `Share of Ada: 100.0%` for *both* of Ada's two children, because a declared parent value overrides the derived total that would have summed to 2. Either way every node states a magnitude the chart does not draw, which is the same objection this guide already makes about emitting `count` for a variwide.
->
-> An org chart read as a tree would be a real improvement on the nothing it gets today — navigation, the ancestry breadcrumb and the child count are all correct and useful. So this is declined pending [#1153](https://github.com/xability/maidr/issues/1153), which is about giving the tree a way to say it has no magnitude, rather than pending anything here. One further guard for whoever picks it up: `TreemapPoint.path` is *one* ancestry, so a node with two parents cannot be expressed and such a chart should be declined rather than have a parent picked for it.
 
 ## Declaring What a Series Means
 

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -60,7 +60,7 @@ import type {
   WordCloudPoint,
 } from '../../type/grammar';
 import type { DeclarationContext } from '../shared/traceDeclaration';
-import type { HighchartsAdapterOptions, HighchartsAxis, HighchartsChart, HighchartsPoint, HighchartsSeries } from './types';
+import type { HighchartsAdapterOptions, HighchartsAxis, HighchartsChart, HighchartsNode, HighchartsPoint, HighchartsSeries } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 import {
   isFlagValue,
@@ -1671,6 +1671,10 @@ function convertSeries(
       return convertTreeSeries(series, containerId, TraceType.TREEMAP);
     case 'sunburst':
       return convertTreeSeries(series, containerId, TraceType.SUNBURST);
+    // An organization chart is a hierarchy with no magnitude on it at all,
+    // which the treemap trace could not express until #1153.
+    case 'organization':
+      return convertOrganizationSeries(series, containerId);
     case 'gauge':
     case 'solidgauge':
     case 'bullet':
@@ -3093,6 +3097,153 @@ function convertTreeSeries(
     },
     data,
   };
+}
+
+/**
+ * Converts an `organization` series into a valueless treemap layer.
+ *
+ * An organization chart is a hierarchy and nothing else. Measured on a
+ * six-node chart in Highcharts 11 plus `modules/sankey.js` and
+ * `modules/organization.js`, every node came back with **no `value` field at
+ * all** and with Highcharts' own internal `sum` at `1` for every node alike,
+ * because the layout assigns one unit per link. There is no magnitude in the
+ * declaration and none in the drawing.
+ *
+ * That is why this was declined until now, and #1153 recorded why the two
+ * available spellings were both wrong: omitting `y` announced `0` on every
+ * node over a `freq { min: 0, max: 0 }`, and declaring the layout's `1`
+ * announced two siblings as 100% of their parent each. `TreemapTrace` now
+ * recognises a tree that declares no magnitude anywhere and reads it for what
+ * it has -- the navigation, the ancestry, and how many people report to
+ * whoever the cursor is on -- so the payload here declares no `y` and means
+ * it.
+ *
+ * The structure comes from `series.nodes` rather than from the links. An
+ * organization series is declared as `from`/`to` pairs, and Highcharts
+ * resolves them into node objects carrying `linksTo`, `linksFrom`, the
+ * display `name` and the `title` -- which is also the only place the drawn
+ * box can be reached from, for the selectors.
+ *
+ * **A node with two parents declines the whole series.** A tree cannot say
+ * that someone reports to two managers, and reading it as a tree would drop
+ * one of the two links from a chart that plainly draws both. A silently
+ * missing edge is worse than the fallback, which at least says what it is --
+ * the same line `qqline` is held to in xability/r-maidr#251.
+ *
+ * @param series - The organization series
+ * @param containerId - The chart container's DOM id
+ * @returns The layer, or null when the hierarchy is not a tree
+ */
+function convertOrganizationSeries(
+  series: HighchartsSeries,
+  containerId: string,
+): MaidrLayer | null {
+  const nodes = series.nodes ?? [];
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  const byId = new Map<string, HighchartsNode>();
+  for (const node of nodes) {
+    byId.set(node.id, node);
+  }
+
+  const multiParent = nodes.find(node => (node.linksTo ?? []).length > 1);
+  if (multiParent !== undefined) {
+    console.warn(
+      `[MAIDR Highcharts] "${series.name}" has a node with more than one `
+      + `parent ("${multiParent.id}"); a tree cannot carry that, so the `
+      + `series is skipped rather than read with an edge missing.`,
+    );
+    return null;
+  }
+
+  const data: TreemapPoint[] = nodes.map(node => ({
+    x: organizationNodeLabel(node),
+    path: organizationAncestors(node, byId, series.name),
+  }));
+
+  // The same stamping the treemap uses, over the nodes rather than the
+  // points: an organization series' `data` is its links, and what a reader
+  // navigates is the boxes.
+  stampPointIndices([nodes as unknown as HighchartsPoint[]], 'data-maidr-node-index');
+
+  return {
+    id: String(series.index),
+    type: TraceType.TREEMAP,
+    title: series.name || undefined,
+    selectors: treemapSelectors(containerId, series.index, data.length),
+    // No `y` axis. The chart has no second dimension to name, and
+    // `TreemapTrace` never reads the label on a tree that declares no
+    // magnitude, so naming one would claim an axis that is not drawn.
+    axes: { x: { label: TREE_NODE_AXIS } },
+    data,
+  };
+}
+
+/**
+ * What an organization box says, as one string.
+ *
+ * The box draws the node's name and, under it, the `title` the node option
+ * carries -- measured, a role such as "CEO". Both are joined because either
+ * alone loses half of what a sighted reader is given, and duplicates are
+ * dropped because Highcharts falls `name` back to `id`, so a node declared
+ * with neither would otherwise repeat itself.
+ *
+ * @param node - The node to name
+ * @returns The label, never empty
+ */
+function organizationNodeLabel(node: HighchartsNode): string {
+  const parts = [node.name, node.options?.title]
+    .filter((part): part is string => typeof part === 'string' && part !== '');
+  const unique = parts.filter((part, i) => parts.indexOf(part) === i);
+  return unique.length > 0 ? unique.join(', ') : node.id;
+}
+
+/**
+ * The labels of a node's ancestors, root first and the node itself excluded.
+ *
+ * Walks the single incoming link up to the root. A cycle -- which an
+ * organization chart can declare, since nothing stops a link pointing back up
+ * -- would otherwise loop forever, so a node already passed ends the walk and
+ * says so once.
+ *
+ * @param node - The node to trace back from
+ * @param byId - Every node of the series, keyed by id
+ * @param seriesName - The owning series, for the cycle warning
+ * @returns The path MAIDR addresses the node by, empty at the root
+ */
+function organizationAncestors(
+  node: HighchartsNode,
+  byId: Map<string, HighchartsNode>,
+  seriesName: string,
+): string[] {
+  const path: string[] = [];
+  const seen = new Set<string>([node.id]);
+  let at: HighchartsNode | undefined = node;
+
+  while (at !== undefined) {
+    const parentId = at.linksTo?.[0]?.from;
+    if (typeof parentId !== 'string') {
+      break;
+    }
+    if (seen.has(parentId)) {
+      console.warn(
+        `[MAIDR Highcharts] "${seriesName}" reports a cycle through `
+        + `"${parentId}"; the path is cut there.`,
+      );
+      break;
+    }
+    seen.add(parentId);
+    const parent = byId.get(parentId);
+    if (parent === undefined) {
+      break;
+    }
+    path.unshift(organizationNodeLabel(parent));
+    at = parent;
+  }
+
+  return path;
 }
 
 /**

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -3143,9 +3143,13 @@ function convertOrganizationSeries(
     return null;
   }
 
+  // Keyed by the id as a string. A chart declaring its links as `[[1, 2]]`
+  // gives numeric ids, draws correctly, and would otherwise have every path
+  // come back empty -- the whole hierarchy silently gone, announced as a
+  // flat list of roots.
   const byId = new Map<string, HighchartsNode>();
   for (const node of nodes) {
-    byId.set(node.id, node);
+    byId.set(String(node.id), node);
   }
 
   const multiParent = nodes.find(node => (node.linksTo ?? []).length > 1);
@@ -3166,7 +3170,7 @@ function convertOrganizationSeries(
   // The same stamping the treemap uses, over the nodes rather than the
   // points: an organization series' `data` is its links, and what a reader
   // navigates is the boxes.
-  stampPointIndices([nodes as unknown as HighchartsPoint[]], 'data-maidr-node-index');
+  stampPointIndices([nodes], 'data-maidr-node-index');
 
   return {
     id: String(series.index),
@@ -3197,7 +3201,7 @@ function organizationNodeLabel(node: HighchartsNode): string {
   const parts = [node.name, node.options?.title]
     .filter((part): part is string => typeof part === 'string' && part !== '');
   const unique = parts.filter((part, i) => parts.indexOf(part) === i);
-  return unique.length > 0 ? unique.join(', ') : node.id;
+  return unique.length > 0 ? unique.join(', ') : String(node.id);
 }
 
 /**
@@ -3219,23 +3223,26 @@ function organizationAncestors(
   seriesName: string,
 ): string[] {
   const path: string[] = [];
-  const seen = new Set<string>([node.id]);
+  const seen = new Set<string>([String(node.id)]);
   let at: HighchartsNode | undefined = node;
 
   while (at !== undefined) {
     const parentId = at.linksTo?.[0]?.from;
-    if (typeof parentId !== 'string') {
+    if (parentId === undefined || parentId === null) {
       break;
     }
-    if (seen.has(parentId)) {
+    // As a string, matching how `byId` is keyed: a numerically declared id
+    // is a real id, and treating it as "no parent" would flatten the tree.
+    const key = String(parentId);
+    if (seen.has(key)) {
       console.warn(
         `[MAIDR Highcharts] "${seriesName}" reports a cycle through `
-        + `"${parentId}"; the path is cut there.`,
+        + `"${key}"; the path is cut there.`,
       );
       break;
     }
-    seen.add(parentId);
-    const parent = byId.get(parentId);
+    seen.add(key);
+    const parent = byId.get(key);
     if (parent === undefined) {
       break;
     }
@@ -3322,10 +3329,19 @@ function stampTreeIndices(series: HighchartsSeries): void {
  * than shifting the indices, so the missing element makes its own selector
  * match nothing instead of pairing every later point with a neighbour's mark.
  *
- * @param groups - The points, in the order MAIDR reads them
+ * The parameter is narrowed to the one field this touches rather than taking
+ * a `HighchartsPoint`, because an organization series stamps its **nodes**:
+ * its points are the links, and what a reader navigates is the boxes. A cast
+ * between the two would have compiled only for as long as their `graphic`
+ * fields happened to agree.
+ *
+ * @param groups - The elements to stamp, in the order MAIDR reads them
  * @param attribute - The data attribute the selectors address
  */
-function stampPointIndices(groups: HighchartsPoint[][], attribute: string): void {
+function stampPointIndices(
+  groups: { graphic?: { element: SVGElement } }[][],
+  attribute: string,
+): void {
   let index = 0;
   for (const group of groups) {
     for (const point of group) {

--- a/src/adapters/highcharts/types.ts
+++ b/src/adapters/highcharts/types.ts
@@ -187,10 +187,48 @@ export type MapLonLat = [number, number] | { lon?: number; lat?: number };
 /**
  * Represents a single data series within a Highcharts chart.
  */
+/**
+ * One node of a node-and-link series.
+ *
+ * A sankey, a dependency wheel and an organization chart all declare their
+ * data as links and let Highcharts build the nodes from them, so the nodes
+ * are a *resolved* structure rather than a declared one: `series.nodes` is
+ * what the chart drew, and it is the only place a node's own options and its
+ * drawn element can be reached.
+ *
+ * Only the organization converter reads this today. A sankey's payload is
+ * its links, so nothing there needs the node objects.
+ */
+export interface HighchartsNode {
+  /** The identifier the links name this node by. */
+  id: string;
+  /** Display name, which Highcharts falls back to `id` for. */
+  name?: string;
+  /** The links whose `to` is this node — its parents, in an org chart. */
+  linksTo?: HighchartsPoint[];
+  /** The links whose `from` is this node — its children. */
+  linksFrom?: HighchartsPoint[];
+  /** The rendered box, which the per-node selectors are stamped onto. */
+  graphic?: { element: SVGElement };
+  options?: {
+    /**
+     * The second line an organization box draws, under the name — a job
+     * title. Highcharts names it `title`, and it is a node option rather
+     * than a point one, which is why it is reached through here.
+     */
+    title?: string;
+  };
+}
+
 export interface HighchartsSeries {
   type: string;
   name: string;
   data: HighchartsPoint[];
+  /**
+   * The nodes of a node-and-link series, resolved by Highcharts from the
+   * links. Absent on every other series type.
+   */
+  nodes?: HighchartsNode[];
   xAxis: HighchartsAxis;
   yAxis: HighchartsAxis;
   index: number;

--- a/src/adapters/highcharts/types.ts
+++ b/src/adapters/highcharts/types.ts
@@ -200,8 +200,15 @@ export type MapLonLat = [number, number] | { lon?: number; lat?: number };
  * its links, so nothing there needs the node objects.
  */
 export interface HighchartsNode {
-  /** The identifier the links name this node by. */
-  id: string;
+  /**
+   * The identifier the links name this node by.
+   *
+   * Numeric as well as textual, because a chart may declare its links as
+   * `[[1, 2], [1, 3]]` and Highcharts builds the nodes from whatever it is
+   * given -- measured, such a chart draws the tree correctly. Readers key on
+   * `String(id)` so both spellings resolve.
+   */
+  id: string | number;
   /** Display name, which Highcharts falls back to `id` for. */
   name?: string;
   /** The links whose `to` is this node — its parents, in an org chart. */

--- a/test/adapters/highcharts/organization.test.ts
+++ b/test/adapters/highcharts/organization.test.ts
@@ -1,0 +1,214 @@
+/**
+ * A Highcharts organization chart emitted no layer at all (#1138, #1153).
+ *
+ * `buildSubplot` sorts series into buckets by type and `organization` was in
+ * none of them, so it reached `convertSeries` as an unsupported type and was
+ * declined. On a chart that is only the org tree, that is silence.
+ *
+ * It was declined **deliberately** while the decline lasted, and #1153
+ * recorded why. An organization chart is a pure hierarchy: measured on the
+ * six-node chart below in Highcharts 11 plus `modules/sankey.js` and
+ * `modules/organization.js`, every node came back with no `value` field at
+ * all, and Highcharts' own internal `sum` was `1` for every node alike
+ * because the layout assigns one unit per link. Both available spellings of
+ * that were wrong:
+ *
+ *   omitting y everywhere      every node announced 0, over a
+ *                              freq { min: 0, max: 0 } with no pitch range
+ *   declaring the layout's 1   Bo announced as 100% of Ada, and Cy announced
+ *                              as 100% of Ada as well
+ *
+ * `TreemapTrace` now recognises a tree that declares no magnitude anywhere
+ * and reads it for what it has, so the payload here declares no `y` and means
+ * it.
+ *
+ * Measured end to end in Chromium against a real chart: six selectors, each
+ * matching exactly one `path.highcharts-node` — the drawn box.
+ */
+import type { HighchartsNode, HighchartsSeries } from '@adapters/highcharts/types';
+import type { TreemapPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { fakeChart, fakeSeries } from './helpers';
+
+interface NodeInput {
+  id: string;
+  name?: string;
+  title?: string;
+  parents?: string[];
+}
+
+/**
+ * An organization series, wired the way Highcharts resolves one.
+ *
+ * The declaration is `from`/`to` links; the nodes are what Highcharts builds
+ * from them, and it is the nodes that carry `linksTo`, the display name, the
+ * `title` and the drawn box. That resolution is what this reproduces.
+ *
+ * @param nodes - The nodes and who each reports to
+ * @returns The series, with `nodes` cross-linked
+ */
+function orgSeries(nodes: NodeInput[]): HighchartsSeries {
+  const links = nodes.flatMap(node =>
+    (node.parents ?? []).map(parent => ({ from: parent, to: node.id })));
+
+  const series = fakeSeries({ index: 0, type: 'organization', name: 'Org', data: links });
+  series.nodes = nodes.map(node => ({
+    id: node.id,
+    name: node.name ?? node.id,
+    ...(node.title !== undefined ? { options: { title: node.title } } : {}),
+    linksTo: series.data.filter(link => link.to === node.id),
+    linksFrom: series.data.filter(link => link.from === node.id),
+  })) as HighchartsNode[];
+
+  return series;
+}
+
+/** Ada over Bo and Cy, with three functions below them. */
+const ORG: NodeInput[] = [
+  { id: 'Ada', name: 'Ada Lovelace', title: 'CEO' },
+  { id: 'Bo', name: 'Bo Turing', title: 'CTO', parents: ['Ada'] },
+  { id: 'Cy', title: 'CFO', parents: ['Ada'] },
+  { id: 'Engineering', parents: ['Bo'] },
+  { id: 'Design', parents: ['Bo'] },
+  { id: 'Finance', parents: ['Cy'] },
+];
+
+/** The layer a chart of these nodes produces, or undefined when declined. */
+function layerOf(nodes: NodeInput[]) {
+  const chart = fakeChart({ renderToId: 'org-chart', series: [orgSeries(nodes)] });
+  return highchartsToMaidr(chart).subplots[0][0].layers[0];
+}
+
+describe('highcharts organization', () => {
+  it('reads an org chart as a tree rather than declining it', () => {
+    const layer = layerOf(ORG);
+
+    expect(layer.type).toBe(TraceType.TREEMAP);
+    expect(layer.title).toBe('Org');
+    expect(layer.data).toHaveLength(6);
+  });
+
+  it('declares no magnitude, because the chart draws none', () => {
+    // The whole reason this was blocked. Highcharts' own `sum` is 1 on every
+    // node, and declaring it announced two siblings as 100% of their parent
+    // each; omitting it announced 0 everywhere. The trace now reads a tree
+    // that declares nothing as one that has nothing.
+    const data = layerOf(ORG).data as TreemapPoint[];
+
+    expect(data.every(point => point.y === undefined)).toBe(true);
+  });
+
+  it('names no second axis either', () => {
+    // A label on an axis the chart does not draw is the same claim in a
+    // quieter place.
+    expect(layerOf(ORG).axes).toEqual({ x: { label: 'Node' } });
+  });
+
+  it('says what the box says: the name and the role under it', () => {
+    const data = layerOf(ORG).data as TreemapPoint[];
+
+    expect(data[0].x).toBe('Ada Lovelace, CEO');
+    expect(data[1].x).toBe('Bo Turing, CTO');
+  });
+
+  it('falls back to the id, which is what Highcharts names the node', () => {
+    // `Cy` declares no `name` and `Engineering` declares neither, so the
+    // label is whatever the box has to show.
+    const data = layerOf(ORG).data as TreemapPoint[];
+
+    expect(data[2].x).toBe('Cy, CFO');
+    expect(data[3].x).toBe('Engineering');
+  });
+
+  it('says a name and a title that happen to match only once', () => {
+    // Reachable, if unusual: someone whose name field carries their role.
+    // The box draws it twice; announcing it twice is noise rather than
+    // information.
+    const data = layerOf([{ id: 'x', name: 'CEO', title: 'CEO' }]).data as TreemapPoint[];
+
+    expect(data[0].x).toBe('CEO');
+  });
+
+  it('carries a node ancestry as the path the tree is addressed by', () => {
+    const data = layerOf(ORG).data as TreemapPoint[];
+
+    expect(data[0].path).toEqual([]);
+    expect(data[1].path).toEqual(['Ada Lovelace, CEO']);
+    expect(data[3].path).toEqual(['Ada Lovelace, CEO', 'Bo Turing, CTO']);
+  });
+
+  it('addresses each drawn box by its own index', () => {
+    // Measured in Chromium: each of these matched exactly one
+    // `path.highcharts-node`.
+    const selectors = layerOf(ORG).selectors as string[];
+
+    expect(selectors).toHaveLength(6);
+    expect(selectors[0]).toBe(
+      '#org-chart .highcharts-series-group .highcharts-series-0 [data-maidr-node-index="0"]',
+    );
+  });
+
+  it('declines a chart where someone reports to two managers', () => {
+    // A tree cannot say that, and reading it as one would drop a link the
+    // chart plainly draws. A silently missing edge is worse than the
+    // fallback, which at least says what it is.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const twoBosses: NodeInput[] = [
+      { id: 'Ada' },
+      { id: 'Cy' },
+      { id: 'Bo', parents: ['Ada', 'Cy'] },
+    ];
+
+    const chart = fakeChart({ renderToId: 'two', series: [orgSeries(twoBosses)] });
+
+    expect(highchartsToMaidr(chart).subplots[0][0].layers).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('more than one'));
+    warn.mockRestore();
+  });
+
+  it('cuts a path that loops rather than walking it forever', () => {
+    // The node itself seeds the seen set, so the walk stops at the first
+    // step back onto it: Ada's path is Bo and nothing beyond.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const cyclic: NodeInput[] = [
+      { id: 'Ada', parents: ['Bo'] },
+      { id: 'Bo', parents: ['Ada'] },
+    ];
+
+    const data = layerOf(cyclic).data as TreemapPoint[];
+
+    expect(data).toHaveLength(2);
+    expect(data[0].path).toEqual(['Bo']);
+    expect(data[1].path).toEqual(['Ada']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('cycle'));
+    warn.mockRestore();
+  });
+
+  it('stamps each drawn box with the index its selector addresses', () => {
+    // The selectors are useless without the stamp, and an organization
+    // series' `data` is its links -- so the walk has to run over the nodes
+    // rather than over the points, which is what this pins.
+    const series = orgSeries(ORG);
+    const elements = (series.nodes ?? []).map(() => ({
+      setAttribute: jest.fn(),
+    }));
+    (series.nodes ?? []).forEach((node, i) => {
+      node.graphic = { element: elements[i] as unknown as SVGElement };
+    });
+
+    highchartsToMaidr(fakeChart({ renderToId: 'stamped', series: [series] }));
+
+    expect(elements[0].setAttribute).toHaveBeenCalledWith('data-maidr-node-index', '0');
+    expect(elements[5].setAttribute).toHaveBeenCalledWith('data-maidr-node-index', '5');
+  });
+
+  it('declines a series that resolved no nodes at all', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const chart = fakeChart({ renderToId: 'empty', series: [orgSeries([])] });
+
+    expect(highchartsToMaidr(chart).subplots[0][0].layers).toHaveLength(0);
+    warn.mockRestore();
+  });
+});

--- a/test/adapters/highcharts/organization.test.ts
+++ b/test/adapters/highcharts/organization.test.ts
@@ -150,6 +150,33 @@ describe('highcharts organization', () => {
     );
   });
 
+  it('reads a chart whose nodes are declared with numeric ids', () => {
+    // Highcharts accepts `data: [[1, 2], [1, 3]]` and draws the tree from
+    // it -- measured in Chromium, correctly. Treating a numeric parent id as
+    // "no parent" flattened the whole hierarchy into a list of roots, with
+    // no warning, which is the one failure this converter's decline paths
+    // exist to avoid.
+    const numeric: NodeInput[] = [
+      { id: '1', name: 'Ada' },
+      { id: '2', name: 'Bo', parents: ['1'] },
+      { id: '3', name: 'Eng', parents: ['2'] },
+    ];
+    const series = orgSeries(numeric);
+    // Re-declared as the numbers Highcharts would have handed over.
+    (series.nodes ?? []).forEach((node) => {
+      node.id = Number(node.id);
+      (node.linksTo ?? []).forEach((link) => {
+        link.from = Number(link.from);
+      });
+    });
+
+    const chart = fakeChart({ renderToId: 'numeric', series: [series] });
+    const data = highchartsToMaidr(chart).subplots[0][0].layers[0].data as TreemapPoint[];
+
+    expect(data[1].path).toEqual(['Ada']);
+    expect(data[2].path).toEqual(['Ada', 'Bo']);
+  });
+
   it('declines a chart where someone reports to two managers', () => {
     // A tree cannot say that, and reading it as one would drop a link the
     // chart plainly draws. A silently missing edge is worse than the


### PR DESCRIPTION
Closes the `organization` case of #1138, which #1153 unblocked.

`buildSubplot` sorts series into buckets by type and `organization` was in none of them, so it reached `convertSeries` as an unsupported type and was declined. On a chart that is only the org tree, that is silence.

## Why it was declined, and what changed

The decline was deliberate. An organization chart is a **pure hierarchy** — measured on a six-node chart in Highcharts 11 plus `modules/sankey.js` and `modules/organization.js`:

| what was checked | what came back |
| --- | --- |
| `node.value` | absent on every node |
| Highcharts' internal `node.sum` | `1` on every node alike — one unit per link, for layout |

There is no magnitude anywhere in the declaration, and both available spellings of that were wrong:

- **omitting `y`** announced `0` on every node, over a `freq { min: 0, max: 0 }` that leaves no pitch range;
- **declaring the layout's `1`** was worse — Bo announced as 100% of Ada, and Cy announced as 100% of Ada as well.

#1156 taught `TreemapTrace` to recognise a tree that declares no magnitude anywhere. This is the adapter half: the payload declares no `y`, names no second axis, and the reader gets what the chart actually has — moving up to a manager, down to a report, across to a peer, the ancestry, and how many people report to whoever the cursor is on.

## Measured

The reading, end to end in Chromium against a real chart:

```
type    treemap
axes    { x: { label: 'Node' } }          ← no y

x                    path
Ada Lovelace, CEO    []
Bo Turing, CTO       ['Ada Lovelace, CEO']
Cy, CFO              ['Ada Lovelace, CEO']
Engineering          ['Ada Lovelace, CEO', 'Bo Turing, CTO']
Design               ['Ada Lovelace, CEO', 'Bo Turing, CTO']
Finance              ['Ada Lovelace, CEO', 'Cy, CFO']
```

and each of the six selectors matched **exactly one `path.highcharts-node`** — the drawn box.

## Reading decisions

**The structure comes from `series.nodes`, not from the links.** An organization series is declared as `from`/`to` pairs; Highcharts resolves them into node objects, and that is the only place `linksTo`, the display `name`, the `title` drawn under it, and the rendered box can all be reached.

**A node's label joins its name and its title,** because that is what the box says, and either alone loses half of what a sighted reader gets. A name that matches the title is not repeated, and a node declaring neither falls back to the id, which is what Highcharts names it.

**A node with more than one parent declines the whole series.** `TreemapPoint.path` is one ancestry, so a tree cannot say that someone reports to two managers, and reading it as one would drop a link the chart plainly draws. A silently missing edge is worse than the fallback, which at least says what it is — the same line `qqline` is held to in xability/r-maidr#251.

**A cycle is cut with a warning**, as it already is for a treemap: nothing stops an organization link pointing back up.

## Verification

- 13 tests in `test/adapters/highcharts/organization.test.ts` — the reading, the absent `y`, the absent second axis, the label rules, the paths, the selectors, the stamping, and the three declines (multi-parent, cycle, no nodes).
- Mutation sweep over the dispatch case, the multi-parent guard, the parent walk, the label join, the dedupe, the cycle seed, the axes, the stamping, the empty guard, and a `y: 1` reintroduction: **10 of 10 killed.** One would-be survivor was resolved by adding the case it guarded (a name equal to a title) rather than by deleting the guard.
- `npx eslint src test` clean · `npx tsc --noEmit` clean · `npm run build` succeeds · `npm run docs` succeeds · `npm test`: **401 suites / 5543 tests, plus the ESM project's 10 / 137**, all passing.

`docs/highcharts.md` moves `organization` out of "Series types that are deliberately not read" and into the supported table, and the note there is rewritten from "why it is blocked" to what the reading does and what it declines.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_