### PR TITLE
feat(google-charts): read a BubbleChart as the scatter it draws

### DIFF
--- a/docs/google-charts.md
+++ b/docs/google-charts.md
@@ -84,6 +84,7 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
 | Column | `ColumnChart` | `'ColumnChart'` |
 | Line | `LineChart` | `'LineChart'` |
 | Scatter | `ScatterChart` | `'ScatterChart'` |
+| Bubble | `BubbleChart` | `'BubbleChart'` |
 | Candlestick | `CandlestickChart` | `'CandlestickChart'` |
 | Stacked Column | `ColumnChart` + `isStacked: true` | `'StackedColumnChart'` |
 | Dodged/Grouped Column | `ColumnChart` (multi-series) | `'DodgedColumnChart'` |
@@ -113,9 +114,11 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
 | Manhattan | `ScatterChart` with one series per chromosome | `'ManhattanChart'` |
 | Tree | `OrgChart` (`orgchart` package) — people joined by manager pointers | `'OrgChart'` |
 
-**Not supported:** Histogram (Google Charts API doesn't expose bin boundaries), Heatmap (not a native Google Charts type).
+**Not supported:** Histogram (Google Charts API doesn't expose bin boundaries), Heatmap (not a native Google Charts type), Calendar.
 
 > **Stacking note:** the adapter is handed the chart, the DataTable and the container, but never the draw options — so `isStacked` is invisible to it. That is why a stacked or percent-stacked chart is named by its own `chartType` string rather than detected. Passing `'AreaChart'` for a chart drawn with `isStacked: true` is not a cosmetic mistake: the bands would be announced as independent series, and the running total a sighted reader sees along the top edge would go missing entirely.
+
+> **Bubble note:** Google's bubble table is `[ID, x, y, group?, size?]`, and it is read as a scatter — which is what it is, with more carried per point. The ID becomes the point's **name**, announced alongside its coordinates, and the **size** becomes `z`, which is sonified as well as read, so a big bubble sounds like one. The last two columns are optional and are read by **type** rather than by position: Google lets column 3 be either a series name or a number picking a colour off a gradient, so a number there is treated as a magnitude and used for `z` when there is no size column, while a size column always wins over it — there is one `z`, and the size is what the chart is named for. Whichever column supplies it names the `z` axis, so a reader is told *Population* or *Temperature* rather than left to guess. `[ID, x, y]` alone is legal and reads as a plain named scatter. **The series column is not announced:** MAIDR's scatter reads a point's name, its two coordinates and `z`, and nothing else, so a group in the payload would be a field no reader is ever told about; recognising a string column 3 keeps it from being mistaken for a magnitude, and that is all it does.
 
 > **Interval note:** intervals are the one variant the adapter *can* detect, because `role: 'interval'` columns live in the DataTable rather than in the options. A single-series chart declaring them becomes an error bar layer: left and right walk the samples, up and down walk the lower bound, the estimate, and the upper bound. Two interval pairs (a 95% band drawn inside a 99% one) are read as the outermost, and a single interval column is read as the one bound it is, chosen by which side of the estimate it falls on. A **multi-series** chart with intervals keeps its previous reading — `ErrorBarPoint[]` is flat, so a second estimate column has nowhere to go, and losing a series is worse than losing its intervals. Highlighting uses the chart's own point markers, so draw with `pointSize` set; the audio, text and braille do not depend on it.
 

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -688,6 +688,11 @@ function buildLayer(
       return buildPieLayer(dt, container);
     case 'ScatterChart':
       return buildScatterLayer(chart, dt, container);
+    // A bubble is a scatter carrying more per point, not a different chart:
+    // the ID is the point's name, and the group and the size are fields
+    // `ScatterPoint` already has (#1174).
+    case 'BubbleChart':
+      return buildBubbleLayer(chart, dt, container);
     // Both are scatters read through a threshold, and one class reads them:
     // they differ in what the x axis means and in nothing a reader navigates.
     case 'VolcanoChart':
@@ -742,7 +747,8 @@ function buildLayer(
     default:
       throw new Error(
         `Unsupported Google Charts type: ${chartType as string}. `
-        + 'Supported types: AreaChart, BarChart, BumpChart, CandlestickChart, ColumnChart, '
+        + 'Supported types: AreaChart, BarChart, BubbleChart, BumpChart, CandlestickChart, '
+        + 'ColumnChart, '
         + 'DivergingBarChart, DivergingColumnChart, DodgedBarChart, DodgedColumnChart, '
         + 'DotChart, DumbbellChart, FunnelChart, Gantt, Gauge, GeoChart, LineChart, '
         + 'LollipopChart, ManhattanChart, NormalizedAreaChart, OrgChart, PieChart, Sankey, '
@@ -1113,6 +1119,117 @@ function buildScatterLayer(
     axes: {
       x: { label: dt.getColumnLabel(0) || undefined },
       y: { label: dt.getColumnLabel(1) || undefined },
+    },
+    data,
+  };
+}
+
+/**
+ * Builds a scatter layer from a Google Charts `BubbleChart`.
+ *
+ * A bubble chart is a scatter that carries more per point than a position,
+ * and every one of the extras already has a home. Google fixes the first
+ * three columns and admits two more (BubbleChart, "Data Format"):
+ *
+ * ```
+ * [ ID, x, y, group?, size? ]
+ * ```
+ *
+ * | column | field | what already reads it |
+ * |---|---|---|
+ * | 0 — ID | {@link ScatterPoint.label} | `ScatterTrace` announces it as the point's name |
+ * | 1 — x | {@link ScatterPoint.x} | |
+ * | 2 — y | {@link ScatterPoint.y} | |
+ * | 3 — group | *not emitted* — see below |
+ * | 4 — size | {@link ScatterPoint.z} | #826 — `zIntensityFor()`, so it is *audible* |
+ *
+ * The same reading Chart.js already gives its own `bubble` type, which
+ * `chartjs/extractor.ts` maps alongside `'scatter'` onto `TraceType.SCATTER`
+ * and whose radius it keeps.
+ *
+ * **Columns 3 and 4 are both optional and are read by type rather than by
+ * position.** Google lets column 3 be either a string, which names the
+ * series a bubble belongs to, or a number, which picks a colour off a
+ * gradient. A number there is a magnitude, and it becomes `z` only when
+ * column 4 — the size — is absent. When both are numbers the **size** wins,
+ * because the size is what the chart is named for and what a sighted reader
+ * takes off the mark's area, and there is one `z` to put it in. Whichever
+ * column supplies it also names `axes.z`, so a reader is told "Population"
+ * or "Temperature" rather than left to guess which third quantity they are
+ * hearing.
+ *
+ * `[ID, x, y]` alone is legal and reads as a plain named scatter.
+ *
+ * **The group is deliberately not emitted.** `group` is declared on
+ * {@link VolcanoPoint}, not on {@link ScatterPoint}, and `VolcanoTrace` is
+ * the only thing that reads it — `ScatterTrace` announces `label`, the two
+ * coordinates and `z`, and nothing else. Putting a series name in the
+ * payload would add a field no reader is told, which looks like coverage and
+ * is not. A string column 3 is therefore recognised only so it is not
+ * mistaken for a magnitude. Carrying it properly means promoting `group` to
+ * `ScatterPoint` and teaching `ScatterTrace` to announce it — the same move
+ * {@link ScatterPoint.label} records having already been made, and one that
+ * changes every adapter's scatter rather than this one converter, so it is
+ * left to its own change (#1174).
+ *
+ * A `BubbleChart` is a **corechart** class, so unlike Sankey, TreeMap and
+ * Gantt it does expose `getChartLayoutInterface()`, and its circles are
+ * marked by {@link markScatterElements} exactly as a scatter's are.
+ *
+ * @param chart     - The Google Chart instance
+ * @param dt        - The DataTable the chart was drawn from
+ * @param container - The DOM container element
+ * @returns The MAIDR layer
+ */
+function buildBubbleLayer(
+  chart: GoogleChart,
+  dt: GoogleDataTable,
+  container: HTMLElement,
+): MaidrLayer {
+  const columns = dt.getNumberOfColumns();
+  // The size column when there is one, and otherwise a numeric column 3 --
+  // a gradient value is still a third magnitude, and naming the axis after
+  // its own column is what keeps that honest. A *string* column 3 is a
+  // series name and falls through to neither, which is what leaves it out.
+  const magnitudeCol = columns > 4 && dt.getColumnType(4) === 'number'
+    ? 4
+    : (columns > 3 && dt.getColumnType(3) === 'number' ? 3 : undefined);
+
+  const rows = dt.getNumberOfRows();
+  const data: ScatterPoint[] = [];
+
+  for (let r = 0; r < rows; r++) {
+    const point: ScatterPoint = {
+      x: numericValue(dt, r, 1),
+      y: numericValue(dt, r, 2),
+    };
+
+    const id = dt.getValue(r, 0);
+    if (typeof id === 'string' && id !== '') {
+      point.label = id;
+    }
+    if (magnitudeCol !== undefined) {
+      const z = numericValue(dt, r, magnitudeCol);
+      if (Number.isFinite(z)) {
+        point.z = z;
+      }
+    }
+
+    data.push(point);
+  }
+
+  const selector = markScatterElements(chart, container, data);
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.SCATTER,
+    ...(selector ? { selectors: selector } : {}),
+    axes: {
+      x: { label: dt.getColumnLabel(1) || undefined },
+      y: { label: dt.getColumnLabel(2) || undefined },
+      ...(magnitudeCol !== undefined
+        ? { z: { label: dt.getColumnLabel(magnitudeCol) || undefined } }
+        : {}),
     },
     data,
   };

--- a/src/adapters/google-charts/types.ts
+++ b/src/adapters/google-charts/types.ts
@@ -159,6 +159,15 @@ export type GoogleChartType
   = | 'AreaChart'
     | 'BarChart'
     /**
+     * A Google `BubbleChart`: a scatter whose points carry a name, a group
+     * and a size as well as a position.
+     *
+     * Read as a scatter rather than as a type of its own, because that is
+     * what it is — every extra column has a `ScatterPoint` field waiting for
+     * it, and the size becomes `z`, which is sonified.
+     */
+    | 'BubbleChart'
+    /**
      * A `LineChart` of ranks, drawn with `vAxis: {direction: -1}` so rank 1
      * sits at the top — a bump chart.
      *

--- a/test/adapters/google-charts/bubble.test.ts
+++ b/test/adapters/google-charts/bubble.test.ts
@@ -1,0 +1,229 @@
+/**
+ * A Google `BubbleChart` was refused outright — `createMaidrFromGoogleChart`
+ * threw `Unsupported Google Charts type` — so a caller got an exception
+ * rather than a chart (#1174).
+ *
+ * It is a scatter carrying more per point, not a different chart. Google
+ * fixes `[ID, x, y]` and admits two optional columns after them, and the
+ * ones MAIDR can read have homes already: the ID is
+ * {@link ScatterPoint.label}, which `ScatterTrace` announces as the point's
+ * name, and the size is {@link ScatterPoint.z}, which `zIntensityFor()`
+ * sonifies. The series column is left out on purpose — `group` belongs to
+ * `VolcanoPoint` and only `VolcanoTrace` reads it, so emitting one would put
+ * a field in the payload no reader is told about.
+ */
+import type {
+  GoogleBoundingBox,
+  GoogleChart,
+  GoogleChartType,
+  GoogleDataTable,
+} from '@adapters/google-charts/types';
+import type { ScatterPoint } from '@type/grammar';
+import { createMaidrFromGoogleChart } from '@adapters/google-charts/converters';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** The four-country table Google's own bubble example is drawn from. */
+const FULL_ROWS: (string | number)[][] = [
+  ['CAN', 80.66, 1.67, 'North America', 33739900],
+  ['DEU', 79.84, 1.36, 'Europe', 81902307],
+  ['DNK', 78.6, 1.84, 'Europe', 5523095],
+  ['EGY', 72.73, 2.78, 'Middle East', 79716203],
+];
+
+function table(
+  rows: (string | number)[][],
+  labels: string[],
+  types: string[],
+): GoogleDataTable {
+  return {
+    getNumberOfRows: () => rows.length,
+    getNumberOfColumns: () => labels.length,
+    getValue: (r: number, c: number) => rows[r][c],
+    getFormattedValue: (r: number, c: number) => String(rows[r][c] ?? ''),
+    getColumnLabel: (c: number) => labels[c],
+    getColumnType: (c: number) => types[c],
+    getColumnRole: () => '',
+  } as unknown as GoogleDataTable;
+}
+
+function fullTable(): GoogleDataTable {
+  return table(
+    FULL_ROWS,
+    ['ID', 'Life Expectancy', 'Fertility', 'Region', 'Population'],
+    ['string', 'number', 'number', 'string', 'number'],
+  );
+}
+
+function pointBox(row: number): GoogleBoundingBox {
+  return { left: 20 + row * 30, top: 40, width: 6, height: 6 };
+}
+
+function chartDrawing(rows: number): GoogleChart {
+  return {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => ({
+      getBoundingBox: (id) => {
+        const match = /^point#0#(\d+)$/.exec(id);
+        if (!match || Number(match[1]) >= rows) {
+          return null;
+        }
+        return pointBox(Number(match[1]));
+      },
+      getXLocation: value => Number(value),
+      getYLocation: value => Number(value),
+    }),
+  };
+}
+
+function containerDrawing(rows: number): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="c"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('c') as HTMLElement;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  for (let r = 0; r < rows; r++) {
+    const box = pointBox(r);
+    const circle = doc.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('cx', `${box.left + box.width / 2}`);
+    circle.setAttribute('cy', `${box.top + box.height / 2}`);
+    svg.appendChild(circle);
+  }
+  return container;
+}
+
+function build(dt: GoogleDataTable, rows = dt.getNumberOfRows()): {
+  type: TraceType;
+  data: ScatterPoint[];
+  axes: Record<string, { label?: string }>;
+  selectors: unknown;
+} {
+  const maidr = createMaidrFromGoogleChart(
+    chartDrawing(rows),
+    dt,
+    containerDrawing(rows),
+    { chartType: 'BubbleChart' as GoogleChartType, title: 'bubbles' },
+  );
+  const layer = maidr.subplots[0][0].layers[0];
+  return {
+    type: layer.type,
+    data: layer.data as ScatterPoint[],
+    axes: layer.axes as Record<string, { label?: string }>,
+    selectors: layer.selectors,
+  };
+}
+
+describe('google charts bubble chart', () => {
+  it('is read rather than refused', () => {
+    expect(() => build(fullTable())).not.toThrow();
+  });
+
+  it('is a scatter, which is what it is drawn from', () => {
+    expect(build(fullTable()).type).toBe(TraceType.SCATTER);
+  });
+
+  it('takes its position from columns 1 and 2, not from the ID column', () => {
+    const { data } = build(fullTable());
+    expect(data.map(p => [p.x, p.y])).toEqual([
+      [80.66, 1.67],
+      [79.84, 1.36],
+      [78.6, 1.84],
+      [72.73, 2.78],
+    ]);
+  });
+
+  it('names each point from the ID column', () => {
+    expect(build(fullTable()).data.map(p => p.label))
+      .toEqual(['CAN', 'DEU', 'DNK', 'EGY']);
+  });
+
+  it('carries the size as z, which is what makes it audible', () => {
+    expect(build(fullTable()).data.map(p => p.z))
+      .toEqual([33739900, 81902307, 5523095, 79716203]);
+  });
+
+  it('names the z axis after the column the magnitude came from', () => {
+    const { axes } = build(fullTable());
+    expect(axes.x.label).toBe('Life Expectancy');
+    expect(axes.y.label).toBe('Fertility');
+    expect(axes.z.label).toBe('Population');
+  });
+
+  it('does not put the series column in the payload', () => {
+    // `group` is `VolcanoPoint`'s and only `VolcanoTrace` reads it. A field
+    // no reader is told about is not coverage.
+    for (const point of build(fullTable()).data) {
+      expect(point).not.toHaveProperty('group');
+    }
+  });
+
+  it('reads a three-column table as a plain named scatter', () => {
+    const { data, axes } = build(table(
+      [['CAN', 80.66, 1.67], ['DEU', 79.84, 1.36]],
+      ['ID', 'Life Expectancy', 'Fertility'],
+      ['string', 'number', 'number'],
+    ));
+    expect(data).toEqual([
+      { x: 80.66, y: 1.67, label: 'CAN' },
+      { x: 79.84, y: 1.36, label: 'DEU' },
+    ]);
+    expect(axes.z).toBeUndefined();
+  });
+
+  it('reads a numeric column 3 as the magnitude when there is no size column', () => {
+    // Google lets column 3 be a number, which picks a colour off a gradient.
+    // That is still a third quantity per point, and naming the axis after its
+    // own column is what keeps saying so honest.
+    const { data, axes } = build(table(
+      [['CAN', 80.66, 1.67, 12.5], ['DEU', 79.84, 1.36, 3.25]],
+      ['ID', 'Life Expectancy', 'Fertility', 'Temperature'],
+      ['string', 'number', 'number', 'number'],
+    ));
+    expect(data.map(p => p.z)).toEqual([12.5, 3.25]);
+    expect(axes.z.label).toBe('Temperature');
+  });
+
+  it('prefers the size over a numeric column 3 when a table carries both', () => {
+    // There is one `z`, and the size is what the chart is named for and what
+    // a sighted reader takes off the mark's area.
+    const { data, axes } = build(table(
+      [['CAN', 80.66, 1.67, 12.5, 33739900]],
+      ['ID', 'Life Expectancy', 'Fertility', 'Temperature', 'Population'],
+      ['string', 'number', 'number', 'number', 'number'],
+    ));
+    expect(data[0].z).toBe(33739900);
+    expect(axes.z.label).toBe('Population');
+  });
+
+  it('ignores a string column 3 rather than reading it as a magnitude', () => {
+    const { data, axes } = build(table(
+      [['CAN', 80.66, 1.67, 'North America']],
+      ['ID', 'Life Expectancy', 'Fertility', 'Region'],
+      ['string', 'number', 'number', 'string'],
+    ));
+    expect(data[0].z).toBeUndefined();
+    expect(axes.z).toBeUndefined();
+  });
+
+  it('leaves a point unnamed when the ID cell is empty', () => {
+    const { data } = build(table(
+      [['', 80.66, 1.67, 'NA', 1], ['DEU', 79.84, 1.36, 'EU', 2]],
+      ['ID', 'Life Expectancy', 'Fertility', 'Region', 'Population'],
+      ['string', 'number', 'number', 'string', 'number'],
+    ));
+    expect(data[0]).not.toHaveProperty('label');
+    expect(data[1].label).toBe('DEU');
+  });
+
+  it('marks the circles it drew, one per bubble', () => {
+    // A `BubbleChart` is a corechart class, so unlike Sankey and TreeMap it
+    // does expose `getChartLayoutInterface()` and the circles can be matched
+    // by their bounding box rather than only by DOM order.
+    const { selectors } = build(fullTable());
+    expect(selectors).toBeDefined();
+  });
+});


### PR DESCRIPTION
First half of #1174. The `Calendar` half is separate and needs its own measurement.

## What was wrong

```
### BubbleChart    THREW Unsupported Google Charts type: BubbleChart. Supported types: AreaChart, …
### ScatterChart   point n=3 {"x":80,"y":167}
```

A caller passing `'BubbleChart'` got an exception rather than a chart. The name appears nowhere under `src/adapters/google-charts/`, and `docs/google-charts.md`'s "Not supported" line does not mention it either — it was declined **by omission** rather than on purpose, unlike Histogram and Heatmap, which the guide names and explains.

## The reading

A bubble chart is a scatter carrying more per point, not a different chart. Google fixes `[ID, x, y]` and admits two optional columns after them, and the ones MAIDR can read have homes already:

| Google column | field | what already reads it |
|---|---|---|
| 0 — ID | `ScatterPoint.label` | `ScatterTrace` announces it as the point's name |
| 1 — x | `ScatterPoint.x` | |
| 2 — y | `ScatterPoint.y` | |
| 3 — group | *not emitted* | see below |
| 4 — size | `ScatterPoint.z` | #826 — `zIntensityFor()`, so a big bubble **sounds** like one |

Same reading Chart.js already gives its own `bubble` type, which `chartjs/extractor.ts` maps alongside `'scatter'` onto `TraceType.SCATTER` and whose radius it keeps. A `BubbleChart` is a **corechart** class, so unlike Sankey/TreeMap/Gantt it exposes `getChartLayoutInterface()` and `markScatterElements` marks its circles the same way it marks a scatter's.

**Columns 3 and 4 are read by type, not by position.** Google lets column 3 be either a string naming the series or a number picking a colour off a gradient. A number there is a third magnitude and supplies `z` when there is no size column; a size column always wins over it — there is one `z`, and the size is what the chart is named for and what a sighted reader takes off the mark's area. Whichever column supplies it names `axes.z`, so a reader is told *Population* or *Temperature* rather than left to guess.

## Why the group is deliberately dropped

`group` is declared on `VolcanoPoint`, not on `ScatterPoint`, and `VolcanoTrace` is the only thing that reads it — `ScatterTrace` announces `label`, the two coordinates and `z`, and nothing else. Emitting a series name would put a field in the payload no reader is ever told about, which looks like coverage and is not. A string column 3 is recognised only so it cannot be mistaken for a magnitude.

Carrying it properly means promoting `group` to `ScatterPoint` and teaching `ScatterTrace` to announce it — the same move `ScatterPoint.label` records having already been made, and one that changes every adapter's scatter rather than this one converter. Left to its own change; recorded in the code, in the docs and in #1174.

## A note on how this was measured

The adapter's whole test suite drives `createMaidrFromGoogleChart` with fake `DataTable`s, and this follows that idiom — every behaviour below is measured through the adapter. The **column layout** itself is Google's documented BubbleChart data format rather than something read off a live chart: Chromium's CONNECT to `gstatic.com` is reset by this sandbox's egress proxy (`curl` reaches it, the browser does not), so a live draw was not available. Flagging it rather than implying otherwise.

## Tests

`test/adapters/google-charts/bubble.test.ts`, 13 cases: read rather than refused; is a scatter; position from columns 1–2 rather than 0–1; named from the ID column; size carried as `z`; `z` axis named from its own column; no `group` in the payload; a three-column table reads as a plain named scatter; a numeric column 3 supplies the magnitude when there is no size column; a size column wins when a table carries both; a string column 3 is ignored rather than read as a magnitude; an empty ID leaves the point unnamed; the circles are marked.

Mutation sweep, nine mutations, **all killed**:

| mutation | result |
|---|---|
| drop the dispatch case | KILLED (13) |
| route a bubble to the plain scatter builder | KILLED (8) |
| read x/y from columns 0 and 1 | KILLED (2) |
| never name a point from the ID column | KILLED (3) |
| name a point even when the ID cell is empty | KILLED (1) |
| prefer a numeric column 3 over the size column | KILLED (1) |
| take column 3 as the magnitude whatever its type | KILLED (1) |
| name the z axis after the size column always | KILLED (1) |
| emit z even when there is no magnitude column | KILLED (2) |

## Gate

`npx eslint src test` clean · `npx tsc --noEmit` clean · `npm run build` succeeded · `npm run docs` succeeded · `npm test` **411 suites / 5667 tests, all passing** (up from 410 / 5654 — the new suite and its 13 cases).

`docs/google-charts.md` gains a Bubble row and a Bubble note, and `Calendar` is added to the "Not supported" line so it is now declined on purpose rather than by omission.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_