### PR TITLE
feat(anychart): read a circle packing as the hierarchy it draws

### DIFF
--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -90,6 +90,7 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 | Choropleth | a `choropleth` series on `anychart.map()` | [Choropleth map](examples.html) |
 | Gantt | `anychart.ganttProject()`, `anychart.ganttResource()` | [Gantt chart](examples.html) |
 | Sunburst | `anychart.sunburst()` | [Sunburst chart](examples.html) |
+| Pack | `anychart.circlePacking()` | [Circle packing](examples.html) |
 
 `step-area` is the one series that still loses its fill: MAIDR has no stepped area trace, so it keeps its staircase and maps to a step trace. A console warning is emitted when that downgrade occurs.
 
@@ -134,7 +135,13 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 
   Depth-first is not a convention chosen here; it is the order AnyChart draws the arcs in, which is what lets each node be pointed at individually. Measured on a deliberately unbalanced tree, so that depth-first and breadth-first disagree, the arcs came back depth-first — and `sort('asc')` / `sort('desc')` reorder the rings around the circle while leaving the drawing order alone.
 
-- **Treemaps** and **circle packings** are **not** read, though both draw the same hierarchy from the same tree (#1170). What separates them from the sunburst is what they draw it with. `anychart.treeMap()` shows an aggregate: `maxDepth` defaults to 1, so an interior node stands in for its whole subtree and the nodes beneath it have no element on the chart at all — announcing the full hierarchy over that would name nodes the reader is not being shown, and pointing at one would outline its parent. `anychart.circlePacking()` does draw one circle per node, but orders them by magnitude rather than by the tree and labels only its root, so nothing on the chart says which circle is which node. Both bind as nothing rather than as a hierarchy whose highlight lands elsewhere.
+- **Circle packings** come from `anychart-circle-packing.min.js` and are read as a `pack` — the same hierarchy as a treemap, drawn as nested circles sized by magnitude, which is what the reader is told is on the page. Two things make it the odd one out. It is the only chart here that reports **no `getType()` at all** (`toJson()` throws on it too), so it is identified by `labelsMode()` — its own label placement, and the one public method the other two hierarchy charts lack — corroborated by having no series API and a tree on `data()`. And it does not draw the tree in the author's order: it sorts each parent's children by magnitude, largest first, and walks depth first, which is the order the layer's nodes and selectors come back in.
+
+  That order is **checked rather than assumed**. A packing sizes a circle by the square root of its magnitude, so within one parent's children `r / sqrt(total)` is a single constant; measured across four tree shapes it held to four significant figures every time. The pairing is confirmed against those radii before anything is stamped, so a future change in AnyChart's packing would cost the chart its highlight rather than quietly move it onto the wrong circle.
+
+  **A tie is refused.** Two children of one parent with the same magnitude are drawn as two circles of the same radius, and a packing labels only its root — so nothing on the chart says which is which, and that chart binds as nothing rather than announcing one node's name over another's circle. An interior node is sized by its subtree, but that derived total is never emitted as its value: it orders the siblings and checks the circle, and the node's own value stays absent exactly as it is written.
+
+- **Treemaps** are **not** read, though they draw the same hierarchy from the same tree (#1170). `anychart.treeMap()` shows an aggregate: `maxDepth` defaults to 1, so an interior node stands in for its whole subtree and the nodes beneath it have no element on the chart at all. Announcing the full hierarchy over that would name nodes the reader is not being shown, and pointing at one would outline its parent, so it binds as nothing instead.
 
   `anychart.timeline()` is **not** read. It is a third constructor with a series API of its own whose `moment` series are instants rather than intervals, and announcing one as a schedule would describe work the chart never drew; it binds as nothing instead.
 
@@ -458,6 +465,7 @@ AnyChart's SVG output uses opaque, internally-generated ids (`ac_path_*`, `ac_re
 | Choropleth | `data-maidr-anychart-region` | `"<seriesIndex>-<regionIndex>"` |
 | Gantt | `data-maidr-anychart-task-bar` | `"<laneIndex>-<intervalIndex>"` |
 | Sunburst | `data-maidr-anychart-sunburst-node` | `"<nodeIndex>"`, depth-first |
+| Pack | `data-maidr-anychart-pack-node` | `"<nodeIndex>"`, depth-first, siblings largest first |
 
 The adapter's generated `selectors` then target those attributes (e.g. `[data-maidr-anychart-bar="0-3"]`), which keeps highlighting stable across re-renders.
 

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -826,6 +826,24 @@ const GANTT_ATTR = 'data-maidr-anychart-task-bar';
 const SUNBURST_ATTR = 'data-maidr-anychart-sunburst-node';
 
 /**
+ * Attribute name stamped onto each circle of an AnyChart circle packing by
+ * {@link stampPackAttributes}. The value encodes the node's position in the
+ * order the packing draws in -- depth first, siblings largest first (#1170).
+ */
+const PACK_ATTR = 'data-maidr-anychart-pack-node';
+
+/**
+ * How far a circle's radius may sit from the one its magnitude implies before
+ * the pairing is refused, as a fraction of the radius.
+ *
+ * A packing sizes a circle by the square root of its magnitude, so the ratio
+ * `r / sqrt(value)` is one constant across a parent's children. Measured
+ * across four tree shapes it held to better than one part in ten thousand;
+ * this leaves room for the serializer's rounding and nothing else.
+ */
+const PACK_RADIUS_TOLERANCE = 0.01;
+
+/**
  * Attribute name stamped onto each panel's own `<svg>` root by
  * {@link bindAnyCharts}. Its value is the panel token
  * (`<figureId>-<row>-<col>`), which uniquely identifies one chart's SVG
@@ -1180,6 +1198,7 @@ function enableLineMarkersIfNeeded(chart: AnyChartInstance): boolean {
     || isWordCloudChart(chart)
     || isSankeyChart(chart)
     || isSunburstChart(chart)
+    || isCirclePackingChart(chart)
     || isGanttChart(chart)
   ) {
     return false;
@@ -2524,6 +2543,28 @@ function isSunburstChart(chart: AnyChartInstance): boolean {
 }
 
 /**
+ * Whether a chart is a circle packing.
+ *
+ * Not by name: `anychart.circlePacking()` is the one chart here that reports
+ * no `getType()` at all, and `toJson()` throws on it too, so the name every
+ * other detection asks for does not exist (#1170). What it does have is
+ * `labelsMode()` -- its own label placement, and the only public method the
+ * other two hierarchy charts lack.
+ *
+ * Corroborated structurally, as the gantt's name is: a packing has no series
+ * API and its `data()` hands back a tree. Requiring the type name to be
+ * absent as well keeps an undrawn treemap out, since {@link readChartType}
+ * answers `''` on a chart that has not been drawn.
+ */
+function isCirclePackingChart(chart: AnyChartInstance): boolean {
+  if (typeof chart.labelsMode !== 'function')
+    return false;
+  if (readChartType(chart) !== '')
+    return false;
+  return readChartTree(chart) !== null;
+}
+
+/**
  * Whether a chart draws a map.
  *
  * Asked only by the paths that need a CHART-level answer — which stampers to
@@ -2763,6 +2804,8 @@ function resolveStampers(
     return [['sankey', stampSankeyAttributes]];
   if (isSunburstChart(chart))
     return [['sunburst', stampSunburstAttributes]];
+  if (isCirclePackingChart(chart))
+    return [['circle packing', stampPackAttributes]];
   // A map does have a series API, and its regions are a mark family no XY
   // stamper writes — so a map running the XY set would be stamped by nothing
   // at all. Running the region stamper ALONE is the second half of that: a
@@ -4140,6 +4183,120 @@ function resolveGanttScale(lanes: GanttLane[]): GanttScale {
  * On any other chart type this is a no-op.
  */
 /**
+ * Stamp `data-maidr-anychart-pack-node="<index>"` on every circle of an
+ * AnyChart circle packing.
+ *
+ * The circles are paired with the nodes by position, in the order
+ * {@link collectPackLayout} puts them -- and then that pairing is CHECKED
+ * against the drawing rather than trusted. A packing sizes a circle by the
+ * square root of its magnitude, so within one parent's children the ratio
+ * `r / sqrt(total)` is a single constant; if the pairing is right that holds,
+ * and if the layout ever ordered its siblings differently it would not.
+ *
+ * That is the difference between this and reading the order off the library's
+ * documentation: a change in AnyChart's packing would make the chart fall
+ * back to no highlight rather than silently outline the wrong circle.
+ *
+ * On any other chart type this is a no-op.
+ *
+ * @param chart       - The chart being bound
+ * @param svg         - Its rendered `<svg>` root
+ * @param stampPrefix - Panel token prefix, in multi-panel mode
+ */
+function stampPackAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  stampPrefix = '',
+): void {
+  if (!isCirclePackingChart(chart))
+    return;
+
+  const tree = readChartTree(chart);
+  if (!tree)
+    return;
+
+  const layout = collectPackLayout(tree);
+  if (!layout)
+    return;
+
+  const circles = Array.from(
+    svg.querySelectorAll<SVGElement>('circle'),
+  ).filter(circle => Number.isFinite(readCircleRadius(circle)));
+
+  if (circles.length !== layout.nodes.length || !packRadiiAgree(layout, circles)) {
+    console.warn(
+      `[maidr/anychart] Could not match this circle packing's `
+      + `${layout.nodes.length} nodes to the ${circles.length} circles its SVG `
+      + 'holds. Highlighting is disabled for this chart; pass an explicit '
+      + '`selectors` entry to override.',
+    );
+    return;
+  }
+
+  circles.forEach((circle, i) => {
+    circle.setAttribute(PACK_ATTR, `${stampPrefix}${i}`);
+  });
+}
+
+/**
+ * One circle's radius, as the drawing states it.
+ *
+ * @param circle - The `<circle>` to measure
+ * @returns Its radius, or `NaN` where it carries none
+ */
+function readCircleRadius(circle: SVGElement): number {
+  const raw = circle.getAttribute('r');
+  if (raw === null)
+    return Number.NaN;
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) && value > 0 ? value : Number.NaN;
+}
+
+/**
+ * Whether the circles are sized the way the paired nodes' magnitudes say.
+ *
+ * Asked per parent, because a packing rescales each nesting level to fit
+ * inside its own circle: `r / sqrt(total)` is constant among one parent's
+ * children and differs between parents. A parent with a single child states
+ * nothing -- one ratio is always constant with itself -- so those pass, and
+ * what they would have caught is caught by the parent above.
+ *
+ * @param layout  - The hierarchy in the order the circles were paired with
+ * @param circles - The drawn circles, in document order
+ * @returns Whether every sibling group agrees with its circles
+ */
+function packRadiiAgree(layout: PackLayout, circles: SVGElement[]): boolean {
+  const groups = new Map<number, number[]>();
+  layout.parents.forEach((parent, index) => {
+    const group = groups.get(parent);
+    if (group)
+      group.push(index);
+    else
+      groups.set(parent, [index]);
+  });
+
+  for (const group of groups.values()) {
+    let expected: number | null = null;
+    for (const index of group) {
+      // Always positive: {@link collectPackLayout} drops a subtree with no
+      // magnitude, because the packing draws no circle for one.
+      const total = layout.totals[index];
+      const ratio = readCircleRadius(circles[index]) / Math.sqrt(total);
+      if (!Number.isFinite(ratio))
+        return false;
+      if (expected === null) {
+        expected = ratio;
+        continue;
+      }
+      if (Math.abs(ratio - expected) > expected * PACK_RADIUS_TOLERANCE)
+        return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * Stamp `data-maidr-anychart-sunburst-node="<index>"` on every arc of an
  * AnyChart sunburst.
  *
@@ -5107,6 +5264,168 @@ function collectHierarchyNodes(tree: AnyChartTree): TreemapPoint[] {
   return nodes;
 }
 
+/** One hierarchy laid out the way a circle packing draws it. */
+interface PackLayout {
+  /** The nodes, depth first with each parent's children largest first. */
+  nodes: TreemapPoint[];
+  /** Each node's magnitude, its own or its subtree's. */
+  totals: number[];
+  /** Each node's parent, as an index into {@link nodes}; `-1` for a root. */
+  parents: number[];
+}
+
+/**
+ * A node's magnitude, its own where it declared one and its subtree's where
+ * it did not.
+ *
+ * The packing sizes every circle, interior ones included, so an interior node
+ * has a size on the chart whatever the data said. That derived figure is what
+ * orders the siblings and what the radius check is asked about; it is never
+ * emitted as the node's value, which stays absent exactly as it is written.
+ *
+ * @param item - The tree item to total
+ * @returns Its magnitude, or 0 where neither it nor its subtree declares one
+ */
+function packTotal(item: AnyChartTreeItem): number {
+  const declared = item.get('value');
+  const own = declared === null || declared === undefined || declared === ''
+    ? Number.NaN
+    : asNumber(declared, Number.NaN);
+  if (Number.isFinite(own))
+    return own;
+  let sum = 0;
+  const count = item.numChildren?.() ?? 0;
+  for (let i = 0; i < count; i++) {
+    const child = item.getChildAt?.(i);
+    if (child)
+      sum += packTotal(child);
+  }
+  return sum;
+}
+
+/**
+ * A hierarchy in the order a circle packing draws it, or `null` where that
+ * order is not determined.
+ *
+ * The packing does not draw the tree in the author's order: it sorts each
+ * parent's children by magnitude, largest first, and walks depth first.
+ * Measured across four tree shapes -- a deep chain beside a shallow sibling,
+ * an ascending declared order, two multi-child subtrees, and a pair of tied
+ * siblings -- the circles came back in exactly that order every time, with
+ * `r / sqrt(magnitude)` constant within each parent to four significant
+ * figures (#1170).
+ *
+ * **Tied siblings are refused.** Two children of one parent with the same
+ * magnitude are drawn as two circles of the same size, and nothing on the
+ * chart says which is which -- a packing labels only its root. Ordering them
+ * by anything would be a coin toss, and losing it announces one node's name
+ * while outlining another's circle. The chart is left unread instead.
+ *
+ * @param tree - The chart's data tree
+ * @returns The layout, or `null` where a parent has children of equal size
+ */
+function collectPackLayout(tree: AnyChartTree): PackLayout | null {
+  const nodes: TreemapPoint[] = [];
+  const totals: number[] = [];
+  const parents: number[] = [];
+  let tied = false;
+
+  const childrenOf = (item: AnyChartTreeItem): AnyChartTreeItem[] => {
+    const out: AnyChartTreeItem[] = [];
+    const count = item.numChildren?.() ?? 0;
+    for (let i = 0; i < count; i++) {
+      const child = item.getChildAt?.(i);
+      if (child)
+        out.push(child);
+    }
+    return out;
+  };
+
+  const largestFirst = (items: AnyChartTreeItem[]): AnyChartTreeItem[] => {
+    // A subtree with no magnitude anywhere in it is dropped, because the
+    // packing draws no circle for one. Measured: a four-node tree whose
+    // second branch declared no value came back as two circles, the root and
+    // the one branch that had a size. Keeping those nodes would announce a
+    // part of the chart the reader is not being shown, and it is also why
+    // they never reach the tie test -- every one of them totals zero.
+    const sized = items
+      .map(item => ({ item, total: packTotal(item) }))
+      .filter(entry => entry.total > 0);
+    const ordered = [...sized].sort((a, b) => b.total - a.total);
+    for (let i = 1; i < ordered.length; i++) {
+      if (ordered[i].total === ordered[i - 1].total)
+        tied = true;
+    }
+    return ordered.map(entry => entry.item);
+  };
+
+  const visit = (
+    item: AnyChartTreeItem,
+    path: (string | number)[],
+    parent: number,
+  ): void => {
+    const name = asString(item.get('name'));
+    const declared = item.get('value');
+    const magnitude = declared === null || declared === undefined || declared === ''
+      ? Number.NaN
+      : asNumber(declared, Number.NaN);
+    const index = nodes.length;
+    nodes.push({
+      x: name,
+      ...(Number.isFinite(magnitude) ? { y: magnitude } : {}),
+      path: [...path],
+    });
+    totals.push(packTotal(item));
+    parents.push(parent);
+    for (const child of largestFirst(childrenOf(item)))
+      visit(child, [...path, name], index);
+  };
+
+  const roots: AnyChartTreeItem[] = [];
+  const rootCount = tree.numChildren();
+  for (let i = 0; i < rootCount; i++) {
+    const root = tree.getChildAt(i);
+    if (root)
+      roots.push(root);
+  }
+  for (const root of largestFirst(roots))
+    visit(root, [], -1);
+
+  return tied || nodes.length === 0 ? null : { nodes, totals, parents };
+}
+
+/**
+ * Build a PACK layer from a hierarchy's nodes.
+ *
+ * `pack` rather than `treemap`: the same hierarchy, drawn as nested circles
+ * sized by magnitude, which is what the reader is told is on the page.
+ *
+ * The selectors are one per node, in the order the packing draws them, so a
+ * hierarchy can be navigated circle by circle.
+ *
+ * @param layout    - The hierarchy in the order the circles are drawn
+ * @param selectors - Caller-supplied selector override, when there is one
+ * @param panel     - The owning panel, in multi-panel mode
+ * @returns The MAIDR pack layer
+ */
+function buildPackLayer(
+  layout: PackLayout,
+  selectors: string | string[] | undefined,
+  panel?: PanelContext,
+): MaidrLayer {
+  const scope = panelScope(panel);
+  const stamp = panelStampPrefix(panel);
+  const defaultSelectors = layout.nodes.map(
+    (_, i) => `${scope}[${PACK_ATTR}="${stamp}${i}"]`,
+  );
+  return {
+    id: '0',
+    type: TraceType.PACK,
+    selectors: selectors ?? defaultSelectors,
+    data: layout.nodes,
+  };
+}
+
 /**
  * Build a SUNBURST layer from a hierarchy's nodes.
  *
@@ -5729,6 +6048,13 @@ const SANKEY_AXIS_FALLBACKS = { x: 'Node', y: 'Flow' };
 const SUNBURST_AXIS_FALLBACKS = { x: 'Node', y: 'Value' };
 
 /**
+ * What a circle packing's two dimensions are called when the chart names
+ * neither. Like the sunburst it is bound to no axis: its circles are a
+ * hierarchy rather than positions on a scale.
+ */
+const PACK_AXIS_FALLBACKS = { x: 'Node', y: 'Value' };
+
+/**
  * What a choropleth's two dimensions are called when the chart names neither.
  * A map is bound to no axis: its regions are places rather than positions on a
  * scale, and AnyChart's map chart has no `xAxis()` / `yAxis()` to borrow a
@@ -5928,6 +6254,25 @@ function buildSubplot(
       return null;
     const layer = buildSunburstLayer(nodes, chartLevelSelector, panel);
     attachAxes(layer, SUNBURST_AXIS_FALLBACKS);
+    return finalize([layer]);
+  }
+
+  // A circle packing is the third tree chart, and the one that names itself
+  // least: no `getType()`, no series API, and a `data()` that hands back a
+  // tree (#1170).
+  if (isCirclePackingChart(chart)) {
+    const tree = readChartTree(chart);
+    if (!tree)
+      return null;
+    // `null` where a parent has two children of equal size: the packing draws
+    // them as two circles of the same radius and labels only its root, so
+    // which is which is not something the chart says. Announcing one node's
+    // name over another's circle is worse than announcing nothing.
+    const layout = collectPackLayout(tree);
+    if (!layout)
+      return null;
+    const layer = buildPackLayer(layout, chartLevelSelector, panel);
+    attachAxes(layer, PACK_AXIS_FALLBACKS);
     return finalize([layer]);
   }
 

--- a/src/adapters/anychart/types.ts
+++ b/src/adapters/anychart/types.ts
@@ -229,6 +229,13 @@ export interface AnyChartInstance {
 
   /** Chart type string (e.g. "bar", "line", "pie"). */
   getType?: () => string;
+  /**
+   * Circle packing's own label placement, and the one public method that
+   * separates it from the other two hierarchy charts: a treemap and a
+   * sunburst have neither it nor anything else readable of their own, and a
+   * circle packing reports no `getType()` at all (#1170).
+   */
+  labelsMode?: () => unknown;
 
   /**
    * How a waterfall chart reads its series values (`'diff'` by default, or

--- a/test/adapters/anychart/circlePacking.test.ts
+++ b/test/adapters/anychart/circlePacking.test.ts
@@ -1,0 +1,405 @@
+/**
+ * `anychart.circlePacking()` drew and the adapter read nothing (#1170).
+ *
+ * It was left alone when the sunburst was read, for a reason that turned out
+ * to be only half true: the packing does not draw its circles in the tree's
+ * order, so pairing them by position looked like a coin toss. Measured, the
+ * order is not arbitrary at all -- it is depth first with each parent's
+ * children largest first, and the sizes say so out loud.
+ *
+ * A packing sizes a circle by the square root of its magnitude, so within one
+ * parent's children `r / sqrt(total)` is a single constant. Measured across
+ * four tree shapes -- a deep chain beside a shallow sibling, an ascending
+ * declared order, two multi-child subtrees, and a pair of tied siblings --
+ * the circles came back in that order every time and the ratio held to four
+ * significant figures.
+ *
+ * So the pairing is not assumed, it is *checked*: the order gives a candidate
+ * and the radii confirm it. If AnyChart's packing ever ordered its siblings
+ * differently the check would fail and the chart would lose its highlight
+ * rather than quietly outline the wrong circle.
+ *
+ * The one case the drawing genuinely cannot settle is two siblings of equal
+ * size. They are drawn as two circles of the same radius and a packing labels
+ * only its root, so nothing says which is which; that chart is left unread.
+ */
+
+import type { AnyChartInstance, AnyChartTreeItem } from '@adapters/anychart/types';
+import type { TreemapPoint } from '@type/grammar';
+import { anyChartToMaidr, bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface NodeSpec {
+  name: string;
+  value?: number;
+  children?: NodeSpec[];
+}
+
+function createTreeItem(spec: NodeSpec): AnyChartTreeItem {
+  const children = (spec.children ?? []).map(createTreeItem);
+  return {
+    get: (field: string) => (spec as unknown as Record<string, unknown>)[field],
+    numChildren: () => children.length,
+    getChildAt: (index: number) => children[index] ?? null,
+  };
+}
+
+/**
+ * A circle packing as the adapter meets one: a tree on `data()`, no series
+ * API, a `labelsMode()` of its own, and NO chart type name -- `getType()`
+ * answers `undefined` on a real packing, which is why the detection cannot
+ * ask for a name the way every other one does.
+ */
+function createPackingChart(
+  roots: NodeSpec[],
+  extra: {
+    container?: HTMLElement;
+    /** Give the chart a type name, as a treemap and a sunburst have. */
+    chartType?: string;
+    /** Take away the one method that identifies a packing. */
+    noLabelsMode?: boolean;
+    /**
+     * Hand back a flat data view instead of a tree, and a series API with it
+     * — the shape of an ordinary chart that happens to carry `labelsMode`.
+     */
+    dataView?: boolean;
+  } = {},
+): AnyChartInstance {
+  const items = roots.map(createTreeItem);
+  const tree = {
+    numChildren: () => items.length,
+    getChildAt: (index: number) => items[index] ?? null,
+  };
+  const rows: Array<[string, number]> = [['A', 3], ['B', 8]];
+  const view = {
+    getIterator: () => {
+      let i = -1;
+      return {
+        reset: () => {
+          i = -1;
+        },
+        advance: () => {
+          i += 1;
+          return i < rows.length;
+        },
+        getIndex: () => i,
+        get: (field: string) => (field === 'x' ? rows[i][0] : rows[i][1]),
+      };
+    },
+  };
+  const chart: Record<string, unknown> = {
+    title: () => 'Head count',
+    container: () => extra.container ?? '',
+    getType: () => extra.chartType,
+    data: () => (extra.dataView ? view : tree),
+  };
+  if (extra.dataView) {
+    chart.getSeriesCount = () => 1;
+    chart.getSeriesAt = () => ({
+      seriesType: () => 'column',
+      data: () => view,
+      name: () => 'Series 1',
+    });
+  }
+  if (!extra.noLabelsMode)
+    chart.labelsMode = () => 'outside';
+  return chart as unknown as AnyChartInstance;
+}
+
+function nodesOf(chart: AnyChartInstance): TreemapPoint[] {
+  const maidr = anyChartToMaidr(chart);
+  return maidr!.subplots[0][0].layers[0].data as TreemapPoint[];
+}
+
+/**
+ * A rendered packing: one `<circle>` per entry, at the given radius, inside a
+ * single AnyChart layer. The backdrop is a `<path>`, as on a real chart, so it
+ * is never a candidate.
+ *
+ * @param id    - The container id
+ * @param radii - One radius per circle, in the order they are drawn
+ * @returns The container and the circles
+ */
+function createRendered(
+  id: string,
+  radii: number[],
+): { container: HTMLElement; circles: SVGElement[] } {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  const backdrop = document.createElementNS(SVG_NS, 'path');
+  backdrop.id = 'ac_path_0_0';
+  backdrop.setAttribute('fill', '#ffffff');
+  svg.appendChild(backdrop);
+
+  const layer = document.createElementNS(SVG_NS, 'g');
+  layer.id = 'ac_layer_1';
+  svg.appendChild(layer);
+  const circles = radii.map((r, i) => {
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.id = `ac_circle_1_${i}`;
+    circle.setAttribute('r', String(r));
+    circle.setAttribute('fill', '#64b5f6');
+    layer.appendChild(circle);
+    return circle as unknown as SVGElement;
+  });
+
+  return { container, circles };
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+/** Two multi-child subtrees, captured from the browser measurement. */
+const WIDE: NodeSpec[] = [{
+  name: 'R',
+  children: [
+    { name: 'X', children: [{ name: 'X1', value: 9 }, { name: 'X2', value: 23 }] },
+    { name: 'Y', children: [
+      { name: 'Y1', value: 7 },
+      { name: 'Y2', value: 41 },
+      { name: 'Y3', value: 2 },
+    ] },
+  ],
+}];
+
+/**
+ * The radii the browser drew `WIDE` at, in draw order, to four decimals:
+ * `R, Y, Y2, Y1, Y3, X, X2, X1`.
+ */
+const WIDE_RADII = [147.5, 70.4766, 41.3088, 17.0687, 9.1236, 56.3813, 29.3892, 18.3842];
+
+const ATTR = 'data-maidr-anychart-pack-node';
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('anyChartToMaidr (circle packing)', () => {
+  it('reads the hierarchy the circles draw, rather than nothing at all', () => {
+    const maidr = anyChartToMaidr(createPackingChart(WIDE));
+
+    expect(maidr!.subplots[0][0].layers.map(layer => layer.type))
+      .toEqual([TraceType.PACK]);
+  });
+
+  it('is a pack rather than a treemap, being drawn as nested circles', () => {
+    // The same hierarchy, and the trace type is what the reader is told is on
+    // the page (#1153).
+    const [layer] = anyChartToMaidr(createPackingChart(WIDE))!.subplots[0][0].layers;
+
+    expect(layer.type).toBe(TraceType.PACK);
+  });
+
+  it('orders each parent\'s children largest first, as the packing draws them', () => {
+    // NOT the declared order: `X` is declared before `Y` and drawn after it,
+    // because `Y` totals 50 against `X`'s 32. Reading the tree's own order
+    // would announce every node against its neighbour's circle.
+    const nodes = nodesOf(createPackingChart(WIDE));
+
+    expect(nodes.map(node => node.x))
+      .toEqual(['R', 'Y', 'Y2', 'Y1', 'Y3', 'X', 'X2', 'X1']);
+  });
+
+  it('gives every node its ancestors and its own magnitude only', () => {
+    const nodes = nodesOf(createPackingChart(WIDE));
+
+    expect(nodes).toEqual([
+      { x: 'R', path: [] },
+      { x: 'Y', path: ['R'] },
+      { x: 'Y2', y: 41, path: ['R', 'Y'] },
+      { x: 'Y1', y: 7, path: ['R', 'Y'] },
+      { x: 'Y3', y: 2, path: ['R', 'Y'] },
+      { x: 'X', path: ['R'] },
+      { x: 'X2', y: 23, path: ['R', 'X'] },
+      { x: 'X1', y: 9, path: ['R', 'X'] },
+    ]);
+  });
+
+  it('sizes an interior node by its subtree, without announcing that total', () => {
+    // `Y` is drawn at the size of 50 and states no value of its own. The
+    // derived figure orders it and checks its circle; it is never emitted,
+    // because the chart does not say it.
+    const nodes = nodesOf(createPackingChart([{
+      name: 'R',
+      children: [
+        { name: 'Small', value: 3 },
+        { name: 'Big', children: [{ name: 'Leaf', value: 90 }] },
+      ],
+    }]));
+
+    expect(nodes.map(node => node.x)).toEqual(['R', 'Big', 'Leaf', 'Small']);
+    expect(nodes[1]).toEqual({ x: 'Big', path: ['R'] });
+  });
+
+  it('drops a subtree the packing draws no circle for', () => {
+    // Measured: `[R, A=30, E, E1]` -- where `E` and `E1` declare no value
+    // anywhere -- came back as TWO circles, the root and `A`. Keeping the
+    // empty branch would announce a part of the chart the reader is not being
+    // shown, and would leave the nodes and the circles out of step.
+    const nodes = nodesOf(createPackingChart([{
+      name: 'R',
+      children: [
+        { name: 'A', value: 30 },
+        { name: 'E', children: [{ name: 'E1' }] },
+      ],
+    }]));
+
+    expect(nodes.map(node => node.x)).toEqual(['R', 'A']);
+  });
+
+  it('names its dimensions, having no axis to borrow a title from', () => {
+    const [layer] = anyChartToMaidr(createPackingChart(WIDE))!.subplots[0][0].layers;
+
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Value' } });
+  });
+});
+
+describe('a circle packing the drawing cannot settle', () => {
+  it('is not read when two of a parent\'s children are the same size', () => {
+    // Measured: `A` and `B` at 20 apiece came back as two circles of radius
+    // 64.3292, one left and one right, and a packing labels only its root.
+    // Announcing `A` over `B`'s circle is worse than announcing nothing.
+    expect(anyChartToMaidr(createPackingChart([{
+      name: 'R',
+      children: [{ name: 'A', value: 20 }, { name: 'B', value: 20 }],
+    }]))).toBeNull();
+  });
+
+  it('is not read when a tie is buried deeper in the tree', () => {
+    // The tie need not be at the top: two grandchildren of equal size are as
+    // indistinguishable as two children.
+    expect(anyChartToMaidr(createPackingChart([{
+      name: 'R',
+      children: [
+        { name: 'Top', value: 99 },
+        { name: 'Pair', children: [{ name: 'L', value: 4 }, { name: 'M', value: 4 }] },
+      ],
+    }]))).toBeNull();
+  });
+});
+
+describe('what is not a circle packing', () => {
+  it('leaves a chart that names a type alone', () => {
+    // `getType()` answers `undefined` on a real packing. A chart that DOES
+    // name one has already been claimed by the branch for that name -- and an
+    // undrawn treemap, whose name is unavailable, must not fall in here.
+    expect(anyChartToMaidr(createPackingChart(WIDE, { chartType: 'tree-map' })))
+      .toBeNull();
+  });
+
+  it('leaves a chart without the one method that identifies one alone', () => {
+    expect(anyChartToMaidr(createPackingChart(WIDE, { noLabelsMode: true })))
+      .toBeNull();
+  });
+
+  it('leaves a chart with a data view to be read as the chart it is', () => {
+    // The structural half of the detection. A chart carrying `labelsMode`
+    // and no type name but a data view and a series is an ordinary chart:
+    // claiming it here would take its own reading away, and its stampers
+    // with it.
+    const layers = anyChartToMaidr(createPackingChart(WIDE, { dataView: true }))
+      ?.subplots[0][0]
+      .layers ?? [];
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.BAR]);
+  });
+});
+
+describe('a circle packing\'s highlight', () => {
+  it('points at one circle per node, in the order they are drawn', () => {
+    const { container, circles } = createRendered('cp-1', WIDE_RADII);
+    const chart = createPackingChart(WIDE, { container });
+
+    bindAnyChart(chart, { id: 'cp-1' });
+
+    expect(circles.map(circle => circle.getAttribute(ATTR)))
+      .toEqual(['0', '1', '2', '3', '4', '5', '6', '7']);
+    cleanUp(container);
+  });
+
+  it('resolves each selector to exactly the circle it names', () => {
+    const { container } = createRendered('cp-2', WIDE_RADII);
+    const chart = createPackingChart(WIDE, { container });
+
+    const maidr = anyChartToMaidr(chart, { id: 'cp-2' });
+    bindAnyChart(chart, { id: 'cp-2' });
+
+    const selectors = maidr!.subplots[0][0].layers[0].selectors as string[];
+    expect(selectors).toHaveLength(8);
+    expect(selectors.map(selector => document.querySelectorAll(selector).length))
+      .toEqual([1, 1, 1, 1, 1, 1, 1, 1]);
+    cleanUp(container);
+  });
+
+  it('withdraws when a circle is not the size its node says', () => {
+    // The check that makes the pairing a claim rather than a guess. Two of
+    // `Y`'s children swapped: the order is still plausible and the count still
+    // matches, but `r / sqrt(total)` no longer agrees across the group.
+    const swapped = [...WIDE_RADII];
+    [swapped[3], swapped[4]] = [swapped[4], swapped[3]];
+    const { container, circles } = createRendered('cp-3', swapped);
+    const chart = createPackingChart(WIDE, { container });
+
+    bindAnyChart(chart, { id: 'cp-3' });
+
+    expect(circles.some(circle => circle.hasAttribute(ATTR))).toBe(false);
+    cleanUp(container);
+  });
+
+  it('names the mismatch when the chart drew a different number of circles', () => {
+    // Counted before the radii are compared, and the count is what the
+    // message is worth. Every stamper runs inside a `try`, so leaving this to
+    // the radius check -- which reads one circle per node and would run off
+    // the end of a short list -- withdraws the highlight either way. What
+    // changes is what the caller is told: two figures they can act on, or a
+    // caught `TypeError`.
+    const { container, circles } = createRendered('cp-4', WIDE_RADII.slice(0, 6));
+    const chart = createPackingChart(WIDE, { container });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    bindAnyChart(chart, { id: 'cp-4' });
+
+    expect(circles.some(circle => circle.hasAttribute(ATTR))).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('8 nodes to the 6 circles'),
+    );
+    cleanUp(container);
+  });
+
+  it('rebinds quietly, resolving the circles it already stamped', () => {
+    const { container, circles } = createRendered('cp-5', WIDE_RADII);
+    const chart = createPackingChart(WIDE, { container });
+
+    bindAnyChart(chart, { id: 'cp-5' });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    bindAnyChart(chart, { id: 'cp-5' });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(circles.map(circle => circle.getAttribute(ATTR)))
+      .toEqual(['0', '1', '2', '3', '4', '5', '6', '7']);
+    cleanUp(container);
+  });
+});

--- a/test/adapters/anychart/sunburst.test.ts
+++ b/test/adapters/anychart/sunburst.test.ts
@@ -13,10 +13,12 @@
  * 99, 132, 66 -- `R, A, A1, A1a, B`, the first and not the second. `sort()`
  * reorders the rings around the circle and leaves the drawing order alone.
  *
- * A circle packing orders its circles by magnitude instead and labels only its
- * root, and a treemap draws an aggregate -- `maxDepth` defaults to 1, so an
- * interior node stands in for its whole subtree. Both are left unread rather
- * than half-read, which the last case here holds to.
+ * A treemap draws an aggregate instead -- `maxDepth` defaults to 1, so an
+ * interior node stands in for its whole subtree -- and is left unread rather
+ * than half-read, which the last case here holds to. A circle packing also
+ * orders its circles by magnitude rather than by the tree, which looked like
+ * the same refusal until the order turned out to be checkable against the
+ * radii; it has a reading of its own in `circlePacking.test.ts`.
  */
 
 import type { AnyChartInstance, AnyChartTreeItem } from '@adapters/anychart/types';
@@ -325,7 +327,7 @@ describe('a sunburst\'s highlight', () => {
   });
 });
 
-describe('the two hierarchy charts that are not read', () => {
+describe('the hierarchy chart that is not read', () => {
   it('leaves a treemap alone, because its default view is an aggregate', () => {
     // `maxDepth` defaults to 1, so a three-level tree draws two leaves and one
     // interior node carrying its children's total. Announcing the whole
@@ -335,10 +337,10 @@ describe('the two hierarchy charts that are not read', () => {
       .toBeNull();
   });
 
-  it('leaves a circle packing alone, because nothing says which circle is which', () => {
-    // One circle per node, but ordered by magnitude rather than by the tree,
-    // and only the root is labelled. Pairing them by position would give every
-    // node but the root the wrong outline.
+  it('does not claim a circle packing either, which has a reading of its own', () => {
+    // A packing names no type at all, so it never reaches the sunburst branch.
+    // It is read as a `pack` instead -- see `circlePacking.test.ts`, which
+    // covers why its order can be paired with its circles after all.
     expect(anyChartToMaidr(createHierarchyChart(COMPANY, { chartType: 'circle-packing' })))
       .toBeNull();
   });


### PR DESCRIPTION
Follow-up to #1171, which read AnyChart's sunburst and left the other two hierarchy charts alone. One of those refusals turns out to have been half true.

#1171 declined the circle packing because it "orders them by magnitude rather than by the tree and labels only its root, so nothing on the chart says which circle is which node." The first half is right; the conclusion is not. The order is not arbitrary, and the sizes say what it is.

## What was measured

**The order.** Depth first, with each parent's children largest first. Measured in Chromium across four tree shapes:

| tree | declared | drawn |
| --- | --- | --- |
| deep chain beside a shallow sibling | `R, A, A1, A1a(13), B(61)` | `R, B, A, A1, A1a` |
| ascending declared order | `R, P(5), Q(17), S(44)` | `R, S, Q, P` |
| two multi-child subtrees | `R, X(→32), …, Y(→50), …` | `R, Y, Y2, Y1, Y3, X, X2, X1` |
| tied siblings | `R, A(20), B(20)` | two circles of identical radius |

**The sizes.** A packing sizes a circle by the square root of its magnitude, so within one parent's children `r / sqrt(total)` is one constant. On the four-child case: `70.4766/√50 = 56.3813/√32 = 9.97`, and among `Y`'s children `41.3088/√41 = 17.0687/√7 = 9.1236/√2 = 6.45`. Every group, every tree, to four significant figures.

## So the pairing is checked, not assumed

The order gives a candidate pairing and the radii confirm it before anything is stamped. That is the difference between this and reading the order out of AnyChart's documentation: if its packing ever ordered siblings differently, the ratio check fails and the chart loses its **highlight** rather than quietly moving it onto the wrong circle. A test swaps two circles of the same group to pin exactly that.

## Three cases the drawing settles

- **A subtree with no magnitude is dropped**, because the packing draws no circle for one. Measured: `[R, A=30, E, E1]` — where `E` and `E1` declare no value anywhere — came back as **two** circles. Keeping them would have announced a part of the chart the reader is not being shown, and left the nodes and circles out of step. This one was found by the mutation sweep, not by the first draft.
- **An interior node is sized by its subtree, and never announced with that total.** The derived figure orders the siblings and checks the circle; the node's own value stays absent exactly as it is written, the same line #1171 drew for the sunburst.
- **A tie is refused.** Two children of one parent with the same magnitude are drawn as two circles of the same radius, and a packing labels only its root — so nothing says which is which. That chart binds as nothing rather than announcing one node's name over another's circle.

## Detection

A circle packing is the one chart here that reports **no `getType()` at all**, and `toJson()` throws on it too, so the name every other detection asks for does not exist. It is identified by `labelsMode()` — its own label placement, and the only public method the other two hierarchy charts lack — corroborated structurally by having no series API and a tree on `data()`. Requiring the type name to be *absent* keeps an undrawn treemap out, since `readChartType` answers `''` on a chart that has not been drawn.

The treemap stays unread, for the reason #1171 gave: `maxDepth` defaults to 1, so an interior node stands in for its whole subtree.

## Verification

- End to end in Chromium: the four trees above read correctly, and on a page with one chart all eight selectors resolve to exactly one circle each.
- 17 new unit cases in `test/adapters/anychart/circlePacking.test.ts`; `sunburst.test.ts`'s decline block updated.
- **16 mutations, all killed** — including three the first sweep left alive, one of which was the empty-subtree defect above. Another showed the count check is behaviourally redundant given the stamper's `try`, so what the test now pins is its message: two figures a caller can act on rather than a caught `TypeError`.
- Full gate green: `eslint`, `tsc --noEmit`, `npm run build`, `npm run docs`, `npm test` — 409 suites / 5650 tests, ESM 10 / 137.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_