### PR TITLE
feat(amcharts): name a Tree and a Pack after the painting on the page

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -84,7 +84,7 @@ Series are classified by their amCharts class name and field configuration:
 - `am5percent.FunnelSeries` (and `PyramidSeries`, `PictorialStackedSeries`) → **funnel**
 - `ColumnSeries` with `openValueYField` on a category X axis → **waterfall** when the bars chain (each opens where the previous one closed), **dumbbell** when they do not
 - `ColumnSeries` with `openValueXField` on a category Y axis → **gantt**
-- `am5hierarchy.Treemap` → **treemap**; `am5hierarchy.Partition` → **icicle**; `am5hierarchy.Sunburst` → **sunburst**
+- `am5hierarchy.Treemap` → **treemap**; `am5hierarchy.Partition` → **icicle**; `am5hierarchy.Sunburst` → **sunburst**; `am5hierarchy.Tree` and `LinkedHierarchy` → **tree**; `am5hierarchy.Pack` → **pack**. One tree, five paintings, five names — `am5hierarchy.Venn` is declined, having no axis and no per-node magnitude to walk
 - two `ColumnSeries` on one category axis, one side's values all negative and the other's all positive → **diverging bar** (a population pyramid); any other unstacked group stays **dodged**
 - `LineSeries` with its stroke switched off and bullets pushed on, on a category axis → **dot** (a Cleveland dot plot)
 - `ColumnSeries` whose columns are narrowed to a hairline, with bullets → **lollipop**
@@ -125,6 +125,8 @@ A sankey, alluvial, chord or network layer is outlined one **ribbon** at a time 
 | Treemap | `am5hierarchy.Treemap` | series class (requires `hierarchy.js`) |
 | Icicle | `am5hierarchy.Partition` | series class (requires `hierarchy.js`) |
 | Sunburst | `am5hierarchy.Sunburst` | series class (requires `hierarchy.js`) |
+| Tree (node-link) | `am5hierarchy.Tree`, `LinkedHierarchy` | series class (requires `hierarchy.js`) |
+| Circle Packing | `am5hierarchy.Pack` | series class (requires `hierarchy.js`) |
 | Diverging Bar / Population Pyramid | two `ColumnSeries` | shared categories, one series entirely negative and the other entirely positive |
 | Dot Plot (Cleveland) | `LineSeries` | category axis + `strokes.template` hidden + bullets |
 | Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
@@ -467,7 +469,7 @@ The lanes come from the **category axis**, not from the bars, so a lane with not
 
 A `DateAxis` stores positions as epoch milliseconds, which no reader can hear a length in, so the adapter rescales them to the axis' own `baseInterval` time unit, measured from the earliest interval: a schedule reads as "day 0 to day 30, length 30 days". The absolute dates are dropped by that, and everything a schedule is drawn to answer — what overlaps what, what hands over to what, where the slack is — survives it. A plain `ValueAxis` is passed through untouched and named with no unit.
 
-### Treemap / Icicle / Sunburst
+### Treemap / Icicle / Sunburst / Tree / Pack
 
 An `am5hierarchy` layout is **not** a chart: it is a series pushed straight into a container, with no series list and no axes, so the adapter recognises the series itself and treats it as one panel. A treemap, an icicle (amCharts calls it a `Partition`) and a sunburst draw the same tree with different marks and are read identically — as a tree, not a grid: Left and Right move between siblings, Down steps into a node's children, Up returns to its parent. A runnable page covering all three is at [`examples/amcharts-treemap.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-treemap.html).
 
@@ -486,7 +488,7 @@ series.data.setAll([{
 
 The single root object amCharts requires is dropped: it is a container for the chart rather than a finding, and keeping it would add a level that always holds one node worth 100% of the total. A branch is emitted without a value unless it declares one of its own, so its total is derived from what is under it and cannot disagree with its own children.
 
-A `Sunburst` extends `Partition` but carries its own class name, so it is recognised in its own right rather than inherited — which is also what keeps it from being announced as an icicle. The one thing the mark does change is the highlight: a treemap block and an icicle bar are rectangles, and a sunburst node is a `Slice`, which reports a degenerate box at its own centre and is therefore measured from its radius and sweep instead (the same reading a pie wedge gets).
+A `Sunburst` extends `Partition` but carries its own class name, so it is recognised in its own right rather than inherited — which is also what keeps it from being announced as an icicle. `Tree`, `LinkedHierarchy` and `Pack` are recognised the same way and read through the same converter, and each is named after the painting on the page rather than after the treemap they share their data shape with: a node-link diagram and a circle-packing diagram are both **tree**-shaped to navigate, but neither is a treemap to look at. `Tree` and `LinkedHierarchy` share the name **tree** because `Tree` is drawn by extending `LinkedHierarchy`, so the two are one mark rather than two. The one thing the mark does change is the highlight: a treemap block and an icicle bar are rectangles, and a sunburst node is a `Slice`, which reports a degenerate box at its own centre and is therefore measured from its radius and sweep instead (the same reading a pie wedge gets).
 
 ### Gauge
 

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -405,7 +405,9 @@ function buildChartLayers(
       }
       case 'treemap':
       case 'icicle':
-      case 'sunburst': {
+      case 'sunburst':
+      case 'tree':
+      case 'pack': {
         const data = extractHierarchyPoints(series);
         if (data.length === 0)
           break;
@@ -984,6 +986,8 @@ const HIERARCHY_TRACE_TYPES = {
   treemap: TraceType.TREEMAP,
   icicle: TraceType.ICICLE,
   sunburst: TraceType.SUNBURST,
+  tree: TraceType.TREE,
+  pack: TraceType.PACK,
 } as const;
 
 /**
@@ -1002,7 +1006,7 @@ const HIERARCHY_TRACE_TYPES = {
  */
 function buildHierarchyLayer(
   series: AmXYSeries,
-  kind: 'treemap' | 'icicle' | 'sunburst',
+  kind: keyof typeof HIERARCHY_TRACE_TYPES,
   data: TreemapPoint[],
   options?: AmChartsBinderOptions,
 ): MaidrLayer {

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -2008,27 +2008,27 @@ const STANDALONE_KINDS: Record<string, SeriesKind> = {
   Sunburst: 'sunburst',
   // Three more paintings of the one hierarchy `extractHierarchyPoints`
   // already reads: `Tree` draws it as nodes and links, `Pack` as nested
-  // circles, `LinkedHierarchy` as its base class. They carry the same nested
-  // `children` shape the three above do, and reach the same converter -- the
-  // only thing that kept them out was this map, which gates discovery through
-  // `STANDALONE_SERIES_CLASSES`, so the series was never wrapped as a panel
-  // and the binder reported no supported chart (#1140).
+  // circles, `LinkedHierarchy` as the base class the first draws through.
+  // They carry the same nested `children` shape the three above do, and reach
+  // the same converter -- the only thing that kept them out was this map,
+  // which gates discovery through `STANDALONE_SERIES_CLASSES`, so the series
+  // was never wrapped as a panel and the binder reported no supported chart
+  // (#1140).
   //
-  // Read under `treemap` rather than a name of their own. The grammar already
-  // treats that as the general one -- `ICICLE` and `SUNBURST` are both
-  // documented as "the same hierarchy as a TREEMAP, drawn as ..." -- and the
-  // navigation is identical, since all three share one branch of the
-  // dispatch. The cost is that a circle-packing or node-link diagram
-  // announces itself as a treemap, which is a fourth and fifth painting
-  // reported under the first's name. Trace types of their own would say it
-  // exactly and are a grammar change; that option is open on #1140.
+  // Each under its own name, which is the half of #1140 the grammar had to
+  // grow for. They were read as `treemap` first, because the navigation is
+  // identical and the grammar treats that as the general name -- but the
+  // trace type is also what the reader is *told* the chart is, and a
+  // node-link diagram or a circle-packing diagram announced as a treemap is
+  // a chart type nobody drew. `TraceType.TREE` and `TraceType.PACK` say it
+  // exactly and still share the one branch of the dispatch.
   //
   // `Venn` is deliberately absent. An overlap diagram has no axis and no
   // per-category magnitude to walk, so declining it is the reading, not a
   // gap.
-  Tree: 'treemap',
-  Pack: 'treemap',
-  LinkedHierarchy: 'treemap',
+  Tree: 'tree',
+  Pack: 'pack',
+  LinkedHierarchy: 'tree',
   WordCloud: 'wordcloud',
   Sankey: 'sankey',
   ArcDiagram: 'sankey',
@@ -2182,6 +2182,8 @@ export type SeriesKind
     | 'treemap'
     | 'icicle'
     | 'sunburst'
+    | 'tree'
+    | 'pack'
     | 'wordcloud'
     | 'sankey'
     | 'chord'

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -98,6 +98,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.ICICLE]: 'Icicle Chart',
   [TraceType.SUNBURST]: 'Sunburst Chart',
   [TraceType.TREE]: 'Tree Diagram',
+  [TraceType.PACK]: 'Circle Packing',
   [TraceType.TREEMAP]: 'Treemap',
   [TraceType.VIOLIN_BOX]: 'Violin Box Plot',
   [TraceType.VIOLIN_KDE]: 'Violin Plot',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -166,6 +166,7 @@ export abstract class TraceFactory {
       case TraceType.ICICLE:
       case TraceType.SUNBURST:
       case TraceType.TREE:
+      case TraceType.PACK:
       case TraceType.TREEMAP:
         // One class for all three: they are the same tree drawn three ways,
         // and the layout changes nothing a reader navigates. The sunburst's

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1248,6 +1248,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
       [TraceType.ICICLE, asGeneric(new BarBrailleEncoder())],
       [TraceType.SUNBURST, asGeneric(new BarBrailleEncoder())],
       [TraceType.TREE, asGeneric(new BarBrailleEncoder())],
+      [TraceType.PACK, asGeneric(new BarBrailleEncoder())],
       [TraceType.TREEMAP, asGeneric(new BarBrailleEncoder())],
       // A density curve is a line, which is what the violin already reuses
       // this for. What differs is the scaling, and that is decided in the

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1784,6 +1784,15 @@ export enum TraceType {
    */
   TREE = 'tree',
   /**
+   * The same hierarchy as a {@link TraceType.TREEMAP}, drawn as circles
+   * nested inside circles rather than as nested rectangles. Sized by value
+   * like a treemap and navigated identically, and named apart for the reason
+   * {@link TraceType.TREE} is: the reader is told which chart is on the page,
+   * and a circle-packing diagram announced as a treemap is a chart type
+   * nobody drew.
+   */
+  PACK = 'pack',
+  /**
    * The same hierarchy as a {@link TraceType.TREEMAP}, drawn as rings around
    * a centre rather than as nested rectangles. The layout differs and the
    * tree does not, so it is read by the same trace -- with one thing of its

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -147,6 +147,7 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   [TraceType.ICICLE]: false,
   [TraceType.SUNBURST]: false,
   [TraceType.TREE]: false,
+  [TraceType.PACK]: false,
   [TraceType.TREEMAP]: false,
   [TraceType.VIOLIN_BOX]: true,
   [TraceType.VIOLIN_KDE]: true,

--- a/test/adapters/amcharts/hierarchyPaintings.test.ts
+++ b/test/adapters/amcharts/hierarchyPaintings.test.ts
@@ -25,6 +25,15 @@ import { fakeChart, fakeContainer, fakeRoot, fakeSeries } from './helpers';
  * Both throws are the binder's documented contract, so this was the adapter
  * declining rather than misreading -- the same shape as #1138's Highcharts
  * gap, reached through a discovery gate instead of a switch.
+ *
+ * The second half of #1140 is the name. Opening the gate first read all three
+ * as `treemap`, because the navigation is identical -- but the trace type is
+ * also what the reader is *told* is on the page, and a node-link diagram
+ * announced as a treemap is a chart type nobody drew. `Tree` and
+ * `LinkedHierarchy` are one mark (`Tree` draws by extending
+ * `LinkedHierarchy`) and take `TraceType.TREE`; `Pack` draws nested circles
+ * and takes `TraceType.PACK`. All five still share the one branch of the
+ * dispatch and the one converter, which is the part that was never in doubt.
  */
 
 const NODES = [
@@ -60,30 +69,57 @@ function layerTypes(root: unknown): string[] {
     .map(layer => layer.type);
 }
 
-const PAINTINGS = ['Tree', 'Pack', 'LinkedHierarchy'] as const;
+const PAINTINGS = [
+  ['Tree', TraceType.TREE],
+  ['Pack', TraceType.PACK],
+  ['LinkedHierarchy', TraceType.TREE],
+] as const;
 
 describe('amCharts hierarchy paintings', () => {
-  it.each(PAINTINGS)('reads a standalone %s as the hierarchy it is', (className) => {
+  it.each(PAINTINGS)('reads a standalone %s as the hierarchy it is', (className, type) => {
     // The am5hierarchy pattern: a series pushed straight into a container,
     // with no chart around it. This threw before the fix.
     const root = fakeRoot([fakeContainer([hierarchy(className)])]);
 
-    expect(layerTypes(root)).toEqual([TraceType.TREEMAP]);
+    expect(layerTypes(root)).toEqual([type]);
   });
 
-  it.each(PAINTINGS)('reads %s inside a chart too', (className) => {
+  it.each(PAINTINGS)('reads %s inside a chart too', (className, type) => {
     const root = fakeRoot([fakeChart({ series: [hierarchy(className)] })]);
 
-    expect(layerTypes(root)).toEqual([TraceType.TREEMAP]);
+    expect(layerTypes(root)).toEqual([type]);
   });
 
-  it('reads them the same way it reads a treemap', () => {
-    // The point of the change: these are one hierarchy, so they resolve to
-    // one reading rather than to five near-identical ones.
-    const drawn = PAINTINGS.map(c => classifySeriesKind({ className: c } as never));
+  it('names each after the painting on the page, not after the treemap', () => {
+    // The half of #1140 the grammar had to grow for. Reading all three as
+    // `treemap` navigated correctly and announced the wrong chart.
+    const drawn = PAINTINGS.map(([c]) => classifySeriesKind({ className: c } as never));
 
-    expect(drawn).toEqual(['treemap', 'treemap', 'treemap']);
+    expect(drawn).toEqual(['tree', 'pack', 'tree']);
     expect(classifySeriesKind({ className: 'Treemap' } as never)).toBe('treemap');
+  });
+
+  it('gives a Tree and a Pack different names', () => {
+    // Nailed down separately, because a mapping that collapsed the two back
+    // onto one name would still pass every per-class case above.
+    const tree = fakeRoot([fakeContainer([hierarchy('Tree')])]);
+    const pack = fakeRoot([fakeContainer([hierarchy('Pack')])]);
+
+    expect(layerTypes(tree)).not.toEqual(layerTypes(pack));
+  });
+
+  it('reads all five through the one converter', () => {
+    // The names differ; the data does not. A Tree's points are the treemap's
+    // points, which is why one branch of the dispatch still serves all five.
+    const of = (className: string): unknown =>
+      fromAmCharts(fakeRoot([fakeContainer([hierarchy(className)])]) as never)
+        ?.subplots
+        ?.flat()
+        .flatMap(s => s?.layers ?? [])[0]
+        ?.data;
+
+    expect(of('Tree')).toEqual(of('Treemap'));
+    expect(of('Pack')).toEqual(of('Treemap'));
   });
 
   it('still declines a Venn', () => {

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -105,6 +105,7 @@ describe('resolveOrientation', () => {
     TraceType.ICICLE,
     TraceType.SUNBURST,
     TraceType.TREE,
+    TraceType.PACK,
     TraceType.TREEMAP,
     // A waterfall is navigated one column per step whichever way the bars
     // are drawn, so there is no main and cross axis to swap.


### PR DESCRIPTION
Closes the naming half of #1140.

## The gap

`Tree`, `Pack` and `LinkedHierarchy` already reached the hierarchy converter — the discovery gate was opened when the first half of #1140 landed — but all three were read as `treemap`, and the code said so in a comment:

> The cost is that a circle-packing or node-link diagram announces itself as a treemap, which is a fourth and fifth painting reported under the first's name. Trace types of their own would say it exactly and are a grammar change; that option is open on #1140.

The navigation was never wrong. The announcement was: the trace type is what the reader is *told* is on the page, and a node-link diagram announced as a treemap is a chart type nobody drew — the same defect #1158 fixed for the Highcharts organization chart, which is what put `TraceType.TREE` in the grammar in the first place.

## The change

| amCharts class | was | now |
|---|---|---|
| `Tree` | `treemap` | `tree` |
| `LinkedHierarchy` | `treemap` | `tree` |
| `Pack` | `treemap` | `pack` |

`Tree` and `LinkedHierarchy` share a name because `Tree` draws by extending `LinkedHierarchy` — one mark, not two. `Pack` gets a new `TraceType.PACK`, labelled `Circle Packing`, registered in the factory, the orientation map and the braille encoder map beside the other hierarchy variants, exactly as `TREE` was in #1158.

All five paintings still share one branch of the dispatch and one converter. That is asserted rather than assumed: a test compares a `Tree`'s and a `Pack`'s emitted points against a `Treemap`'s and requires them equal.

`Venn` stays declined — an overlap diagram has no axis and no per-node magnitude to walk, which is the reading rather than a gap.

## Tests

- `test/adapters/amcharts/hierarchyPaintings.test.ts` — each class asserted to its own type by both routes a series can arrive by; a separate case requires a `Tree` and a `Pack` to differ, which a mapping that collapsed them back onto one name would otherwise pass; and the shared-converter case above.
- `test/util/orientation.test.ts` — `PACK` added to the exhaustive list, which failed until it was.

## Verification

`npx eslint src test` clean · `npm run type-check` clean · `npm run build` succeeds · `npm run docs` succeeds · `npm test` **403 suites / 5574 tests**, ESM project **10 / 137**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_