### PR TITLE
feat(chartjs): read the error-bar controllers as the intervals they draw

### DIFF
--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -90,6 +90,7 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Radar | `'radar'` | — | [Radar chart](examples.html) |
 | Polar Area | `'polarArea'` | — | [Radar chart](examples.html) |
 | Box Plot | `'boxplot'` | `@sgratzl/chartjs-chart-boxplot` | [Box plot](examples.html) |
+| Error Bar | `'barWithErrorBars'`, `'lineWithErrorBars'`, `'scatterWithErrorBars'` | `chartjs-chart-error-bars` | [Error bar](examples.html) |
 | Candlestick | `'candlestick'` | `chartjs-chart-financial` + a date adapter | [Candlestick](examples.html) |
 | Heatmap | `'matrix'` | `chartjs-chart-matrix` | [Heatmap](examples.html) |
 | Treemap | `'treemap'` | `chartjs-chart-treemap` | [Treemap](examples.html) |
@@ -99,6 +100,8 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Gauge | `'doughnut'` with `circumference` under 360 and two values | — | [Gauge](examples.html) |
 
 > **Pie note:** a pie has no Chart.js scales, so there is no axis title to read. `axes.x` and `axes.y` default to `Category` and `Value`; set `plugins.maidr.axes` to name what the slice labels and their values actually mean. Multiple datasets are concentric rings, not slices of one circle — each becomes its own MAIDR layer with its own total and percentages, and Page Up / Page Down move between them.
+
+> **Error bar note:** the three cartesian controllers of `chartjs-chart-error-bars` all read the same way — an estimate and the interval around it — because the mark each draws at the estimate is not something a reader is told. Several datasets become one series each, every estimate naming its dataset, so a dodged interval chart keeps the comparison it was drawn for. A datum may carry **nested** intervals (`yMin: [8, 7]`); the outermost pair is announced, which is the interval the drawn whiskers reach, and the inner ones are not. A datum written as a plain number draws no whiskers and is announced as an estimate with no interval — which is not the same as an interval of width zero. `polarAreaWithErrorBars`, the plugin's fourth controller, is **not** read: a radial spoke has nowhere to carry a bound, so reading it would announce the estimate and drop the uncertainty.
 
 > **Radar note:** a radar and a polar area are drawn against a single radial `r` scale, so `axes.y` reads `scales.r.title.text` and `axes.x` defaults to `Category` — set `plugins.maidr.axes` to name what the spokes and their magnitudes mean. Both are read as a multi-series layer, one row per dataset and one column per spoke, with each spoke's stereo position following its angle rather than its index.
 

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -7,8 +7,9 @@
  *   waterfall, dumbbell), line (plain, stepped, area, stacked and normalized
  *   area, bump, dot, survival), scatter, bubble, pie, doughnut, gauge, radar,
  *   polarArea
- * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap), treemap, sankey,
- *   wordCloud
+ * - Plugin: boxplot, violin, candlestick/ohlc, matrix (heatmap), treemap,
+ *   sankey, wordCloud, and the cartesian error-bar controllers
+ *   (barWithErrorBars, lineWithErrorBars, scatterWithErrorBars)
  *
  * A type with no MAIDR trace behind it is rejected with an explicit error
  * rather than silently mapped to a bar chart. The three plugins #1108 named
@@ -17,7 +18,7 @@
  */
 
 import type { FieldRef, MaidrTraceDeclaration, ManhattanDeclaration, ScatterDeclaration, VolcanoDeclaration } from '../../type/declaration';
-import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, FlowPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallKind, WaterfallPoint, WordCloudPoint } from '../../type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, ErrorBarPoint, FlowPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallKind, WaterfallPoint, WordCloudPoint } from '../../type/grammar';
 import type { DeclarationContext } from '../shared/traceDeclaration';
 import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsPointValue, ChartJsRangeBound, ChartJsSankeyValue, ChartJsTreemapValue, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
@@ -804,6 +805,20 @@ function extractLayers(
       return extractRadarLayers(chart, TraceType.RADAR, pluginOptions);
     case 'polarArea':
       return extractRadarLayers(chart, TraceType.POLAR_AREA, pluginOptions);
+    // The three cartesian controllers of `chartjs-chart-error-bars`. All
+    // three parse the same way -- an estimate plus bounds on whichever axis
+    // carries the measurement -- so one reading serves them, and the mark
+    // each draws around the interval changes nothing a reader is told.
+    //
+    // `polarAreaWithErrorBars`, the plugin's fourth, is deliberately absent.
+    // It draws wedges with radial whiskers, and `RadarTrace` reads a spoke as
+    // `{x: angle, y: radius}` with nowhere to put a bound -- so reading it as
+    // a polar area would announce the estimate and drop the uncertainty the
+    // chart was drawn for. It keeps the explicit refusal below (#1176).
+    case 'barWithErrorBars':
+    case 'lineWithErrorBars':
+    case 'scatterWithErrorBars':
+      return extractErrorBarLayers(chart, pluginOptions, datasetIndices);
     case 'boxplot':
       return extractBoxplotLayers(chart, pluginOptions);
     // The boxplot plugin registers both, and a violin is the same summary with
@@ -826,7 +841,7 @@ function extractLayers(
         `MAIDR Chart.js adapter: unsupported chart type "${chartType}". `
         + 'Supported types: bar, line, scatter, bubble, pie, doughnut, radar, '
         + 'polarArea, boxplot, violin, candlestick, ohlc, matrix, treemap, sankey, '
-        + 'wordCloud.',
+        + 'wordCloud, barWithErrorBars, lineWithErrorBars, scatterWithErrorBars.',
       );
   }
 }
@@ -2376,6 +2391,183 @@ function extractPieLayers(
       data: points,
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Error bar chart extraction (chartjs-chart-error-bars plugin)
+// ---------------------------------------------------------------------------
+
+/**
+ * One end of an interval, as a single number.
+ *
+ * The plugin draws nested intervals -- a 95% inside a 99%, say -- from an
+ * array bound, and `ErrorBarPoint.yMin` is one number. Measured, the parse
+ * keeps the array *and* adds a scalar `yMinMin`/`yMaxMax`, which is the
+ * outermost pair:
+ *
+ *     {y: 10, yMin: [8, 7], yMax: [13, 14], yMinMin: 7, yMaxMax: 14}
+ *
+ * The outermost is what is announced, because it is the interval the drawn
+ * whiskers reach. The inner ones are dropped, and that is a real loss rather
+ * than a rounding: a reader is told the widest interval and not that there
+ * were others.
+ *
+ * @param bound - The parsed bound, scalar or nested
+ * @param outermost - The parse's own `yMinMin`/`yMaxMax` for that bound
+ * @returns The bound to announce, or undefined when the datum has none
+ */
+function errorBarBound(
+  bound: number | number[] | null | undefined,
+  outermost: number | undefined,
+): number | undefined {
+  // `null` is a datum written as a plain number, which draws no whiskers;
+  // an object datum with no bounds omits the key. Both are "no interval",
+  // and neither is the same as an interval of width zero.
+  if (bound == null)
+    return undefined;
+  if (Array.isArray(bound))
+    return outermost;
+  return Number.isFinite(bound) ? bound : undefined;
+}
+
+/**
+ * The positions one error-bar dataset drew, in the order they are drawn.
+ *
+ * Exported because the highlight half has to walk them the same way: the
+ * plugin outlines by index through the table `computeTargetMaps` builds, and
+ * a table built by a different walk names a different mark from the one the
+ * payload announces (#1024). Sharing this is what keeps the two paired.
+ *
+ * @param chart - The Chart.js chart
+ * @param datasetIndex - Which dataset to walk
+ * @returns Its drawn positions, skipping any datum with no estimate
+ */
+export function drawnErrorBarIndices(
+  chart: ChartJsChart,
+  datasetIndex: number,
+): number[] {
+  const isHorizontal = chart.options.indexAxis === 'y';
+  const parsed = chart.getDatasetMeta(datasetIndex)?._parsed ?? [];
+  const drawn: number[] = [];
+  for (const i of drawnCategoryPositions(chart, parsed.length)) {
+    const estimate = isHorizontal ? parsed[i]?.x : parsed[i]?.y;
+    if (typeof estimate === 'number' && Number.isFinite(estimate))
+      drawn.push(i);
+  }
+  return drawn;
+}
+
+/**
+ * Reads the cartesian error-bar controllers as the intervals they draw.
+ *
+ * `barWithErrorBars`, `lineWithErrorBars` and `scatterWithErrorBars` differ
+ * only in the mark drawn at the estimate, which is not something a reader is
+ * told -- all three announce an estimate and the interval around it, which is
+ * `TraceType.ERROR_BAR` exactly.
+ *
+ * ## Why the parse and not `dataset.data`
+ *
+ * Both are available; the controller leaves `dataset.data` verbatim. Only the
+ * parse resolves the horizontal case. Measured on `indexAxis: 'y'`, the datum
+ * `{x: 10, xMin: 8, xMax: 13}` parses to `{y: 0, x: 10, xMin: 8, xMax: 13}` --
+ * the bounds and the value on X, the category on Y. Reading the raw rows would
+ * mean working out which axis is which a second time, and the parse has
+ * already done it.
+ *
+ * ## One layer per dataset when there are several
+ *
+ * A dodged interval chart puts two estimates at every category, and #942 added
+ * `ErrorBarPoint.z` precisely so they arrive distinguishable. So several
+ * datasets emit the grouped shape, one series each, every point naming its
+ * dataset; a single dataset emits the flat one and needs no name for its one
+ * group.
+ *
+ * ## What is not handled, because the plugin gets there first
+ *
+ * A `null` entry is not a gap to skip: the controller throws laying the chart
+ * out ("Cannot read properties of null") before MAIDR ever sees it. Measured,
+ * the same shape the sankey rows have.
+ *
+ * @param chart - The Chart.js chart
+ * @param pluginOptions - The MAIDR plugin options, for the axis labels
+ * @param datasetIndices - Collects which datasets back the emitted layer
+ * @returns One error-bar layer
+ */
+function extractErrorBarLayers(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
+): MaidrLayer[] {
+  // `indexAxis: 'y'` is Chart.js's own name for the horizontal reading, and
+  // it is what decides which axis carries the measurement -- so it is read
+  // from there rather than inferred from which bounds the parse happens to
+  // hold.
+  const isHorizontal = chart.options.indexAxis === 'y';
+  const labels = chart.data.labels ?? [];
+  const series: ErrorBarPoint[][] = [];
+  // Which dataset each emitted series came from. A dataset that drew nothing
+  // contributes no row, and recording the survivors is what keeps MAIDR row
+  // `n` pointing at the dataset that actually drew it -- the default is
+  // "every dataset, in order", which a skipped one puts out by one.
+  const backing: number[] = [];
+  const grouped = chart.data.datasets.length > 1;
+
+  for (let d = 0; d < chart.data.datasets.length; d++) {
+    const dataset = chart.data.datasets[d];
+    const parsed = chart.getDatasetMeta(d)?._parsed ?? [];
+    const points: ErrorBarPoint[] = [];
+
+    // The categories in drawn order, so a reversed axis reads the way it is
+    // drawn rather than the way it was written (#1024).
+    for (const i of drawnErrorBarIndices(chart, d)) {
+      const value = parsed[i];
+      // `drawnErrorBarIndices` has already accepted the estimate; this is
+      // the narrowing rather than a second test of it.
+      const estimate = (isHorizontal ? value?.x : value?.y) as number;
+
+      const min = isHorizontal
+        ? errorBarBound(value.xMin, value.xMinMin)
+        : errorBarBound(value.yMin, value.yMinMin);
+      const max = isHorizontal
+        ? errorBarBound(value.xMax, value.xMaxMax)
+        : errorBarBound(value.yMax, value.yMaxMax);
+
+      // A scatter names no categories, so its position is the number the
+      // other axis parsed to; a bar or line names them, and the label is
+      // what the reader is shown.
+      const position = labels[i] ?? (isHorizontal ? value.y : value.x) ?? i;
+
+      points.push({
+        x: position,
+        y: estimate,
+        ...(min !== undefined ? { yMin: min } : {}),
+        ...(max !== undefined ? { yMax: max } : {}),
+        ...(grouped && dataset.label !== undefined ? { z: dataset.label } : {}),
+      });
+    }
+
+    if (points.length > 0) {
+      series.push(points);
+      backing.push(d);
+    }
+  }
+  datasetIndices?.set('0', backing);
+
+  return [
+    {
+      id: '0',
+      type: TraceType.ERROR_BAR,
+      ...(chart.data.datasets.length === 1 && chart.data.datasets[0]?.label !== undefined
+        ? { title: chart.data.datasets[0].label }
+        : {}),
+      ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
+      axes: {
+        x: { label: getAxisLabel(chart, 'x', pluginOptions) },
+        y: { label: getAxisLabel(chart, 'y', pluginOptions) },
+      },
+      data: grouped ? series : (series[0] ?? []),
+    },
+  ];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -11,7 +11,7 @@
 import type { GanttData, HeatmapData, MaidrLayer, TreemapPoint } from '../../type/grammar';
 import type { ChartJsActiveElement, ChartJsChart, ChartJsDataset, ChartJsDataValue } from './types';
 import { TraceType } from '../../type/grammar';
-import { drawnCategoryPositions, isMatrixValue, isPointValue, isRangeValue, toFiniteNumber } from './extractor';
+import { drawnCategoryPositions, drawnErrorBarIndices, isMatrixValue, isPointValue, isRangeValue, toFiniteNumber } from './extractor';
 
 /**
  * Figure-unique layer id → original Chart.js dataset indices backing that
@@ -388,6 +388,21 @@ export function computeTargetMaps(
         barLineIndices.set(
           layer.id,
           dsIndices.map(dsIdx => finiteIndices(datasets[dsIdx]?.data ?? [])),
+        );
+        break;
+      }
+      // An interval chart is one MAIDR row per dataset, columns along the
+      // category axis -- the shape a line has. It cannot borrow the line
+      // branch's walk, though: that tests the raw entries with
+      // `toFiniteNumber`, which reads `.y` and so finds nothing at all on a
+      // horizontal chart, whose data carry the estimate on `x`. The
+      // extractor's own walk is shared instead, so the table and the payload
+      // cannot drift (#1176).
+      case TraceType.ERROR_BAR: {
+        const dsIndices = layerDatasetIndices.get(layer.id) ?? datasets.map((_, i) => i);
+        barLineIndices.set(
+          layer.id,
+          dsIndices.map(dsIdx => drawnErrorBarIndices(chart, dsIdx)),
         );
         break;
       }

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -403,6 +403,31 @@ export interface ChartJsParsedValue {
   items?: number[];
   /** A violin's density curve; absent on a boxplot. */
   coords?: ChartJsKdeCoord[];
+  /**
+   * The interval bounds `chartjs-chart-error-bars` parses onto a datum.
+   *
+   * Whichever axis carries the measurement carries the bounds: a vertical
+   * chart parses to `yMin`/`yMax`, and `indexAxis: 'y'` moves them to
+   * `xMin`/`xMax` along with the value itself. That is why the reading comes
+   * from here rather than from `dataset.data`, where working out which axis
+   * is which would have to be done again.
+   *
+   * An array is the plugin's nested-interval form -- a 95% inside a 99%, say.
+   * `yMinMin`/`yMaxMax` are then the outermost pair, and are scalars whether
+   * or not the bound is an array.
+   *
+   * `null` is a datum written as a plain number, which draws a bar with no
+   * whiskers; an object datum with no bounds omits the keys entirely. Both
+   * mean "no interval", which is why the test is `!= null` (#1176).
+   */
+  xMin?: number | number[] | null;
+  xMax?: number | number[] | null;
+  xMinMin?: number;
+  xMaxMax?: number;
+  yMin?: number | number[] | null;
+  yMax?: number | number[] | null;
+  yMinMin?: number;
+  yMaxMax?: number;
 }
 
 /**

--- a/test/adapters/chartjs/errorBars.test.ts
+++ b/test/adapters/chartjs/errorBars.test.ts
@@ -1,0 +1,325 @@
+/**
+ * The Chart.js adapter refused error-bar charts, though `error_bar` has
+ * existed since #789 (#1176).
+ *
+ * `chartjs-chart-error-bars` is the sibling of the boxplot plugin the adapter
+ * already reads, and `ErrorBarPoint` is `{x, y?, yMin?, yMax?, z?}` -- the
+ * exact shape its controllers parse into. An identical interval chart drawn
+ * in plotly, Vega-Lite or ggplot2 was navigable; only a Chart.js one raised.
+ *
+ * Measured against a running chart -- `chart.js@4.5` with
+ * `chartjs-chart-error-bars@4.4.5`, driven headlessly through Chart.js's own
+ * `BasicPlatform` -- and the fixtures below are what `_parsed` came back as:
+ *
+ *     barWithErrorBars      {x: 0, y: 10, yMin: 8, yMax: 13, yMinMin: 8, yMaxMax: 13}
+ *     lineWithErrorBars     the same
+ *     scatterWithErrorBars  the same plus xMin/xMax/xMinMin/xMaxMax
+ *     indexAxis: 'y'        {y: 0, x: 10, xMin: 8, xMax: 13, xMinMin: 8, xMaxMax: 13}
+ *
+ * Four things that decided the reading, each measured rather than assumed:
+ *
+ *   - **`_parsed`, not `dataset.data`.** Both are available -- the controller
+ *     leaves the caller's rows verbatim, as the sankey one does -- but only
+ *     the parse resolves the horizontal case, where the bounds and the value
+ *     move to X and the category to Y.
+ *
+ *   - **a bound may be an array.** The plugin draws nested intervals from
+ *     `yMin: [8, 7]` / `yMax: [13, 14]`, and the parse then carries scalar
+ *     `yMinMin: 7` / `yMaxMax: 14` beside them -- the outermost pair, which
+ *     is the interval the drawn whiskers reach.
+ *
+ *   - **"no interval" has two spellings.** A datum written as a plain number
+ *     parses to `yMin: null`; an object datum with no bounds omits the key
+ *     entirely. Both mean no whiskers, and neither is an interval of width
+ *     zero, so the test is `!= null`.
+ *
+ *   - **a `null` entry is not a case to handle.** The controller throws
+ *     laying the chart out ("Cannot read properties of null") before MAIDR
+ *     sees it -- the same shape a sankey row with no `flow` has.
+ */
+import type { ChartJsChart, ChartJsDataset, ChartJsParsedValue } from '@adapters/chartjs/types';
+import type { ErrorBarPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { describe, expect, it } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+
+interface ChartOptions {
+  type?: string;
+  labels?: (string | number)[];
+  indexAxis?: 'x' | 'y';
+  reverse?: boolean;
+}
+
+/**
+ * An error-bar chart as Chart.js leaves it after `update()`.
+ *
+ * @param parsed - One parse per dataset, in the shape measured above
+ * @param options - The chart type, its labels and its axis settings
+ * @returns The chart
+ */
+function errorBarChart(
+  parsed: ChartJsParsedValue[][],
+  options: ChartOptions = {},
+): ChartJsChart {
+  const { type = 'barWithErrorBars', labels = ['a', 'b', 'c'], indexAxis, reverse } = options;
+  const datasets = parsed.map((_, index) => ({
+    label: `S${index + 1}`,
+    // The controller leaves the caller's rows alone, so `data` is only ever
+    // read here for its length; every value comes from the parse.
+    data: parsed[index].map(() => 0),
+  })) as unknown as ChartJsDataset[];
+
+  const categoryAxis = indexAxis === 'y' ? 'y' : 'x';
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: { labels, datasets },
+    options: {
+      plugins: {},
+      ...(indexAxis ? { indexAxis } : {}),
+      scales: {
+        x: { title: { text: 'Treatment' } },
+        y: { title: { text: 'Response' } },
+        ...(reverse ? { [categoryAxis]: { reverse: true, title: { text: categoryAxis === 'x' ? 'Treatment' : 'Response' } } } : {}),
+      },
+    },
+    config: { type },
+    getDatasetMeta: (index: number) => ({ data: [], type, _parsed: parsed[index] ?? [] }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** One dataset of three categories with a symmetric interval at each. */
+const THREE_INTERVALS: ChartJsParsedValue[] = [
+  { x: 0, y: 10, yMin: 8, yMax: 13, yMinMin: 8, yMaxMax: 13 },
+  { x: 1, y: 20, yMin: 17, yMax: 22, yMinMin: 17, yMaxMax: 22 },
+  { x: 2, y: 15, yMin: 14, yMax: 19, yMinMin: 14, yMaxMax: 19 },
+];
+
+/** The single layer of an error-bar chart. */
+function errorBarLayer(chart: ChartJsChart): {
+  layer: any;
+  points: ErrorBarPoint[];
+  series: ErrorBarPoint[][];
+} {
+  const layer = extractChartData(chart).maidr.subplots[0][0].layers[0];
+  const data = layer.data as ErrorBarPoint[] | ErrorBarPoint[][];
+  const grouped = Array.isArray(data[0]);
+  return {
+    layer,
+    points: grouped ? (data as ErrorBarPoint[][]).flat() : (data as ErrorBarPoint[]),
+    series: grouped ? (data as ErrorBarPoint[][]) : [data as ErrorBarPoint[]],
+  };
+}
+
+describe('chart.js error bars', () => {
+  it('reads a barWithErrorBars as an error_bar rather than raising', () => {
+    // The reproduction. Before this the dispatcher's default threw, naming
+    // sixteen supported types and not this one.
+    const { layer, points } = errorBarLayer(errorBarChart([THREE_INTERVALS]));
+
+    expect(layer.type).toBe(TraceType.ERROR_BAR);
+    expect(points).toEqual([
+      { x: 'a', y: 10, yMin: 8, yMax: 13 },
+      { x: 'b', y: 20, yMin: 17, yMax: 22 },
+      { x: 'c', y: 15, yMin: 14, yMax: 19 },
+    ]);
+  });
+
+  it.each(['barWithErrorBars', 'lineWithErrorBars', 'scatterWithErrorBars'])(
+    'reads %s the same way',
+    (type) => {
+      // The three cartesian controllers differ only in the mark drawn at the
+      // estimate, which is not something a reader is told.
+      const { layer, points } = errorBarLayer(errorBarChart([THREE_INTERVALS], { type }));
+
+      expect(layer.type).toBe(TraceType.ERROR_BAR);
+      expect(points.map(point => [point.y, point.yMin, point.yMax])).toEqual([
+        [10, 8, 13],
+        [20, 17, 22],
+        [15, 14, 19],
+      ]);
+    },
+  );
+
+  it('names the axes from the chart rather than the generic pair', () => {
+    const { layer } = errorBarLayer(errorBarChart([THREE_INTERVALS]));
+
+    expect(layer.axes).toEqual({
+      x: { label: 'Treatment' },
+      y: { label: 'Response' },
+    });
+  });
+
+  it('leaves the payload alone on a horizontal chart and says it is horizontal', () => {
+    // `MaidrLayer.orientation` swaps `x` and `y` for the bar family and for
+    // nothing else: an `error_bar` keeps the category on `x` and the
+    // magnitudes on `y`/`yMin`/`yMax` either way, and `horz` moves only which
+    // axis label the reading is announced against.
+    //
+    // The parse is where the horizontal case is resolved: measured, the
+    // bounds and the value arrive on X and the category on Y.
+    const horizontal: ChartJsParsedValue[] = [
+      { y: 0, x: 10, xMin: 8, xMax: 13, xMinMin: 8, xMaxMax: 13 },
+      { y: 1, x: 20, xMin: 17, xMax: 22, xMinMin: 17, xMaxMax: 22 },
+    ];
+    const { layer, points } = errorBarLayer(
+      errorBarChart([horizontal], { labels: ['a', 'b'], indexAxis: 'y' }),
+    );
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(points).toEqual([
+      { x: 'a', y: 10, yMin: 8, yMax: 13 },
+      { x: 'b', y: 20, yMin: 17, yMax: 22 },
+    ]);
+  });
+
+  it('announces the outermost of a nested pair of intervals', () => {
+    // The plugin draws a 95% inside a 99% from an array bound, and
+    // `ErrorBarPoint.yMin` is one number. The outermost is the interval the
+    // whiskers reach; the inner one is dropped, which is a real loss and not
+    // a rounding.
+    const nested: ChartJsParsedValue[] = [
+      { x: 0, y: 10, yMin: [8, 7], yMax: [13, 14], yMinMin: 7, yMaxMax: 14 },
+    ];
+    const { points } = errorBarLayer(errorBarChart([nested], { labels: ['a'] }));
+
+    expect(points).toEqual([{ x: 'a', y: 10, yMin: 7, yMax: 14 }]);
+  });
+
+  it.each([
+    ['a plain-number datum, whose bounds parse to null', null],
+    ['an object datum with no bounds at all', undefined],
+  ])('announces no interval for %s', (_label, bound) => {
+    // Both spellings mean "no whiskers", and neither is an interval of width
+    // zero -- which is why the parse's own `yMinMin`/`yMaxMax` are not used
+    // as a fallback here: measured, they are both the estimate itself.
+    const bare: ChartJsParsedValue[] = [
+      { x: 0, y: 10, yMinMin: 10, yMaxMax: 10, ...(bound === null ? { yMin: null, yMax: null } : {}) },
+    ];
+    const { points } = errorBarLayer(errorBarChart([bare], { labels: ['a'] }));
+
+    expect(points).toEqual([{ x: 'a', y: 10 }]);
+  });
+
+  it('gives every estimate its group name when there is more than one dataset', () => {
+    // #942 added `ErrorBarPoint.z` for exactly this: a dodged interval chart
+    // puts two estimates at every category, and without a name they arrive as
+    // two readings of one category with nothing telling them apart.
+    const second: ChartJsParsedValue[] = [
+      { x: 0, y: 30, yMin: 28, yMax: 33, yMinMin: 28, yMaxMax: 33 },
+      { x: 1, y: 40, yMin: 37, yMax: 42, yMinMin: 37, yMaxMax: 42 },
+      { x: 2, y: 35, yMin: 34, yMax: 39, yMinMin: 34, yMaxMax: 39 },
+    ];
+    const { series } = errorBarLayer(errorBarChart([THREE_INTERVALS, second]));
+
+    expect(series).toHaveLength(2);
+    expect(series[0].every(point => point.z === 'S1')).toBe(true);
+    expect(series[1].every(point => point.z === 'S2')).toBe(true);
+    expect(series[1].map(point => point.y)).toEqual([30, 40, 35]);
+  });
+
+  it('names no group on a single-dataset chart', () => {
+    // One group needs no name for itself, and `z` is documented as meaningful
+    // on the grouped shape.
+    const { points } = errorBarLayer(errorBarChart([THREE_INTERVALS]));
+
+    expect(points.every(point => point.z === undefined)).toBe(true);
+  });
+
+  it('reads a reversed category axis in the order it is drawn', () => {
+    // The family of bugs #1024 closed: `chart.data.labels` and the datasets
+    // stay in the written order while the axis is drawn from the far end, and
+    // `ErrorBarTrace` announces `layer.data` as it arrives.
+    const { points } = errorBarLayer(errorBarChart([THREE_INTERVALS], { reverse: true }));
+
+    expect(points.map(point => point.x)).toEqual(['c', 'b', 'a']);
+    expect(points.map(point => point.y)).toEqual([15, 20, 10]);
+  });
+
+  it('outlines the mark the payload announces, in that same drawn order', () => {
+    // The half an accessibility suite cannot hear: audio, text and braille
+    // read from the payload while the highlight is resolved by index, so a
+    // table built by a different walk lights up a different mark.
+    const chart = errorBarChart([THREE_INTERVALS], { reverse: true });
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    const targets = [0, 1, 2].map(col =>
+      resolveActiveTargets(layers, maps, extraction.layerDatasetIndices, layers[0].id, 0, col));
+
+    expect(targets).toEqual([
+      [{ datasetIndex: 0, index: 2 }],
+      [{ datasetIndex: 0, index: 1 }],
+      [{ datasetIndex: 0, index: 0 }],
+    ]);
+  });
+
+  it('outlines the right dataset when there are several', () => {
+    const second: ChartJsParsedValue[] = [
+      { x: 0, y: 30, yMin: 28, yMax: 33, yMinMin: 28, yMaxMax: 33 },
+      { x: 1, y: 40, yMin: 37, yMax: 42, yMinMin: 37, yMaxMax: 42 },
+      { x: 2, y: 35, yMin: 34, yMax: 39, yMinMin: 34, yMaxMax: 39 },
+    ];
+    const chart = errorBarChart([THREE_INTERVALS, second]);
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    const first = resolveActiveTargets(
+      layers,
+      maps,
+      extraction.layerDatasetIndices,
+      layers[0].id,
+      0,
+      1,
+    );
+    const other = resolveActiveTargets(
+      layers,
+      maps,
+      extraction.layerDatasetIndices,
+      layers[0].id,
+      1,
+      1,
+    );
+
+    expect(first).toEqual([{ datasetIndex: 0, index: 1 }]);
+    expect(other).toEqual([{ datasetIndex: 1, index: 1 }]);
+  });
+
+  it('keeps a drawing dataset paired with its own row when another draws nothing', () => {
+    // A dataset that contributed no points emits no row, so the default
+    // "every dataset, in order" would put the survivor's row one place out
+    // and outline the empty dataset instead.
+    const chart = errorBarChart([[], THREE_INTERVALS]);
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    const { series } = errorBarLayer(chart);
+    expect(series).toHaveLength(1);
+    expect(resolveActiveTargets(
+      layers,
+      maps,
+      extraction.layerDatasetIndices,
+      layers[0].id,
+      0,
+      1,
+    )).toEqual([{ datasetIndex: 1, index: 1 }]);
+  });
+
+  it('still refuses polarAreaWithErrorBars, and says so', () => {
+    // The plugin's fourth controller draws wedges with radial whiskers, and
+    // `RadarTrace` reads a spoke as `{x: angle, y: radius}` with nowhere to
+    // put a bound. Reading it as a polar area would announce the estimate and
+    // drop the uncertainty the chart was drawn for, so it keeps the explicit
+    // refusal rather than gaining a lossy reading.
+    const chart = errorBarChart(
+      [[{ y: 10 }, { y: 20 }]],
+      { type: 'polarAreaWithErrorBars', labels: ['N', 'E'] },
+    );
+
+    expect(() => extractChartData(chart)).toThrow(/polarAreaWithErrorBars/);
+  });
+});


### PR DESCRIPTION
Closes #1176.

`chartjs-chart-error-bars` is the sibling of `@sgratzl/chartjs-chart-boxplot`, which the adapter already reads, and `TraceType.ERROR_BAR` has existed since #789. `extractLayers` threw on every one of its controllers, so an interval chart navigable in plotly, Vega-Lite or ggplot2 raised in Chart.js:

```
MAIDR Chart.js adapter: unsupported chart type "barWithErrorBars".
```

`barWithErrorBars`, `lineWithErrorBars` and `scatterWithErrorBars` now read as `error_bar`. They differ only in the mark drawn at the estimate, which is not something a reader is told.

## Measured

`chart.js@4.5` with `chartjs-chart-error-bars@4.4.5`, driven headlessly through Chart.js's own `BasicPlatform`, reading `getDatasetMeta(0)._parsed` after `update()`:

| chart | `_parsed[0]` |
| --- | --- |
| `barWithErrorBars` | `{x: 0, y: 10, yMin: 8, yMax: 13, yMinMin: 8, yMaxMax: 13}` |
| `lineWithErrorBars` | the same |
| `scatterWithErrorBars` | the same plus `xMin`/`xMax`/`xMinMin`/`xMaxMax` |
| `indexAxis: 'y'` | `{y: 0, x: 10, xMin: 8, xMax: 13, xMinMin: 8, xMaxMax: 13}` |
| nested bounds | `{x: 0, y: 10, yMin: [8, 7], yMax: [13, 14], yMinMin: 7, yMaxMax: 14}` |
| a plain-number datum | `{x: 0, y: 10, yMin: null, yMax: null, yMinMin: 10, yMaxMax: 10}` |

Four decisions came out of that, each measured rather than assumed:

**1. `_parsed`, not `dataset.data`.** Both are available — the controller leaves the caller's rows verbatim, as the sankey one does — but only the parse resolves the horizontal case, where the bounds and the value move to X and the category to Y. Reading the raw rows would mean working out which axis is which a second time.

**2. A bound may be an array.** The plugin draws nested intervals — a 95% inside a 99%. `ErrorBarPoint.yMin` is one number, so the **outermost** pair is announced: it is the interval the drawn whiskers reach. The inner ones are dropped, which is a real loss rather than a rounding, and it is written down in the code, the tests and the guide.

**3. "No interval" has two spellings.** A plain-number datum parses to `yMin: null`; an object datum with no bounds omits the key entirely. Both mean no whiskers, and neither is an interval of width zero — so the test is `!= null`, and the parse's own `yMinMin`/`yMaxMax` are **not** used as a fallback, because on such a datum both are the estimate itself.

**4. A `null` entry is not a case to handle.** The controller throws laying the chart out (`Cannot read properties of null`) before MAIDR sees it — the same shape a sankey row with no `flow` has.

## Grouping and the highlight

Several datasets emit the grouped shape, one series each, every estimate naming its dataset — which is what #942 added `ErrorBarPoint.z` for: a dodged interval chart puts two estimates at every category, and without a name they arrive as two readings of one category with nothing telling them apart. A single dataset emits the flat shape and needs no name for its one group.

The highlight table is built by the **extractor's own walk**, exported as `drawnErrorBarIndices`, rather than by the line branch's. That branch tests raw entries with `toFiniteNumber`, which reads `.y` and so finds nothing at all on a horizontal chart. Sharing one walk is what keeps the table and the payload from naming different marks — the drift #1024 closed. A dataset that drew nothing contributes no row and is recorded as such, so the survivor's row still points at the dataset that drew it.

## `polarAreaWithErrorBars` keeps its refusal

The plugin's fourth controller draws wedges with radial whiskers. `RadarTrace` reads a spoke as `{x: angle, y: radius}` and has nowhere to put a bound, so reading it as a polar area would announce the estimate and drop the uncertainty the chart was drawn for. That is a decision, and it is recorded in the code, the tests and `docs/chartjs.md` rather than left looking like an oversight.

## Changes

| file | |
| --- | --- |
| `src/adapters/chartjs/types.ts` | `ChartJsParsedValue` gains the interval fields, documented with what each spelling means |
| `src/adapters/chartjs/extractor.ts` | `extractErrorBarLayers`, `errorBarBound`, `drawnErrorBarIndices`, three dispatch cases |
| `src/adapters/chartjs/highlightTargets.ts` | an `ERROR_BAR` case sharing the extractor's walk |
| `docs/chartjs.md` | a table row and a note covering the four decisions above |

## Tests

`test/adapters/chartjs/errorBars.test.ts` — 16 cases: the reproduction, the three controllers reading alike, the axis titles, the horizontal payload and its `horz`, the nested bound, both spellings of "no interval", grouping and its absence, a reversed category axis, the highlight resolving to the mark the payload announces in that same order, the right dataset when there are several, a non-drawing dataset not shifting the rows, and `polarAreaWithErrorBars` still refused.

No new E2E spec: this is an adapter emitting an existing trace type, which `errorbar.spec.ts` and `errorbarGrouped.spec.ts` already drive — the same shape the Chart.js sankey, treemap and word-cloud additions took.

## Mutation sweep

Nine mutations, one per rule the change adds. All killed.

| mutation | |
| --- | --- |
| `barWithErrorBars` is not dispatched (the reproduction) | killed |
| the value axis is always y, whatever `indexAxis` says | killed |
| a nested bound announces the innermost interval | killed |
| a datum with no bounds gets a zero-width interval | killed |
| the drawing datasets are not recorded, so the rows shift | killed |
| the highlight table is not built for an error bar | killed |
| a grouped estimate carries no group name | killed |
| a horizontal chart does not say it is horizontal | killed |
| a reversed category axis is read in the written order | killed |

## Verification

```
npx eslint src test   clean
npx tsc --noEmit      clean
npm run build         all 14 builds complete
npm run docs          done
npm test              412 suites / 5683 tests passed  (411 / 5667 before)
                       10 suites /  137 tests passed  (ESM project)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_