### PR TITLE
feat(highcharts): read a treegraph and a packed bubble as the hierarchies they are

### DIFF
--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -120,6 +120,8 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 | Treemap | `treemap` (requires `modules/treemap.js`) | [highcharts-treemap.html](examples/highcharts-treemap.html) |
 | Sunburst | `sunburst` (requires `modules/sunburst.js`, which ships treemap) | [highcharts-sunburst.html](examples/highcharts-sunburst.html) |
 | Tree | `organization` (requires `modules/sankey.js` and `modules/organization.js`), read as a hierarchy with no magnitude | — |
+| Tree | `treegraph` (requires `modules/treegraph.js`, which ships treemap) | — |
+| Pack | `packedbubble` (requires `highcharts-more.js`) | — |
 | Gauge | `gauge`, `solidgauge` (require `highcharts-more.js`; solid gauge also `modules/solid-gauge.js`), `bullet` (requires `modules/bullet.js`) | [highcharts-gauge.html](examples/highcharts-gauge.html) |
 | Waterfall | `waterfall` (requires `highcharts-more.js`) | [highcharts-waterfall.html](examples/highcharts-waterfall.html) |
 | Error Bar | `errorbar` (requires `highcharts-more.js`), reading its estimates from the series it is `linkedTo`; `arearange`, `areasplinerange`, `columnrange` (require `highcharts-more.js`), each read as the band of intervals it draws | [highcharts-errorbar.html](examples/highcharts-errorbar.html) |
@@ -171,6 +173,10 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 
 > **Hierarchy note:** Highcharts declares a treemap or sunburst with `id`/`parent` pointers, and MAIDR declares one as a path — a node's ancestors, root first, itself excluded — so the adapter walks each node's parent chain to build it. A parent id that was never declared ends the path there, matching how Highcharts attaches such a node to the root, and a cyclic chain is broken with a warning rather than followed. Interior nodes keep whatever value they declared and are otherwise left valueless, since MAIDR derives an interior total from the children the paths give it. Both series file their marks into one DOM group per depth ordered by z-index, so document order says nothing about declaration order; the adapter stamps `data-maidr-node-index` onto each rendered node and the selectors address the stamp. A node Highcharts did not draw leaves MAIDR with fewer elements than nodes, and highlighting is withdrawn for that layer rather than paired with the wrong rectangles.
 
+> **Treegraph note:** a treegraph declares exactly what a treemap does — `id`, `parent`, `name` — and draws it as boxes joined by links rather than nested rectangles, so it shares the parent-chain walk above and is read as a `tree` for the same reason `organization` is: the trace type is what the reader is told is on the page. What it does **not** share is where the magnitude comes from. A treegraph's layout sizes nothing by value and Highcharts fills the field in regardless — measured on a five-node chart in Highcharts 13, every node came back with `value === 0` and `options.value === undefined` — so the adapter reads the author's declaration instead. With nothing declared, no node carries a `y` and the layer names no value axis; with values declared, they are read as written, and an undeclared node beside declared siblings is left valueless so the trace derives its total from the children. A treemap keeps reading the computed field, where it is a real total rather than an artefact: an interior node with no declared value comes back carrying the sum of its children, and a treemap with no values anywhere renders no nodes at all.
+>
+> **Packed bubble note:** a `packedbubble` series is a group of circles sized by value, with no `parent` on anything — the grouping is which series a bubble is in, and each series already becomes its own layer named after it. So the paths are empty and each layer is the flat pack the chart draws. It is read as `pack`, the name #1159 added for circle packing, rather than as a treemap: the navigation is the same and the picture is not. Note that Highcharts classes its legend swatches `highcharts-point` too; the selectors are scoped inside `.highcharts-series-group`, which the legend is not part of.
+>
 > **Organization note:** an organization chart is a pure hierarchy and carries no magnitude at all. Measured on a six-node chart in Highcharts 11, every node came back with **no `value` field** and with Highcharts' own internal `sum` at `1` for every node alike, because the layout assigns one unit per link. It is read as a `tree` layer -- the same hierarchy a treemap is, under the name of the painting that is actually on the page -- declaring no `y`, which the trace recognises as a tree with nothing to announce on a second axis: no value clause, no shares, no total, and the empty tone rather than a flat one. What a reader gets is the structure — moving up to a manager, down to a report, across to a peer, the ancestry, and how many people report to whoever the cursor is on.
 >
 > The structure comes from `series.nodes` rather than from the links, because that is where Highcharts resolves `linksTo`, the display `name`, the `title` drawn under it, and the box itself. A node's label joins its name and its title, which is what the box says; a name Highcharts fell back to the id for is not repeated. A cyclic chain is cut with a warning, as it is for a treemap.
@@ -205,14 +211,15 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 
 ### Series types that are deliberately not read
 
-Every other Highcharts series type either has a reading above or is a spelling of one. These four are drawn, understood, and declined — a chart containing one gets no layer for it. They are listed so that a later sweep finds the reasons rather than re-deriving them.
+Every other Highcharts series type either has a reading above or is a spelling of one. These three are drawn, understood, and declined — a chart containing one gets no layer for it. They are listed so that a later sweep finds the reasons rather than re-deriving them.
 
 | Series | Why it is declined |
 | --- | --- |
 | `venn` | Its magnitudes are overlap areas and its positions are a layout. There is no axis to announce a coordinate against. |
 | `polygon` | An arbitrary closed shape with no statistical reading — already noted in `test/adapters/highcharts/arearange.test.ts`. |
 | `vector`, `windbarb`, `flags` | Direction and annotation rather than a measured series. A vector's payload is an angle and a length at a position; a flag is a note pinned to a date. |
-| `packedbubble` | It has a magnitude, but the positions are a packing rather than data — announcing a bubble's x and y would report where the layout put it. |
+
+`packedbubble` was a fourth entry here, declined because "it has a magnitude, but the positions are a packing rather than data — announcing a bubble's x and y would report where the layout put it." That reason was right about the chart and is now answered by the grammar: `pack` (#1159) is a trace whose points carry a magnitude and **no** coordinate at all, so nothing announces where the layout put a bubble. It is read as one, per the packed bubble note above.
 
 ## Declaring What a Series Means
 

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -1671,6 +1671,16 @@ function convertSeries(
       return convertTreeSeries(series, containerId, TraceType.TREEMAP);
     case 'sunburst':
       return convertTreeSeries(series, containerId, TraceType.SUNBURST);
+    // A treegraph is the same `id`/`parent` hierarchy drawn as nodes and
+    // links rather than nested rectangles, and a packed bubble is the same
+    // points drawn as circles packed together. Both are hierarchies MAIDR
+    // now has names for, and the naming argument is #1140's: the trace type
+    // is what the reader is *told* is on the page, so a node-link diagram is
+    // a `tree` and a cluster of circles is a `pack`, not a treemap.
+    case 'treegraph':
+      return convertTreeGraphSeries(series, containerId);
+    case 'packedbubble':
+      return convertTreeSeries(series, containerId, TraceType.PACK);
     // An organization chart is a hierarchy with no magnitude on it at all,
     // which the treemap trace could not express until #1153.
     case 'organization':
@@ -3049,7 +3059,70 @@ function treeNodeLabel(point: HighchartsPoint): string | number {
 }
 
 /**
- * Converts a `treemap` or `sunburst` series into a hierarchy layer.
+ * Converts a `treegraph` series into a node-link hierarchy layer.
+ *
+ * A treegraph declares exactly what a treemap does -- `id`, `parent`, `name`
+ * -- and draws it as boxes joined by links instead of nested rectangles. The
+ * walk up the `parent` chain is therefore the treemap's, and this delegates to
+ * it for everything except the one thing that differs: whether the chart has a
+ * magnitude at all.
+ *
+ * `point.value` cannot answer that here. A treegraph's layout does not size
+ * anything by value, and Highcharts fills the field in regardless: measured on
+ * a five-node chart in Highcharts 13 with `modules/treegraph.js`, every node
+ * came back with `value === 0` and `options.value === undefined`. Reading
+ * `point.value` would emit `y: 0` on every node and announce a magnitude of
+ * zero for a chart that has none -- which is #1153's defect, and the reason
+ * `convertOrganizationSeries` exists rather than reusing the treemap path.
+ *
+ * `point.options.value` is what the author wrote, so it separates the two:
+ *
+ *     treegraph, no values      options.value undefined   value 0
+ *     treegraph, values 1..5    options.value 1..5        value 1..5
+ *
+ * A treemap keeps reading `point.value` and is untouched by this. There the
+ * computed field is not an artefact: an interior node with no declared value
+ * comes back carrying the sum of its children (measured, 12 and 8 on a
+ * leaves-only tree), which is a real total the rectangles are sized by. And a
+ * treemap with no values anywhere draws nothing at all -- measured, zero
+ * rendered nodes -- so the case this guards against cannot arise there.
+ *
+ * @param series - The treegraph series to read
+ * @param containerId - The chart container's DOM id, for the selectors
+ * @returns The layer
+ */
+function convertTreeGraphSeries(
+  series: HighchartsSeries,
+  containerId: string,
+): MaidrLayer {
+  const layer = convertTreeSeries(series, containerId, TraceType.TREE);
+  const declared = series.data.map(point => point.options?.value);
+  const anyDeclared = declared.some(value => typeof value === 'number');
+
+  const data = (layer.data as TreemapPoint[]).map((node, index) => {
+    const value = declared[index];
+    // An undeclared node carries no `y` at all rather than Highcharts' zero.
+    // Beside declared siblings that is the treemap's own behaviour --
+    // `TreemapTrace` derives the total from the children the paths give it --
+    // and with nothing declared anywhere it leaves the whole layer valueless,
+    // which is what the chart is.
+    const { y: _computed, ...rest } = node;
+    return typeof value === 'number' ? { ...rest, y: value } : rest;
+  });
+
+  return {
+    ...layer,
+    // No magnitude anywhere means no value axis either: naming one would
+    // claim an axis the chart does not draw, the same answer an organization
+    // chart already gets.
+    axes: anyDeclared ? layer.axes : { x: { label: TREE_NODE_AXIS } },
+    data,
+  };
+}
+
+/**
+ * Converts a `treemap`, `sunburst` or `packedbubble` series into a hierarchy
+ * layer.
  *
  * Highcharts declares the tree with `id` / `parent` pointers on each node,
  * while MAIDR declares it as a path — a node's ancestors, root first, itself
@@ -3062,11 +3135,18 @@ function treeNodeLabel(point: HighchartsPoint): string | number {
  * at all: `TreemapTrace` derives an undeclared interior total from the
  * children the paths give it, and keeps a declared one that disagrees, since a
  * parent may carry mass no child accounts for.
+ *
+ * A `packedbubble` series declares no `parent` on anything -- the grouping is
+ * which *series* a bubble is in, and the adapter already gives each series its
+ * own layer named after it. So every bubble walks back to an empty path and
+ * the layer is a flat pack of circles sized by value, which is what the chart
+ * draws. Nothing else about the walk changes, which is why it shares this
+ * converter rather than getting one of its own.
  */
 function convertTreeSeries(
   series: HighchartsSeries,
   containerId: string,
-  traceType: TraceType.TREEMAP | TraceType.SUNBURST,
+  traceType: TraceType.TREEMAP | TraceType.SUNBURST | TraceType.PACK | TraceType.TREE,
 ): MaidrLayer {
   const byId = new Map<string, HighchartsPoint>();
   for (const point of series.data) {

--- a/test/adapters/highcharts/hierarchyPaintings.test.ts
+++ b/test/adapters/highcharts/hierarchyPaintings.test.ts
@@ -1,0 +1,259 @@
+import type { HighchartsPoint, HighchartsSeries } from '@adapters/highcharts/types';
+import type { MaidrLayer, TreemapPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { TraceType } from '@type/grammar';
+import { fakeChart, fakeGraphic, fakeSeries } from './helpers';
+
+/**
+ * Highcharts draws a hierarchy five ways, and the adapter read three (#1140's
+ * shape, on the Highcharts side).
+ *
+ * `treemap`, `sunburst` and `organization` were already read. `treegraph`
+ * (nodes and links) and `packedbubble` (circles packed together) were not:
+ * both fell through the series-type switch to
+ *
+ *     [MAIDR Highcharts] Unsupported series type: "treegraph"; skipping.
+ *     [MAIDR Highcharts] Unsupported series type: "packedbubble"; skipping.
+ *
+ * and produced no layer at all. Measured in Highcharts 13 with
+ * `modules/treegraph.js` and `highcharts-more.js`, against `treemap` as the
+ * control:
+ *
+ *     treegraph      no layers            <- declined
+ *     packedbubble   no layers            <- declined
+ *     treemap        treemap  n=5         <- control
+ *     bubble         point    n=2         <- control
+ *
+ * Both now have a name in the grammar -- `TREE` from #1158 and `PACK` from
+ * #1159 -- and the naming argument is the one those made: the trace type is
+ * what the reader is *told* is on the page, so a node-link diagram is a tree
+ * and a cluster of circles is a pack, not a treemap.
+ *
+ * ## The one thing that is not shared
+ *
+ * A treegraph declares exactly what a treemap does, so the walk up the
+ * `parent` chain is the treemap's. What differs is the magnitude. A
+ * treegraph's layout sizes nothing by value and Highcharts fills the field in
+ * regardless:
+ *
+ *     treegraph, no values      point.value 0        point.options.value undefined
+ *     treegraph, values 1..5    point.value 1..5     point.options.value 1..5
+ *
+ * so reading `point.value` would announce a magnitude of zero for a chart that
+ * has none -- #1153's defect, and the reason `convertOrganizationSeries`
+ * exists. The declaration is read instead.
+ *
+ * A treemap is untouched by that and must stay so. There the computed field is
+ * a real total: an interior node with no declared value comes back carrying
+ * the sum of its children (measured, 12 and 8 on a leaves-only tree), and a
+ * treemap with no values anywhere renders **zero** nodes, so the case this
+ * guards against cannot arise.
+ */
+
+const NODES = [
+  { id: 'root', name: 'Company' },
+  { id: 'a', parent: 'root', name: 'Sales' },
+  { id: 'b', parent: 'root', name: 'Engineering' },
+  { id: 'b1', parent: 'b', name: 'Frontend' },
+  { id: 'b2', parent: 'b', name: 'Backend' },
+];
+
+/**
+ * A treegraph series shaped the way Highcharts hands one over.
+ *
+ * `value` is the layout's own field and `options.value` is what the author
+ * wrote, so the two are supplied separately -- a fixture that set only
+ * `options` would let a converter reading `value` pass by accident.
+ *
+ * @param declared - The value each node declares, `undefined` for none
+ * @returns The series
+ */
+function treegraph(declared: (number | undefined)[]): HighchartsSeries {
+  return fakeSeries({
+    index: 0,
+    type: 'treegraph',
+    name: 'Org',
+    data: NODES.map((node, i) => ({
+      ...node,
+      // Highcharts' computed field: zero on every node of a valueless chart.
+      value: declared[i] ?? 0,
+      options: declared[i] === undefined ? {} : { value: declared[i] },
+    })),
+  });
+}
+
+/**
+ * One `packedbubble` series: a group of bubbles with no parents among them.
+ *
+ * @param index - The series index
+ * @param name - The group's name, which the chart shows in its legend
+ * @param bubbles - One name and value per bubble
+ * @returns The series
+ */
+function packedBubble(
+  index: number,
+  name: string,
+  bubbles: { name: string; value: number }[],
+): HighchartsSeries {
+  return fakeSeries({
+    index,
+    type: 'packedbubble',
+    name,
+    data: bubbles.map(bubble => ({ ...bubble, options: { value: bubble.value } })),
+  });
+}
+
+/**
+ * The layers a chart produces, or `[]` when every series was declined.
+ *
+ * @param series - The series to read
+ * @param renderToId - The container id the selectors are built against
+ * @returns The layers
+ */
+function layersOf(series: HighchartsSeries[], renderToId: string): MaidrLayer[] {
+  const chart = fakeChart({ type: series[0].type, renderToId, series });
+  return highchartsToMaidr(chart).subplots.flat().flatMap(s => s.layers);
+}
+
+describe('highcharts treegraph series', () => {
+  it('reads the hierarchy a treemap would, under the name of what is drawn', () => {
+    const [layer] = layersOf([treegraph([1, 2, 3, 4, 5])], 'treegraph-valued');
+
+    // TREE, not TREEMAP: the navigation is the same and the picture is not.
+    expect(layer.type).toBe(TraceType.TREE);
+    expect(layer.title).toBe('Org');
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Company', y: 1, path: [] },
+      { x: 'Sales', y: 2, path: ['Company'] },
+      { x: 'Engineering', y: 3, path: ['Company'] },
+      { x: 'Frontend', y: 4, path: ['Company', 'Engineering'] },
+      { x: 'Backend', y: 5, path: ['Company', 'Engineering'] },
+    ]);
+    expect(layer.axes?.y?.label).toBe('Value');
+  });
+
+  it('announces no magnitude for a chart that declares none', () => {
+    // The defect the declaration guards against. Highcharts hands over
+    // `value: 0` on every node here, and emitting it would tell the reader
+    // every box in the org chart measures zero.
+    const [layer] = layersOf([treegraph([])], 'treegraph-valueless');
+
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Company', path: [] },
+      { x: 'Sales', path: ['Company'] },
+      { x: 'Engineering', path: ['Company'] },
+      { x: 'Frontend', path: ['Company', 'Engineering'] },
+      { x: 'Backend', path: ['Company', 'Engineering'] },
+    ]);
+    // And no axis for the magnitude that is not there, which is the answer an
+    // organization chart already gets (#1153).
+    expect(layer.axes?.y).toBeUndefined();
+    expect(layer.axes?.x?.label).toBe('Node');
+  });
+
+  it('keeps a declared value beside an undeclared sibling', () => {
+    // Leaves valued, interiors not -- the ordinary way a weighted tree is
+    // written. The interiors carry no `y`, so `TreemapTrace` derives their
+    // totals from the children the paths give it, exactly as for a treemap.
+    const [layer] = layersOf(
+      [treegraph([undefined, 4, undefined, 4, 4])],
+      'treegraph-partial',
+    );
+
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Company', path: [] },
+      { x: 'Sales', y: 4, path: ['Company'] },
+      { x: 'Engineering', path: ['Company'] },
+      { x: 'Frontend', y: 4, path: ['Company', 'Engineering'] },
+      { x: 'Backend', y: 4, path: ['Company', 'Engineering'] },
+    ]);
+    // One node declares a magnitude, so the axis naming it is drawn.
+    expect(layer.axes?.y?.label).toBe('Value');
+  });
+
+  it('addresses each node by the same stamp a treemap uses', () => {
+    const series = fakeSeries({
+      index: 0,
+      type: 'treegraph',
+      data: NODES.map(node => ({ ...node, value: 0, options: {}, graphic: fakeGraphic() })),
+    });
+    const [layer] = layersOf([series], 'treegraph-stamped');
+
+    // Load-bearing here in a way it is not for a treemap: Highcharts classes
+    // a treegraph's link paths `highcharts-point` too, so a selector list
+    // indexed by document position would address the links.
+    expect(series.data.map((p: HighchartsPoint) =>
+      p.graphic?.element.getAttribute('data-maidr-node-index'))).toEqual(['0', '1', '2', '3', '4']);
+    expect((layer.selectors as string[])[0]).toBe(
+      '#treegraph-stamped .highcharts-series-group .highcharts-series-0 [data-maidr-node-index="0"]',
+    );
+  });
+});
+
+describe('highcharts packedbubble series', () => {
+  it('reads each group as its own pack of circles', () => {
+    const layers = layersOf([
+      packedBubble(0, 'Europe', [{ name: 'Germany', value: 12 }, { name: 'France', value: 8 }]),
+      packedBubble(1, 'Asia', [{ name: 'Japan', value: 15 }, { name: 'India', value: 20 }]),
+    ], 'packed-groups');
+
+    expect(layers.map(l => l.type)).toEqual([TraceType.PACK, TraceType.PACK]);
+    // The grouping is which *series* a bubble is in -- nothing declares a
+    // `parent` -- and the adapter already names each layer after its series,
+    // so the paths are empty and each layer is the flat pack it draws.
+    expect(layers.map(l => l.title)).toEqual(['Europe', 'Asia']);
+    expect(layers[0].data as TreemapPoint[]).toEqual([
+      { x: 'Germany', y: 12, path: [] },
+      { x: 'France', y: 8, path: [] },
+    ]);
+    expect(layers[1].data as TreemapPoint[]).toEqual([
+      { x: 'Japan', y: 15, path: [] },
+      { x: 'India', y: 20, path: [] },
+    ]);
+  });
+
+  it('gives a pack a different name from a treemap', () => {
+    // Nailed down separately: a mapping that collapsed the two back onto one
+    // name would still pass every assertion above.
+    const [packed] = layersOf(
+      [packedBubble(0, 'Europe', [{ name: 'Germany', value: 12 }])],
+      'packed-named',
+    );
+    const [treemapped] = layersOf(
+      [fakeSeries({ index: 0, type: 'treemap', name: 'Europe', data: [{ name: 'Germany', value: 12 }] })],
+      'treemap-named',
+    );
+
+    expect(packed.type).not.toBe(treemapped.type);
+    // The data does not differ; only the name does. That is why one converter
+    // still serves both.
+    expect(packed.data).toEqual(treemapped.data);
+  });
+});
+
+describe('the treemap reading these two were built on', () => {
+  it('still takes its interior totals from the computed field', () => {
+    // The bound on the change. A treegraph reads `options.value` because its
+    // computed field is a layout artefact; a treemap's is a real total, and
+    // moving it to the declaration would silently drop every interior sum.
+    const series = fakeSeries({
+      index: 0,
+      type: 'treemap',
+      name: 'People',
+      data: [
+        { id: 'root', name: 'Company', value: 12 },
+        { id: 'b', parent: 'root', name: 'Engineering', value: 8 },
+        { name: 'Frontend', parent: 'b', value: 4 },
+      ],
+    });
+    const [layer] = layersOf([series], 'treemap-unchanged');
+
+    expect(layer.type).toBe(TraceType.TREEMAP);
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Company', y: 12, path: [] },
+      { x: 'Engineering', y: 8, path: ['Company'] },
+      { x: 'Frontend', y: 4, path: ['Company', 'Engineering'] },
+    ]);
+    expect(layer.axes?.y?.label).toBe('Value');
+  });
+});

--- a/test/adapters/highcharts/hierarchyPaintings.test.ts
+++ b/test/adapters/highcharts/hierarchyPaintings.test.ts
@@ -151,6 +151,27 @@ describe('highcharts treegraph series', () => {
     expect(layer.axes?.x?.label).toBe('Node');
   });
 
+  it('keeps a declared zero, which is not the layout\'s zero', () => {
+    // The case that separates "declared" from "truthy". Highcharts hands
+    // over `value: 0` for a node that declared nothing *and* for a node that
+    // declared zero; only `options.value` tells them apart, and only a
+    // `typeof` test reads a declared zero as declared. Raised in review of
+    // #1165.
+    const [layer] = layersOf([treegraph([0, 0, 0, 0, 0])], 'treegraph-zeros');
+
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Company', y: 0, path: [] },
+      { x: 'Sales', y: 0, path: ['Company'] },
+      { x: 'Engineering', y: 0, path: ['Company'] },
+      { x: 'Frontend', y: 0, path: ['Company', 'Engineering'] },
+      { x: 'Backend', y: 0, path: ['Company', 'Engineering'] },
+    ]);
+    // Declared, so the axis naming the magnitude is drawn -- unlike the
+    // valueless chart above, whose identical `point.value` fields are the
+    // layout's own.
+    expect(layer.axes?.y?.label).toBe('Value');
+  });
+
   it('keeps a declared value beside an undeclared sibling', () => {
     // Leaves valued, interiors not -- the ordinary way a weighted tree is
     // written. The interiors carry no `y`, so `TreemapTrace` derives their


### PR DESCRIPTION
Closes #1164. The same shape as #1140, on the Highcharts side.

## Measured

Highcharts 13.0.1 with `modules/treegraph.js` and `highcharts-more.js`, `treemap` and `bubble` as controls:

```
treegraph      [MAIDR Highcharts] Unsupported series type: "treegraph"; skipping.     layers: (none)
packedbubble   [MAIDR Highcharts] Unsupported series type: "packedbubble"; skipping.  layers: (none)
treemap        layers: treemap n=5                                                    <- control
bubble         layers: point n=2                                                      <- control
```

Both fell through the series-type switch. That is the adapter declining, not misreading.

## The names exist now

`TraceType.TREE` (#1158) and `TraceType.PACK` (#1159). The naming argument is the one those made: the trace type is what the reader is *told* is on the page. A node-link diagram announced as a treemap names a painting nobody drew, and so does a cluster of circles.

## `treegraph` — same declaration, different magnitude

It declares exactly what a treemap does (`id`, `parent`, `name`), so the walk up the parent chain is the treemap's and this delegates to it. What differs is where the magnitude comes from:

```
treegraph, no values      point.value 0      point.options.value undefined
treegraph, values 1..5    point.value 1..5   point.options.value 1..5
```

A treegraph's layout sizes nothing by value and Highcharts fills the field in regardless. Reading `point.value` would emit `y: 0` on every node and announce a magnitude of zero for a chart that has none — #1153's defect, and the reason `convertOrganizationSeries` exists rather than reusing the treemap path. The author's declaration is read instead; with nothing declared anywhere, no node carries a `y` and the layer names no value axis either.

**A treemap keeps reading the computed field** and is untouched by this. There it is not an artefact: an interior node with no declared value comes back carrying the sum of its children (measured, 12 and 8 on a leaves-only tree), which is a real total, and a treemap with no values anywhere renders **zero** nodes — so the case this guards against cannot arise there. A test pins that separately.

One more measured fact worth recording: Highcharts classes a treegraph's **link paths** `highcharts-point` as well as its nodes — 9 elements for 5 nodes. The existing `data-maidr-node-index` stamp goes on each point's own `graphic` so it is unaffected, but it is load-bearing here in a way it is not for a treemap, and a test says so.

## `packedbubble` — a recorded decline, answered rather than overruled

`docs/highcharts.md` listed it under "Series types that are deliberately not read":

> It has a magnitude, but the positions are a packing rather than data — announcing a bubble's x and y would report where the layout put it.

That was right about the chart, and the grammar has since answered it: `pack` is a trace whose points carry a magnitude and **no coordinate at all**, so nothing announces where the layout put a bubble. (`test/util/orientation.test.ts` already files `PACK` under the unoriented types for the same reason.) The docs now carry the reversal and why, rather than dropping the row.

Its shape:

```
series "Europe"  Germany value=12   France value=8    parent undefined
series "Asia"    Japan   value=15   India  value=20   parent undefined
```

Nothing declares a `parent` — the grouping is which *series* a bubble is in, and the adapter already gives each series its own layer named after it. So the paths come out empty and each layer is the flat pack the chart draws, which is why it shares the treemap converter rather than getting one of its own.

Its legend swatches also carry `highcharts-point`, but they sit outside `.highcharts-series-group`, which the selectors are scoped to.

## Reading, after

```
treegraph (no values)     type=tree  axes={"x":{"label":"Node"}}                       y=(none) on all five
treegraph (all values)    type=tree  axes={...,"y":{"label":"Value"}}                  y=1..5
treegraph (leaves only)   type=tree  axes={...,"y":{"label":"Value"}}                  y on leaves, none on interiors
packedbubble              type=pack  titles ["Europe","Asia"]                          12/8 and 15/20
treemap (control)         type=treemap                                                 unchanged
treemap leaves only       type=treemap                                                 interior totals 12 and 8 kept
sunburst (control)        type=sunburst                                                unchanged
```

## Mutations

Nine, all killed:

```
KILLED   treegraph branch removed
KILLED   packedbubble branch removed
KILLED   treegraph named TREEMAP
KILLED   packedbubble named TREEMAP
KILLED   treegraph reads the computed value
KILLED   value axis always named
KILLED   value axis never named
KILLED   undeclared node keeps the computed zero
KILLED   declared value never applied
```

## Verification

```
npx eslint src test    clean
npx tsc --noEmit       clean
npm run build          All builds complete in 134.2s
npm run docs           Done!
npm test               407 suites / 5598 tests, ESM 10 / 137
```

(406/5591 before, so the new suite is the +1/+7.)

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_