### PR TITLE
feat(chartjs): read a funnel as the stages it draws

### DIFF
--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -96,10 +96,13 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Treemap | `'treemap'` | `chartjs-chart-treemap` | [Treemap](examples.html) |
 | Sankey | `'sankey'` | `chartjs-chart-sankey` | [Sankey](examples.html) |
 | Word Cloud | `'wordCloud'` | `chartjs-chart-wordcloud` | [Word cloud](examples.html) |
+| Funnel | `'funnel'` | `chartjs-chart-funnel` | [Funnel](examples.html) |
 | Pie / Doughnut | `'pie'`, `'doughnut'` | — | [Pie chart](examples.html) |
 | Gauge | `'doughnut'` with `circumference` under 360 and two values | — | [Gauge](examples.html) |
 
 > **Pie note:** a pie has no Chart.js scales, so there is no axis title to read. `axes.x` and `axes.y` default to `Category` and `Value`; set `plugins.maidr.axes` to name what the slice labels and their values actually mean. Multiple datasets are concentric rings, not slices of one circle — each becomes its own MAIDR layer with its own total and percentages, and Page Up / Page Down move between them.
+
+> **Funnel note:** a funnel is read as the stages it draws, `data.labels` naming them and `dataset.data` carrying the magnitudes — plain numbers or `{x, y}` rows, either way. The reading MAIDR gives it is a bar's with one difference that matters: the pitch carries the **retention** between adjacent stages rather than the count, and the counts are announced alongside. `indexAxis: 'y'` draws it on its side and the payload is exchanged with it, as for any bar-family chart. Several datasets are several funnels, one layer each, rather than one segmented chart — a funnel is one population shrinking across ordered stages, so a second series is a second population.
 
 > **Error bar note:** the three cartesian controllers of `chartjs-chart-error-bars` all read the same way — an estimate and the interval around it — because the mark each draws at the estimate is not something a reader is told. Several datasets become one series each, every estimate naming its dataset, so a dodged interval chart keeps the comparison it was drawn for. A datum may carry **nested** intervals (`yMin: [8, 7]`); the outermost pair is announced, which is the interval the drawn whiskers reach, and the inner ones are not. A datum written as a plain number draws no whiskers and is announced as an estimate with no interval — which is not the same as an interval of width zero. `polarAreaWithErrorBars`, the plugin's fourth controller, is **not** read: a radial spoke has nowhere to carry a bound, so reading it would announce the estimate and drop the uncertainty.
 

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -8,7 +8,7 @@
  *   area, bump, dot, survival), scatter, bubble, pie, doughnut, gauge, radar,
  *   polarArea
  * - Plugin: boxplot, violin, candlestick/ohlc, matrix (heatmap), treemap,
- *   sankey, wordCloud, and the cartesian error-bar controllers
+ *   sankey, wordCloud, funnel, and the cartesian error-bar controllers
  *   (barWithErrorBars, lineWithErrorBars, scatterWithErrorBars)
  *
  * A type with no MAIDR trace behind it is rejected with an explicit error
@@ -836,12 +836,15 @@ function extractLayers(
       return extractSankeyLayers(chart);
     case 'wordCloud':
       return extractWordCloudLayers(chart);
+    case 'funnel':
+      return extractFunnelLayers(chart, pluginOptions, datasetIndices);
     default:
       throw new Error(
         `MAIDR Chart.js adapter: unsupported chart type "${chartType}". `
         + 'Supported types: bar, line, scatter, bubble, pie, doughnut, radar, '
         + 'polarArea, boxplot, violin, candlestick, ohlc, matrix, treemap, sankey, '
-        + 'wordCloud, barWithErrorBars, lineWithErrorBars, scatterWithErrorBars.',
+        + 'wordCloud, funnel, barWithErrorBars, lineWithErrorBars, '
+        + 'scatterWithErrorBars.',
       );
   }
 }
@@ -873,6 +876,65 @@ function extractBarLayers(
   }
 
   return [singleDatasetToBarLayer(data.datasets[0], data.labels ?? [], chart, pluginOptions)];
+}
+
+/**
+ * Reads a `chartjs-chart-funnel` chart as the stages it draws.
+ *
+ * A funnel is a bar chart the trace reads differently: `FunnelTrace` extends
+ * `BarTrace` and pitches the **retention** between adjacent stages rather
+ * than the count, announcing the counts alongside. So the payload is a bar's,
+ * `{x: stage, y: magnitude}`, and this borrows the bar family's own walk --
+ * which is also what keeps a gap and a reversed axis behaving the same way
+ * here as everywhere else.
+ *
+ * Measured against a running chart -- `chart.js@4` with
+ * `chartjs-chart-funnel@4`, driven headlessly through Chart.js's own
+ * BasicPlatform:
+ *
+ *   - the stages are `data.labels` and the magnitudes are `dataset.data`,
+ *     written as plain numbers or as `{x, y}`; both are what `toFiniteNumber`
+ *     already reads.
+ *
+ *   - `indexAxis: 'y'` draws the funnel on its side, and the raw data is
+ *     unchanged -- only the parse moves the magnitude to `x`. `funnel` is in
+ *     the bar family the grammar's `orientation` table names, so the same
+ *     exchange applies, and `singleDatasetToBarLayer` already makes it.
+ *
+ *   - a `null` stage parses to `y: null` and is skipped rather than announced
+ *     as a zero the chart does not draw.
+ *
+ * **One layer per dataset.** Two datasets are two funnels rather than one
+ * segmented chart: a funnel is one population shrinking across ordered
+ * stages, so a second series is a second population and not a second segment
+ * of the first. That is also the reading the amCharts adapter gives its own
+ * funnel series.
+ *
+ * @param chart - The Chart.js chart
+ * @param pluginOptions - The MAIDR plugin options, for the axis labels
+ * @param datasetIndices - Collects which dataset backs each emitted layer
+ * @returns One layer per dataset
+ */
+function extractFunnelLayers(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
+): MaidrLayer[] {
+  const labels = chart.data.labels ?? [];
+  return chart.data.datasets.map((dataset, index) => {
+    // Recorded rather than left to the per-type default, which is "every
+    // dataset, in order": with two funnels that hands both layers the same
+    // first dataset, so the second one outlines the first funnel's stages.
+    datasetIndices?.set(String(index), [index]);
+    return singleDatasetToBarLayer(
+      dataset,
+      labels,
+      chart,
+      pluginOptions,
+      index,
+      TraceType.FUNNEL,
+    );
+  });
 }
 
 /**

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -293,10 +293,15 @@ export function computeTargetMaps(
         break;
       }
       case TraceType.BAR:
-      case TraceType.DOT: {
+      case TraceType.DOT:
+      case TraceType.FUNNEL: {
         // Single-dataset bar, and the dot plot drawn by the same builder: a
         // single MAIDR row backed by the layer's own dataset, its columns in
         // the order the categories are drawn.
+        //
+        // A funnel comes out of that same builder, one layer per dataset, so
+        // its row is its own dataset's -- which is why the extractor records
+        // the mapping rather than leaving it to the every-dataset default.
         const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
         const data = datasets[dsIdx]?.data ?? [];
         barLineIndices.set(

--- a/test/adapters/chartjs/funnel.test.ts
+++ b/test/adapters/chartjs/funnel.test.ts
@@ -1,0 +1,220 @@
+/**
+ * The Chart.js adapter refused funnels, though `funnel` has existed since
+ * #791 (#1178).
+ *
+ * `chartjs-chart-funnel` is one of three plugin families the adapter still
+ * threw on. An identical funnel drawn in amCharts, AnyChart, Google Charts or
+ * Highcharts was navigable; only a Chart.js one raised.
+ *
+ * Measured against a running chart -- `chart.js@4.5` with
+ * `chartjs-chart-funnel@4`, driven headlessly through Chart.js's own
+ * `BasicPlatform` -- and the reading is the bar family's own walk:
+ *
+ *     plain           parsed [{x:0, y:100}, {x:1, y:40}, {x:2, y:10}]
+ *     indexAxis: 'y'  parsed [{y:0, x:100}, {y:1, x:40}, {y:2, x:10}]
+ *     object data     [{x, y}] rows parse to the same thing
+ *     a null stage    parses to `y: null`
+ *     two datasets    each parses independently, three elements each
+ *
+ * Three things follow, and each is a fact about the plugin rather than a
+ * choice:
+ *
+ *   - the **raw** rows are what is read, not the parse. Both spellings --
+ *     plain numbers and `{x, y}` -- are what `toFiniteNumber` already takes,
+ *     and unlike the error-bar controllers the horizontal case needs nothing
+ *     extra: `indexAxis: 'y'` leaves `dataset.data` untouched and moves only
+ *     the parse.
+ *
+ *   - `funnel` is in the bar family the grammar's `orientation` table names,
+ *     so `horz` exchanges `x` and `y` in the payload -- which
+ *     `singleDatasetToBarLayer` already does.
+ *
+ *   - **two datasets are two funnels.** A funnel is one population shrinking
+ *     across ordered stages, so a second series is a second population rather
+ *     than a second segment of the first -- the reading the amCharts adapter
+ *     gives its own funnel series.
+ */
+import type { ChartJsChart, ChartJsDataset, ChartJsDataValue } from '@adapters/chartjs/types';
+import type { BarPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { describe, expect, it } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+
+interface FunnelOptions {
+  labels?: (string | number)[];
+  indexAxis?: 'x' | 'y';
+  reverse?: boolean;
+}
+
+/**
+ * A funnel chart as Chart.js leaves it after `update()`.
+ *
+ * @param datasets - One entry per drawn funnel, its rows as the caller wrote them
+ * @param options - The stage names and the axis settings
+ * @returns The chart
+ */
+function funnelChart(
+  datasets: ChartJsDataValue[][],
+  options: FunnelOptions = {},
+): ChartJsChart {
+  const { labels = ['visit', 'cart', 'buy'], indexAxis, reverse } = options;
+  const categoryAxis = indexAxis === 'y' ? 'y' : 'x';
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: {
+      labels,
+      datasets: datasets.map((data, index) => ({
+        label: `F${index + 1}`,
+        data,
+      })) as unknown as ChartJsDataset[],
+    },
+    options: {
+      plugins: {},
+      ...(indexAxis ? { indexAxis } : {}),
+      scales: {
+        x: { title: { text: 'Stage' } },
+        y: { title: { text: 'Users' } },
+        ...(reverse ? { [categoryAxis]: { reverse: true } } : {}),
+      },
+    },
+    config: { type: 'funnel' },
+    getDatasetMeta: () => ({ data: [], type: 'funnel' }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** Every layer of a funnel chart, as `(type, points)`. */
+function funnelLayers(chart: ChartJsChart): { layer: any; points: BarPoint[] }[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers.map(layer => ({
+    layer,
+    points: layer.data as BarPoint[],
+  }));
+}
+
+describe('chart.js funnel', () => {
+  it('reads a funnel as a funnel rather than raising', () => {
+    // The reproduction. Before this the dispatcher's default threw, naming
+    // every supported type and not this one.
+    const [{ layer, points }] = funnelLayers(funnelChart([[100, 40, 10]]));
+
+    expect(layer.type).toBe(TraceType.FUNNEL);
+    expect(points).toEqual([
+      { x: 'visit', y: 100 },
+      { x: 'cart', y: 40 },
+      { x: 'buy', y: 10 },
+    ]);
+  });
+
+  it('names the axes from the chart rather than the generic pair', () => {
+    const [{ layer }] = funnelLayers(funnelChart([[100, 40, 10]]));
+
+    expect(layer.axes).toEqual({
+      x: { label: 'Stage' },
+      y: { label: 'Users' },
+    });
+  });
+
+  it('reads rows written as objects the same way', () => {
+    // The plugin takes both spellings, and `toFiniteNumber` reads `.y` off
+    // the object form -- so nothing here has to know which was written.
+    const rows = [{ x: 0, y: 100 }, { x: 1, y: 40 }, { x: 2, y: 10 }];
+    const [{ points }] = funnelLayers(funnelChart([rows as ChartJsDataValue[]]));
+
+    expect(points.map(point => point.y)).toEqual([100, 40, 10]);
+  });
+
+  it('exchanges the payload on a sideways funnel and says it is horizontal', () => {
+    // `funnel` is in the bar family, which is the half of the `orientation`
+    // table that swaps `x` and `y`: `x` becomes the magnitude and `y` the
+    // stage. Getting this wrong puts a stage name where the trace expects a
+    // number and the chart sounds with no magnitude at all.
+    const [{ layer, points }] = funnelLayers(
+      funnelChart([[100, 40, 10]], { indexAxis: 'y' }),
+    );
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(points).toEqual([
+      { x: 100, y: 'visit' },
+      { x: 40, y: 'cart' },
+      { x: 10, y: 'buy' },
+    ]);
+  });
+
+  it('skips a stage with no value rather than announcing a zero', () => {
+    // Measured, a `null` row parses to `y: null`. Announcing it as 0 would
+    // sonify a stage the chart draws nothing for.
+    const [{ points }] = funnelLayers(funnelChart([[100, null, 10]]));
+
+    expect(points).toEqual([
+      { x: 'visit', y: 100 },
+      { x: 'buy', y: 10 },
+    ]);
+  });
+
+  it('reads two datasets as two funnels', () => {
+    // Not a segmented bar: a funnel is one population shrinking across
+    // ordered stages, so a second series is a second population.
+    const layers = funnelLayers(funnelChart([[100, 40, 10], [80, 30, 5]]));
+
+    expect(layers).toHaveLength(2);
+    expect(layers.every(({ layer }) => layer.type === TraceType.FUNNEL)).toBe(true);
+    expect(layers[0].points.map(point => point.y)).toEqual([100, 40, 10]);
+    expect(layers[1].points.map(point => point.y)).toEqual([80, 30, 5]);
+  });
+
+  it('reads a reversed stage axis in the order it is drawn', () => {
+    // The family of bugs #1024 closed: `chart.data.labels` and the dataset
+    // stay in the written order while the axis is drawn from the far end.
+    const [{ points }] = funnelLayers(funnelChart([[100, 40, 10]], { reverse: true }));
+
+    expect(points.map(point => point.x)).toEqual(['buy', 'cart', 'visit']);
+    expect(points.map(point => point.y)).toEqual([10, 40, 100]);
+  });
+
+  it('outlines the stage the payload announces, in that same drawn order', () => {
+    const chart = funnelChart([[100, 40, 10]], { reverse: true });
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    const targets = [0, 1, 2].map(col =>
+      resolveActiveTargets(layers, maps, extraction.layerDatasetIndices, layers[0].id, 0, col));
+
+    expect(targets).toEqual([
+      [{ datasetIndex: 0, index: 2 }],
+      [{ datasetIndex: 0, index: 1 }],
+      [{ datasetIndex: 0, index: 0 }],
+    ]);
+  });
+
+  it('outlines each funnel in its own dataset', () => {
+    // The per-type default is "every dataset, in order", which hands both
+    // layers the same first dataset -- so the second funnel would outline the
+    // first one's stages. The extractor records the mapping instead.
+    const chart = funnelChart([[100, 40, 10], [80, 30, 5]]);
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    const first = resolveActiveTargets(
+      layers,
+      maps,
+      extraction.layerDatasetIndices,
+      layers[0].id,
+      0,
+      1,
+    );
+    const second = resolveActiveTargets(
+      layers,
+      maps,
+      extraction.layerDatasetIndices,
+      layers[1].id,
+      0,
+      1,
+    );
+
+    expect(first).toEqual([{ datasetIndex: 0, index: 1 }]);
+    expect(second).toEqual([{ datasetIndex: 1, index: 1 }]);
+  });
+});


### PR DESCRIPTION
Part of #1178 — one of the six types it lists, and the one it names as cheapest. The other five are unchanged.

`chartjs-chart-funnel` is one of three plugin families the adapter still threw on, though `TraceType.FUNNEL` has existed since #791:

```
MAIDR Chart.js adapter: unsupported chart type "funnel".
```

so an identical funnel drawn in amCharts, AnyChart, Google Charts or Highcharts was navigable and only a Chart.js one raised.

## The reading is the bar family's own walk

`FunnelTrace` extends `BarTrace` and pitches the **retention** between adjacent stages rather than the count, announcing the counts alongside. So the payload is a bar's `{x: stage, y: magnitude}`, and this borrows `singleDatasetToBarLayer` rather than growing a second copy of it — which is also what keeps a gap and a reversed axis behaving here as they do everywhere else.

## Measured

`chart.js@4.5` with `chartjs-chart-funnel@4`, driven headlessly through Chart.js's own `BasicPlatform`:

| written | `_parsed` |
| --- | --- |
| `[100, 40, 10]` | `[{x:0, y:100}, {x:1, y:40}, {x:2, y:10}]` |
| the same, `indexAxis: 'y'` | `[{y:0, x:100}, {y:1, x:40}, {y:2, x:10}]` |
| `[{x, y}]` rows | the same as the plain form |
| `[100, null, 10]` | `[{x:0, y:100}, {x:1, y:null}, {x:2, y:10}]` |
| two datasets | each parses independently, three elements each |

Three things follow, and each is a fact about the plugin rather than a choice:

**1. The raw rows are what is read, not the parse.** Both spellings are what `toFiniteNumber` already takes — and unlike the error-bar controllers of #1176, the horizontal case needs nothing extra here: `indexAxis: 'y'` leaves `dataset.data` untouched and moves only the parse.

**2. `funnel` is in the bar family** the grammar's `orientation` table names — "`funnel`, whose trace extends `BarTrace` and never undoes the exchange" — so `horz` exchanges `x` and `y` in the payload, which the shared builder already does. Getting this wrong puts a stage name where the trace expects a number and the chart sounds with no magnitude at all.

**3. A `null` stage is skipped**, not announced as a zero the chart draws nothing for.

## Two datasets are two funnels

Not one segmented chart. A funnel is one population shrinking across ordered stages, so a second series is a second population rather than a second segment of the first — the reading the amCharts adapter gives its own funnel series.

Each layer records its own backing dataset. The per-type default is "every dataset, in order", which hands both layers the same first dataset, so the second funnel would have outlined the first one's stages — the highlight-only failure #814 names as the blind spot an accessibility suite cannot hear.

## Changes

| file | |
| --- | --- |
| `src/adapters/chartjs/extractor.ts` | `extractFunnelLayers`, one dispatch case, the unsupported-type message |
| `src/adapters/chartjs/highlightTargets.ts` | `TraceType.FUNNEL` joins the single-row bar branch |
| `docs/chartjs.md` | a table row and a note |

## Tests

`test/adapters/chartjs/funnel.test.ts` — 9 cases: the reproduction and its type, the axis titles, object rows, the sideways payload and its `horz`, a `null` stage, two datasets as two funnels, a reversed stage axis, the highlight resolving in that same drawn order, and each funnel outlining its own dataset.

No new E2E spec: this is an adapter emitting an existing trace type, which `funnel.spec.ts` already drives — the same shape the Chart.js sankey, treemap, word-cloud and error-bar additions took.

## Mutation sweep

| mutation | |
| --- | --- |
| funnel is not dispatched (the reproduction) | killed |
| a funnel is read as an ordinary bar | killed |
| only the first dataset becomes a layer | killed |
| the backing datasets are not recorded | killed |
| a funnel gets no highlight table | killed |

## Verification

```
npx eslint src test   clean
npx tsc --noEmit      clean
npm run build         all builds complete
npm run docs          done
npm test              413 suites / 5692 tests passed  (412 / 5683 before)
                       10 suites /  137 tests passed  (ESM project)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_