### PR TITLE
feat(anychart): read a sunburst as the hierarchy it draws

### DIFF
--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -89,6 +89,7 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 | Mosaic | `anychart.mekko()`, `anychart.mosaic()`, `anychart.barmekko()` | [Marimekko chart](examples.html) |
 | Choropleth | a `choropleth` series on `anychart.map()` | [Choropleth map](examples.html) |
 | Gantt | `anychart.ganttProject()`, `anychart.ganttResource()` | [Gantt chart](examples.html) |
+| Sunburst | `anychart.sunburst()` | [Sunburst chart](examples.html) |
 
 `step-area` is the one series that still loses its fill: MAIDR has no stepped area trace, so it keeps its staircase and maps to a step trace. A console warning is emitted when that downgrade occurs.
 
@@ -128,6 +129,12 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 - **Gantt** charts come from `anychart-gantt.min.js`. `anychart.ganttProject()` and `anychart.ganttResource()` report `'gantt-project'` and `'gantt-resource'`, and the type name is corroborated structurally before anything is read: a gantt has no series API at all and its `chart.data()` hands back an `anychart.data.Tree` of tasks rather than a data view, so a chart naming itself a gantt with no tree behind it is bound as nothing rather than as an empty schedule. The tree is flattened depth-first — parents before their children, the order the chart stacks its rows in — into one lane per row. A parent task states no dates of its own, so the pair AnyChart derived for it (`autoStart` / `autoEnd`) is read instead; a task with a start and no end is a milestone and is emitted as the zero-length interval it is; a resource chart's `periods` array becomes several intervals in one lane. A task with no dates at all becomes an **empty lane** that still carries its name, which is what MAIDR's nested gantt shape exists to express. Axis labels fall back to `Date` and `Task` (`Resource` on a resource chart).
 
   The ends are restated in whole days — or hours, on a schedule spanning less than two days — and the unit is named alongside them, because a gantt is read for how long its intervals run and epoch milliseconds announce as an unreadable nine-digit figure. This is read rather than guessed: a gantt's timeline is a date-time scale, so what the tree holds is instants. The x axis carries a formatter that turns a position back into a date, so each end is still announced as one.
+
+- **Sunburst** charts come from `anychart-sunburst.min.js` and report `getType()` as `'sunburst'`. Like the gantt, their data is an `anychart.data.Tree` on `chart.data()` rather than a data view, and the type name is corroborated by that tree before anything is read. The tree is walked depth-first and emitted as one node per ring segment, each carrying its name, its ancestors, and its own value. An **interior node carries no value**: AnyChart derives a total for the layout, and a node announced with a total the author never wrote states a magnitude the chart does not — while a leaf genuinely written as `0` keeps it. Axis labels fall back to `Node` and `Value`.
+
+  Depth-first is not a convention chosen here; it is the order AnyChart draws the arcs in, which is what lets each node be pointed at individually. Measured on a deliberately unbalanced tree, so that depth-first and breadth-first disagree, the arcs came back depth-first — and `sort('asc')` / `sort('desc')` reorder the rings around the circle while leaving the drawing order alone.
+
+- **Treemaps** and **circle packings** are **not** read, though both draw the same hierarchy from the same tree (#1170). What separates them from the sunburst is what they draw it with. `anychart.treeMap()` shows an aggregate: `maxDepth` defaults to 1, so an interior node stands in for its whole subtree and the nodes beneath it have no element on the chart at all — announcing the full hierarchy over that would name nodes the reader is not being shown, and pointing at one would outline its parent. `anychart.circlePacking()` does draw one circle per node, but orders them by magnitude rather than by the tree and labels only its root, so nothing on the chart says which circle is which node. Both bind as nothing rather than as a hierarchy whose highlight lands elsewhere.
 
   `anychart.timeline()` is **not** read. It is a third constructor with a series API of its own whose `moment` series are instants rather than intervals, and announcing one as a schedule would describe work the chart never drew; it binds as nothing instead.
 
@@ -450,6 +457,7 @@ AnyChart's SVG output uses opaque, internally-generated ids (`ac_path_*`, `ac_re
 | Marimekko | `data-maidr-anychart-tile` | `"<seriesIndex>-<categoryIndex>"` |
 | Choropleth | `data-maidr-anychart-region` | `"<seriesIndex>-<regionIndex>"` |
 | Gantt | `data-maidr-anychart-task-bar` | `"<laneIndex>-<intervalIndex>"` |
+| Sunburst | `data-maidr-anychart-sunburst-node` | `"<nodeIndex>"`, depth-first |
 
 The adapter's generated `selectors` then target those attributes (e.g. `[data-maidr-anychart-bar="0-3"]`), which keeps highlighting stable across re-renders.
 

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -40,6 +40,7 @@ import type {
   PiePoint,
   ScatterPoint,
   SegmentedPoint,
+  TreemapPoint,
   WaterfallKind,
   WaterfallPoint,
   WordCloudPoint,
@@ -817,6 +818,14 @@ const CHOROPLETH_ATTR = 'data-maidr-anychart-region';
 const GANTT_ATTR = 'data-maidr-anychart-task-bar';
 
 /**
+ * Attribute name stamped onto each sunburst arc's SVG element by
+ * {@link stampSunburstAttributes}. The value encodes the node's position in
+ * the hierarchy's depth-first order, which is the order the arcs are drawn in
+ * and therefore the order the layer's data arrives in (#1170).
+ */
+const SUNBURST_ATTR = 'data-maidr-anychart-sunburst-node';
+
+/**
  * Attribute name stamped onto each panel's own `<svg>` root by
  * {@link bindAnyCharts}. Its value is the panel token
  * (`<figureId>-<row>-<col>`), which uniquely identifies one chart's SVG
@@ -1170,6 +1179,7 @@ function enableLineMarkersIfNeeded(chart: AnyChartInstance): boolean {
     isFunnelChart(chart)
     || isWordCloudChart(chart)
     || isSankeyChart(chart)
+    || isSunburstChart(chart)
     || isGanttChart(chart)
   ) {
     return false;
@@ -2488,6 +2498,32 @@ function isSankeyChart(chart: AnyChartInstance): boolean {
 }
 
 /**
+ * Whether a chart is a sunburst.
+ *
+ * `anychart.sunburst()` reports `'sunburst'`, and no other AnyChart chart type
+ * name contains the substring, so the same tolerant match the heatmap, pie,
+ * tag cloud and sankey paths use is safe here too.
+ *
+ * `anychart.treeMap()` and `anychart.circlePacking()` are deliberately NOT
+ * matched. All three draw the same hierarchy from the same tree, and what
+ * separates them is what they draw it with. A sunburst gives one arc per node
+ * in the tree's own depth-first order, so every node can be pointed at. A
+ * circle packing gives one circle per node but orders them by magnitude, and
+ * labels only its root, so nothing on the chart says which circle is which
+ * node. A treemap draws an aggregate: `maxDepth` defaults to 1, so an interior
+ * node stands in for its whole subtree and the nodes beneath it have no
+ * element at all. Reading either of those would put the highlight on a node
+ * the reader was not being told about (#1170).
+ */
+function isSunburstChart(chart: AnyChartInstance): boolean {
+  try {
+    return chart.getType?.().includes('sunburst') ?? false;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Whether a chart draws a map.
  *
  * Asked only by the paths that need a CHART-level answer — which stampers to
@@ -2513,7 +2549,7 @@ function isMapChart(chart: AnyChartInstance): boolean {
  * constructors reporting their own names back, and neither shares anything
  * with the rest of the adapter: a gantt has no series API at all, and its
  * `data()` hands back a task tree rather than a data view. The type name is
- * therefore corroborated structurally by {@link readTaskTree} before anything
+ * therefore corroborated structurally by {@link readChartTree} before anything
  * is read — a chart naming itself a gantt with no tree behind it is bound as
  * nothing rather than as an empty schedule.
  *
@@ -2725,6 +2761,8 @@ function resolveStampers(
     return [['word cloud', stampWordCloudAttributes]];
   if (isSankeyChart(chart))
     return [['sankey', stampSankeyAttributes]];
+  if (isSunburstChart(chart))
+    return [['sunburst', stampSunburstAttributes]];
   // A map does have a series API, and its regions are a mark family no XY
   // stamper writes — so a map running the XY set would be stamped by nothing
   // at all. Running the region stamper ALONE is the second half of that: a
@@ -3874,18 +3912,19 @@ interface GanttScale {
 }
 
 /**
- * The task tree behind a gantt chart.
+ * The tree behind a chart whose data is a hierarchy rather than a table.
  *
- * The structural half of the detection: `chart.data()` answers with an
- * `anychart.data.Tree` on a gantt and with a flat data view on every other
- * chart-level type, and the two share no method. A chart naming itself a gantt
- * with no tree behind it has not been given its data, and binding it would
- * announce a schedule with no work in it.
+ * A gantt's schedule and a sunburst's rings are the two: `chart.data()`
+ * answers with an `anychart.data.Tree` on both and with a flat data view on
+ * every other chart-level type, and the two share no method. So this is also
+ * the structural half of each detection — a chart naming itself a gantt or a
+ * sunburst with no tree behind it has not been given its data, and binding it
+ * would announce a schedule with no work in it, or a hierarchy with no nodes.
  *
  * @param chart - The chart to ask
- * @returns Its task tree, or `null` when it has none
+ * @returns Its tree, or `null` when it has none
  */
-function readTaskTree(chart: AnyChartInstance): AnyChartTree | null {
+function readChartTree(chart: AnyChartInstance): AnyChartTree | null {
   let data: AnyChartDataView | AnyChartTree | undefined;
   try {
     data = chart.data?.();
@@ -4100,6 +4139,99 @@ function resolveGanttScale(lanes: GanttLane[]): GanttScale {
  *
  * On any other chart type this is a no-op.
  */
+/**
+ * Stamp `data-maidr-anychart-sunburst-node="<index>"` on every arc of an
+ * AnyChart sunburst.
+ *
+ * The arcs sit in one layer group, one per node, in the hierarchy's depth-first
+ * order -- so pairing them off with {@link collectHierarchyNodes}'s output by
+ * position is the drawing's own order rather than an assumption about it.
+ *
+ * The chart's backdrop is a filled path too, and it sits in a layer of its
+ * own, which is what {@link resolveHierarchyArcs} uses to tell the two apart:
+ * the arcs are the group holding exactly as many shapes as the tree has nodes.
+ * A chart where no group matches -- or where more than one does, so that which
+ * group is the arcs is not something the SVG says -- is left unstamped and
+ * says so, rather than outlining whatever happened to be in the right place.
+ *
+ * On any other chart type this is a no-op.
+ *
+ * @param chart       - The chart being bound
+ * @param svg         - Its rendered `<svg>` root
+ * @param stampPrefix - Panel token prefix, in multi-panel mode
+ */
+function stampSunburstAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  stampPrefix = '',
+): void {
+  if (!isSunburstChart(chart))
+    return;
+
+  const tree = readChartTree(chart);
+  if (!tree)
+    return;
+
+  const nodes = collectHierarchyNodes(tree);
+  if (nodes.length === 0)
+    return;
+
+  // Not filtered for arcs stamped on a prior bind, the way the gantt bars
+  // are: a second bind resolves the same group and writes the same values,
+  // and `setAttribute` with the value already there changes nothing. Skipping
+  // them would instead leave one shape to resolve against five nodes, and the
+  // rebind would warn that it could not find arcs it had already stamped.
+  const candidates = collectFilledDataPaths(svg);
+
+  const arcs = resolveHierarchyArcs(candidates, nodes.length);
+  if (!arcs) {
+    console.warn(
+      `[maidr/anychart] Could not tell this sunburst's ${nodes.length} arcs `
+      + `apart from the ${candidates.length} filled shapes its SVG holds. `
+      + 'Highlighting is disabled for this chart; pass an explicit '
+      + '`selectors` entry to override.',
+    );
+    return;
+  }
+
+  arcs.forEach((arc, i) => {
+    arc.setAttribute(SUNBURST_ATTR, `${stampPrefix}${i}`);
+  });
+}
+
+/**
+ * Pick a hierarchy's arcs out of a chart's filled shapes.
+ *
+ * @param candidates - Every filled path the SVG holds
+ * @param expected   - How many nodes the hierarchy has
+ * @returns The arcs, in document order, or `null` when they cannot be told
+ * apart from the rest of the chart
+ */
+function resolveHierarchyArcs(
+  candidates: SVGElement[],
+  expected: number,
+): SVGElement[] | null {
+  if (candidates.length === expected)
+    return candidates;
+
+  const byLayer = new Map<Element, SVGElement[]>();
+  for (const candidate of candidates) {
+    const layer = candidate.closest('g[id^="ac_layer_"]');
+    if (!layer)
+      continue;
+    const group = byLayer.get(layer);
+    if (group)
+      group.push(candidate);
+    else
+      byLayer.set(layer, [candidate]);
+  }
+
+  const matching = Array.from(byLayer.values()).filter(
+    group => group.length === expected,
+  );
+  return matching.length === 1 ? matching[0] : null;
+}
+
 function stampGanttAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
@@ -4108,7 +4240,7 @@ function stampGanttAttributes(
   if (!isGanttChart(chart))
     return;
 
-  const tree = readTaskTree(chart);
+  const tree = readChartTree(chart);
   if (!tree)
     return;
 
@@ -4919,6 +5051,92 @@ function buildWordCloudLayer(
  * @param panel - The owning panel, in multi-panel mode
  * @returns The MAIDR sankey layer
  */
+/**
+ * A hierarchy's nodes, depth first, one per drawn arc.
+ *
+ * Depth-first pre-order is not a convention chosen here: it is the order
+ * AnyChart draws a sunburst's arcs in. Measured on a deliberately unbalanced
+ * tree (`R -> A -> A1 -> A1a` beside a shallow `R -> B`), so that pre-order
+ * and breadth-first disagree, the arcs came back at radii 33, 66, 99, 132, 66
+ * -- `R, A, A1, A1a, B`, which is the first and not the second. `sort('asc')`
+ * and `sort('desc')` reorder the rings around the circle and leave the drawing
+ * order alone: all three variants produced identical path lists (#1170).
+ *
+ * A node's own `value` is kept and an interior node's is left off, which is
+ * what {@link TreemapPoint} asks for -- AnyChart derives an interior total for
+ * the layout, and a reader is better served by the chart's own silence there
+ * than by a sum restated as if the author had written it.
+ *
+ * @param tree - The chart's data tree
+ * @returns One point per node, in the order the arcs are drawn
+ */
+function collectHierarchyNodes(tree: AnyChartTree): TreemapPoint[] {
+  const nodes: TreemapPoint[] = [];
+
+  const visit = (item: AnyChartTreeItem, path: (string | number)[]): void => {
+    const name = asString(item.get('name'));
+    // The value the author declared, not one coerced from its absence.
+    // `asNumber` answers 0 for an interior node, which has none, and a node
+    // announced as 0 states a magnitude the chart does not -- while a leaf
+    // genuinely written as 0 has to keep it. Only the raw field separates the
+    // two, so it is asked first.
+    const declared = item.get('value');
+    const magnitude = declared === null || declared === undefined || declared === ''
+      ? Number.NaN
+      : asNumber(declared, Number.NaN);
+    nodes.push({
+      x: name,
+      ...(Number.isFinite(magnitude) ? { y: magnitude } : {}),
+      path: [...path],
+    });
+    const count = item.numChildren?.() ?? 0;
+    for (let i = 0; i < count; i++) {
+      const child = item.getChildAt?.(i);
+      if (child)
+        visit(child, [...path, name]);
+    }
+  };
+
+  const roots = tree.numChildren();
+  for (let i = 0; i < roots; i++) {
+    const root = tree.getChildAt(i);
+    if (root)
+      visit(root, []);
+  }
+
+  return nodes;
+}
+
+/**
+ * Build a SUNBURST layer from a hierarchy's nodes.
+ *
+ * The selectors are one per node rather than one for the layer, in the same
+ * depth-first order: a hierarchy is navigated node by node, and a single
+ * selector would outline every ring at once.
+ *
+ * @param nodes     - The hierarchy's nodes, in draw order
+ * @param selectors - Caller-supplied selector override, when there is one
+ * @param panel     - The owning panel, in multi-panel mode
+ * @returns The MAIDR sunburst layer
+ */
+function buildSunburstLayer(
+  nodes: TreemapPoint[],
+  selectors: string | string[] | undefined,
+  panel?: PanelContext,
+): MaidrLayer {
+  const scope = panelScope(panel);
+  const stamp = panelStampPrefix(panel);
+  const defaultSelectors = nodes.map(
+    (_, i) => `${scope}[${SUNBURST_ATTR}="${stamp}${i}"]`,
+  );
+  return {
+    id: '0',
+    type: TraceType.SUNBURST,
+    selectors: selectors ?? defaultSelectors,
+    data: nodes,
+  };
+}
+
 function buildSankeyLayer(
   rows: Array<Record<string, unknown>>,
   selectors: string | string[] | undefined,
@@ -5503,6 +5721,14 @@ const WORD_CLOUD_AXIS_FALLBACKS = { x: 'Term', y: 'Weight' };
 const SANKEY_AXIS_FALLBACKS = { x: 'Node', y: 'Flow' };
 
 /**
+ * What a sunburst's two dimensions are called when the chart names neither. A
+ * sunburst is bound to no axis: its rings are a hierarchy rather than
+ * positions on a scale, and AnyChart's sunburst has no `xAxis()` / `yAxis()`
+ * to borrow a title from.
+ */
+const SUNBURST_AXIS_FALLBACKS = { x: 'Node', y: 'Value' };
+
+/**
  * What a choropleth's two dimensions are called when the chart names neither.
  * A map is bound to no axis: its regions are places rather than positions on a
  * scale, and AnyChart's map chart has no `xAxis()` / `yAxis()` to borrow a
@@ -5690,13 +5916,28 @@ function buildSubplot(
     return finalize([layer]);
   }
 
+  // A sunburst is a tree chart like the gantt below rather than a table
+  // chart: it exposes no series API either, so the `getSeriesCount()` fallback
+  // would find nothing to read and bind the chart as an image (#1170).
+  if (isSunburstChart(chart)) {
+    const tree = readChartTree(chart);
+    if (!tree)
+      return null;
+    const nodes = collectHierarchyNodes(tree);
+    if (nodes.length === 0)
+      return null;
+    const layer = buildSunburstLayer(nodes, chartLevelSelector, panel);
+    attachAxes(layer, SUNBURST_AXIS_FALLBACKS);
+    return finalize([layer]);
+  }
+
   // A gantt is the last of the chart-level types, and the one furthest from
   // the rest: it has no series API to reach the loop below with, and its data
   // is a task tree rather than a data view — so the `getSeriesCount()`
   // fallback would route its schedule to the heatmap builder, which would find
   // no iterator and bind nothing at all.
   if (isGanttChart(chart)) {
-    const tree = readTaskTree(chart);
+    const tree = readChartTree(chart);
     if (!tree)
       return null;
     const lanes = collectGanttLanes(tree);

--- a/test/adapters/anychart/sunburst.test.ts
+++ b/test/adapters/anychart/sunburst.test.ts
@@ -1,0 +1,345 @@
+/**
+ * `anychart.sunburst()` drew and the adapter read nothing (#1170).
+ *
+ * All three of AnyChart's hierarchy charts -- treemap, sunburst and circle
+ * packing -- take the same tree and expose it the same way, on `chart.data()`.
+ * What separates them is what they draw it with, and only one of the three
+ * draws something a reader can be pointed at node by node.
+ *
+ * A sunburst gives one arc per node, in the hierarchy's own depth-first order.
+ * Measured in Chromium against the AnyChart bundle, on a deliberately
+ * unbalanced tree (`R -> A -> A1 -> A1a` beside a shallow `R -> B`) so that
+ * pre-order and breadth-first disagree: the arcs came back at radii 33, 66,
+ * 99, 132, 66 -- `R, A, A1, A1a, B`, the first and not the second. `sort()`
+ * reorders the rings around the circle and leaves the drawing order alone.
+ *
+ * A circle packing orders its circles by magnitude instead and labels only its
+ * root, and a treemap draws an aggregate -- `maxDepth` defaults to 1, so an
+ * interior node stands in for its whole subtree. Both are left unread rather
+ * than half-read, which the last case here holds to.
+ */
+
+import type { AnyChartInstance, AnyChartTreeItem } from '@adapters/anychart/types';
+import type { TreemapPoint } from '@type/grammar';
+import { anyChartToMaidr, bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** A node as an author writes one into `anychart.data.tree`. */
+interface NodeSpec {
+  name: string;
+  value?: number;
+  children?: NodeSpec[];
+}
+
+function createTreeItem(spec: NodeSpec): AnyChartTreeItem {
+  const children = (spec.children ?? []).map(createTreeItem);
+  return {
+    get: (field: string) => (spec as unknown as Record<string, unknown>)[field],
+    numChildren: () => children.length,
+    getChildAt: (index: number) => children[index] ?? null,
+  };
+}
+
+function createHierarchyChart(
+  roots: NodeSpec[],
+  extra: { container?: HTMLElement; chartType?: string; dataView?: boolean } = {},
+): AnyChartInstance {
+  const items = roots.map(createTreeItem);
+  const tree = {
+    numChildren: () => items.length,
+    getChildAt: (index: number) => items[index] ?? null,
+  };
+  return {
+    title: () => 'Head count',
+    container: () => extra.container ?? '',
+    getType: () => extra.chartType ?? 'sunburst',
+    data: () => (extra.dataView ? { getIterator: () => undefined } : tree),
+    // A sunburst has NO series API; a mock that offered one would let a broken
+    // route look like a working one.
+  } as unknown as AnyChartInstance;
+}
+
+function nodesOf(chart: AnyChartInstance): TreemapPoint[] {
+  const maidr = anyChartToMaidr(chart);
+  return maidr!.subplots[0][0].layers[0].data as TreemapPoint[];
+}
+
+/**
+ * A rendered chart: one AnyChart layer per entry, each holding that many
+ * filled paths. A real sunburst holds two -- the backdrop, then the arcs.
+ */
+function createRendered(
+  id: string,
+  layers: number[],
+): { container: HTMLElement; paths: SVGElement[][] } {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  const paths = layers.map((count, layerIndex) => {
+    const layer = document.createElementNS(SVG_NS, 'g');
+    layer.id = `ac_layer_${layerIndex}`;
+    svg.appendChild(layer);
+    return Array.from({ length: count }, (_, i) => {
+      const path = document.createElementNS(SVG_NS, 'path');
+      path.id = `ac_path_${layerIndex}_${i}`;
+      path.setAttribute('d', 'M 0 0 A 44 44 0 0 1 10 10 Z');
+      path.setAttribute('fill', '#64b5f6');
+      layer.appendChild(path);
+      return path as unknown as SVGElement;
+    });
+  });
+
+  return { container, paths };
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+/** The company tree the cases below share. */
+const COMPANY: NodeSpec[] = [{
+  name: 'Company',
+  children: [
+    { name: 'Sales', value: 30 },
+    {
+      name: 'Engineering',
+      children: [
+        { name: 'Frontend', value: 20 },
+        { name: 'Backend', value: 25 },
+      ],
+    },
+  ],
+}];
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('anyChartToMaidr (sunburst)', () => {
+  it('reads the hierarchy the rings draw, rather than nothing at all', () => {
+    const chart = createHierarchyChart(COMPANY);
+
+    const maidr = anyChartToMaidr(chart);
+
+    expect(maidr!.subplots[0][0].layers.map(layer => layer.type))
+      .toEqual([TraceType.SUNBURST]);
+  });
+
+  it('names every node and gives each its ancestors', () => {
+    const nodes = nodesOf(createHierarchyChart(COMPANY));
+
+    expect(nodes).toEqual([
+      { x: 'Company', path: [] },
+      { x: 'Sales', y: 30, path: ['Company'] },
+      { x: 'Engineering', path: ['Company'] },
+      { x: 'Frontend', y: 20, path: ['Company', 'Engineering'] },
+      { x: 'Backend', y: 25, path: ['Company', 'Engineering'] },
+    ]);
+  });
+
+  it('leaves an interior node without a magnitude it never declared', () => {
+    // AnyChart derives an interior total for the layout, and reading the field
+    // through the adapter's numeric coercion turned that absence into a `0`.
+    // A node announced as 0 states a magnitude the chart does not.
+    const nodes = nodesOf(createHierarchyChart(COMPANY));
+
+    expect(nodes.filter(node => 'y' in node).map(node => node.x))
+      .toEqual(['Sales', 'Frontend', 'Backend']);
+  });
+
+  it('keeps a leaf whose magnitude really is zero', () => {
+    // The other side of the same coin: a department with nobody in it is a
+    // fact about the chart, and dropping it would announce the node as an
+    // interior one with a total.
+    const nodes = nodesOf(createHierarchyChart([{
+      name: 'Company',
+      children: [{ name: 'Sales', value: 0 }],
+    }]));
+
+    expect(nodes[1]).toEqual({ x: 'Sales', y: 0, path: ['Company'] });
+  });
+
+  it('treats a blank value cell as no value, not as a zero', () => {
+    // AnyChart's table mappings hand an empty cell through as `''`, and the
+    // adapter's numeric coercion turns that into a `0` as readily as it turns
+    // an interior node's absent field into one. Neither is a magnitude the
+    // author wrote.
+    const nodes = nodesOf(createHierarchyChart([{
+      name: 'Company',
+      children: [{ name: 'Sales', value: '' as unknown as number }],
+    }]));
+
+    expect(nodes[1]).toEqual({ x: 'Sales', path: ['Company'] });
+  });
+
+  it('is not read when the tree it was given is empty', () => {
+    // A tree with no roots is a chart whose data has not arrived. Binding it
+    // would emit a hierarchy with nothing in it, which a reader can enter and
+    // then navigate nowhere within.
+    expect(anyChartToMaidr(createHierarchyChart([]))).toBeNull();
+  });
+
+  it('reads a deep branch before its shallow sibling, as the arcs are drawn', () => {
+    // The order is AnyChart's, not a convention chosen here. Pre-order and
+    // breadth-first disagree on this tree, and the arcs measured in the
+    // browser came back pre-order.
+    const nodes = nodesOf(createHierarchyChart([{
+      name: 'R',
+      children: [
+        { name: 'A', children: [{ name: 'A1', children: [{ name: 'A1a', value: 13 }] }] },
+        { name: 'B', value: 61 },
+      ],
+    }]));
+
+    expect(nodes.map(node => node.x)).toEqual(['R', 'A', 'A1', 'A1a', 'B']);
+  });
+
+  it('reads a forest as the several roots it draws', () => {
+    const nodes = nodesOf(createHierarchyChart([
+      { name: 'North', value: 4 },
+      { name: 'South', value: 7 },
+    ]));
+
+    expect(nodes).toEqual([
+      { x: 'North', y: 4, path: [] },
+      { x: 'South', y: 7, path: [] },
+    ]);
+  });
+
+  it('names its dimensions, having no axis to borrow a title from', () => {
+    const layer = anyChartToMaidr(createHierarchyChart(COMPANY))!
+      .subplots[0][0]
+      .layers[0];
+
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Value' } });
+  });
+
+  it('is not read when the chart has been given no tree', () => {
+    // A chart naming itself a sunburst whose `data()` is a flat view has not
+    // been given its data. Binding it would announce a hierarchy with no
+    // nodes in it.
+    const chart = createHierarchyChart(COMPANY, { dataView: true });
+
+    expect(anyChartToMaidr(chart)).toBeNull();
+  });
+});
+
+describe('a sunburst\'s highlight', () => {
+  it('points at one arc per node, in the order the arcs are drawn', () => {
+    // A hierarchy is navigated node by node. One selector for the layer would
+    // outline every ring at once.
+    const { container, paths } = createRendered('sb-1', [1, 5]);
+    const chart = createHierarchyChart(COMPANY, { container });
+
+    bindAnyChart(chart, { id: 'sb-1' });
+
+    expect(paths[1].map(path => path.getAttribute('data-maidr-anychart-sunburst-node')))
+      .toEqual(['0', '1', '2', '3', '4']);
+    // The backdrop sits in a layer of its own and is left alone.
+    expect(paths[0][0].hasAttribute('data-maidr-anychart-sunburst-node')).toBe(false);
+    cleanUp(container);
+  });
+
+  it('resolves each selector to exactly the arc it names', () => {
+    const { container } = createRendered('sb-2', [1, 5]);
+    const chart = createHierarchyChart(COMPANY, { container });
+
+    const maidr = anyChartToMaidr(chart, { id: 'sb-2' });
+    bindAnyChart(chart, { id: 'sb-2' });
+
+    const selectors = maidr!.subplots[0][0].layers[0].selectors as string[];
+    expect(selectors).toHaveLength(5);
+    expect(selectors.map(selector => document.querySelectorAll(selector).length))
+      .toEqual([1, 1, 1, 1, 1]);
+    cleanUp(container);
+  });
+
+  it('withdraws when two layers could both be the arcs', () => {
+    // Both hold five filled shapes, so which of them is the ring is not
+    // something the SVG says. Taking the first would be a coin toss the
+    // reader cannot check, and it would land on the wrong half of the time.
+    const { container, paths } = createRendered('sb-0', [1, 5, 5]);
+    const chart = createHierarchyChart(COMPANY, { container });
+
+    bindAnyChart(chart, { id: 'sb-0' });
+
+    expect(paths.flat().some(
+      path => path.hasAttribute('data-maidr-anychart-sunburst-node'),
+    )).toBe(false);
+    cleanUp(container);
+  });
+
+  it('withdraws rather than outlining shapes it cannot vouch for', () => {
+    // No layer holds five filled shapes, so which five are the arcs is not
+    // something the SVG says. Stamping the nearest five would put the
+    // highlight on whatever happened to be there.
+    const { container, paths } = createRendered('sb-3', [1, 4, 7]);
+    const chart = createHierarchyChart(COMPANY, { container });
+
+    bindAnyChart(chart, { id: 'sb-3' });
+
+    expect(paths.flat().some(
+      path => path.hasAttribute('data-maidr-anychart-sunburst-node'),
+    )).toBe(false);
+    cleanUp(container);
+  });
+
+  it('rebinds quietly, resolving the arcs it already stamped', () => {
+    // The gantt skips bars stamped on a prior bind, and doing the same here
+    // would leave the backdrop alone to be resolved against five nodes -- so a
+    // rebind would report that it could not find the arcs it had just
+    // stamped. Re-resolving them instead writes the same values back, which
+    // `setAttribute` treats as no change at all.
+    const { container, paths } = createRendered('sb-4', [1, 5]);
+    const chart = createHierarchyChart(COMPANY, { container });
+
+    bindAnyChart(chart, { id: 'sb-4' });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    bindAnyChart(chart, { id: 'sb-4' });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(paths[1].map(path => path.getAttribute('data-maidr-anychart-sunburst-node')))
+      .toEqual(['0', '1', '2', '3', '4']);
+    cleanUp(container);
+  });
+});
+
+describe('the two hierarchy charts that are not read', () => {
+  it('leaves a treemap alone, because its default view is an aggregate', () => {
+    // `maxDepth` defaults to 1, so a three-level tree draws two leaves and one
+    // interior node carrying its children's total. Announcing the whole
+    // hierarchy over that would name nodes the chart is not showing, and
+    // pointing at them would outline their parent.
+    expect(anyChartToMaidr(createHierarchyChart(COMPANY, { chartType: 'tree-map' })))
+      .toBeNull();
+  });
+
+  it('leaves a circle packing alone, because nothing says which circle is which', () => {
+    // One circle per node, but ordered by magnitude rather than by the tree,
+    // and only the root is labelled. Pairing them by position would give every
+    // node but the root the wrong outline.
+    expect(anyChartToMaidr(createHierarchyChart(COMPANY, { chartType: 'circle-packing' })))
+      .toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1170.

`anychart.sunburst()` drew and the adapter bound nothing. Measured in Chromium against the installed AnyChart bundle, with the adapter bundled from `src/`, all three of AnyChart's hierarchy charts came back with no layers at all:

| chart | `getType()` | drawn | before | after |
| --- | --- | --- | --- | --- |
| `sunburst` | `sunburst` | yes | `layers: null` | one `sunburst` layer, 5 nodes, 5 selectors |
| `treeMap` | `tree-map` | yes | `layers: null` | unchanged, and now documented |
| `circlePacking` | — | yes | `layers: null` | unchanged, and now documented |

## Why only one of the three

All three take the same tree and expose it identically — `chart.data()` answers with the `anychart.data.Tree` the gantt reading already walks. What separates them is what they draw it with, and only one draws something a reader can be pointed at node by node.

**A sunburst gives one arc per node, in the hierarchy's own depth-first order.** Measured on a deliberately unbalanced tree (`R → A → A1 → A1a` beside a shallow `R → B`), so that pre-order and breadth-first disagree, the arcs came back at radii 33, 66, 99, 132, 66 — `R, A, A1, A1a, B`, the first and not the second. `sort('asc')` and `sort('desc')` reorder the rings around the circle and leave the drawing order alone: all three variants produced identical path lists.

**A circle packing gives one circle per node but orders them by magnitude.** On a tree with `A=11`, `B1=43`, `C=71` the radii came back `147.5, 69.685, 54.231, 41.945, 27.429` — root, then `C`, `B`, `B1`, `A`, every ratio matching `sqrt(value)` to four figures. Only the root is labelled, so nothing on the chart says which circle is which node.

**A treemap draws an aggregate.** `maxDepth` defaults to 1, so a three-level tree draws two leaves and one interior node carrying its children's total (`Engineering 45`). The nodes beneath it have no element at all.

So the sunburst is read whole and the other two are left alone rather than half-read. Announcing a hierarchy whose highlight lands on the wrong node, or whose nodes the chart is not showing, is worse for a reader than announcing nothing — the same line `docs/anychart.md` already draws for `hilo`, `timeline` and the map's centroids.

## The interior-node zero

An interior node states no value; AnyChart derives a total for the layout. The adapter's `asNumber` answers `0` for that absence, and the first measurement came back with `R` and `Engineering` announced as `0` — a magnitude the chart does not state. The raw field is now asked first, so an interior node carries no `y` at all while a leaf genuinely written as `0` keeps it.

## Also

`readTaskTree` is now `readChartTree`: it was always generic over `chart.data()` being a tree rather than a data view, and the sunburst is its second caller.

## Verification

- End to end in Chromium: 5 nodes with the right names, ancestors and magnitudes, and 5 selectors each resolving to exactly one arc, in the order the arcs are drawn.
- 17 new unit cases in `test/adapters/anychart/sunburst.test.ts`, including the two charts that stay unread.
- 16 mutations of the new reading, all killed — including one that showed the gantt's idempotency filter is dead weight here, which is why this stamper does not copy it and a test now pins the rebind.
- Full gate green: `eslint`, `tsc --noEmit`, `npm run build`, `npm run docs`, `npm test` — 408 suites / 5633 tests, ESM 10 / 137.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_