### PR TITLE
fix(parallel): scale a value by the axis its point names, not by its column

### DIFF
--- a/src/model/parallel.ts
+++ b/src/model/parallel.ts
@@ -1,7 +1,38 @@
 import type { LinePoint, MaidrLayer } from '@type/grammar';
 import type { AudioState, BrailleState, DescriptionState, TraceState } from '@type/state';
 import { MathUtil } from '@util/math';
+import { isMeasured } from './bar';
 import { LineTrace } from './line';
+
+/**
+ * The axis names, in the order the chart draws them.
+ *
+ * The widest observation is the spine: whenever any observation carries a
+ * reading on every variable, its points are the chart's axes left to right.
+ * A name that observation lacks is appended rather than guessed into place --
+ * an axis only gappy observations reach has no neighbour the payload names,
+ * and putting it somewhere would assert a drawing order nobody wrote down.
+ *
+ * @param points - The observations the layer carries
+ * @param seen - Every axis name the layer used, in first-seen order
+ * @returns One name per axis
+ */
+function axisOrder(points: LinePoint[][], seen: Iterable<string>): string[] {
+  const widest = points.reduce(
+    (best: LinePoint[], row) => (row.length > best.length ? row : best),
+    [] as LinePoint[],
+  );
+
+  const order = widest.map(point => String(point.x));
+  const placed = new Set(order);
+  for (const axis of seen) {
+    if (!placed.has(axis)) {
+      order.push(axis);
+      placed.add(axis);
+    }
+  }
+  return order;
+}
 
 /**
  * Trace implementation for parallel coordinates plots.
@@ -30,9 +61,29 @@ import { LineTrace } from './line';
  * inaudible.
  */
 export class ParallelTrace extends LineTrace {
-  /** Per-axis extent, indexed by column rather than by row. */
-  private readonly axisMin: number[];
-  private readonly axisMax: number[];
+  /**
+   * Each axis's extent, keyed by the name its points carry.
+   *
+   * Keyed rather than indexed because a column position is not an axis. An
+   * observation with no reading on one variable is one point shorter, so from
+   * that gap onwards its values sit a column to the left of the axis they
+   * belong to -- and an extent taken by position would then be a horsepower
+   * range with a car's weight at the top of it, which is the exact mixing of
+   * units this class exists to prevent (#1182). Every point already names its
+   * own axis in `x`, so nothing has to be inferred from where it sits.
+   */
+  private readonly axisExtent: Map<string, { min: number; max: number }>;
+
+  /**
+   * The axis names, in the order the chart draws them.
+   *
+   * Taken from the widest observation, which is the chart's axes in order
+   * whenever any observation reaches all of them. A name no widest-row
+   * observation carries is appended: the payload says the axis exists but
+   * gives nothing that would place it between two others, and inventing a
+   * position would be a claim about the drawing that was never made.
+   */
+  private readonly axisOrder: string[];
 
   /**
    * Each value's position on its own axis, from 0 to 1.
@@ -50,21 +101,36 @@ export class ParallelTrace extends LineTrace {
   public constructor(layer: MaidrLayer) {
     super(layer);
 
-    const columns = this.lineValues.reduce(
-      (widest, row) => Math.max(widest, row.length),
-      0,
+    const perAxis = new Map<string, number[]>();
+    this.points.forEach((row, index) => {
+      row.forEach((point, column) => {
+        const axis = String(point.x);
+        // Registered even when every one of its readings is a gap, so an axis
+        // a cursor can still reach is still named rather than disappearing
+        // from the dialog.
+        const collected = perAxis.get(axis) ?? [];
+        perAxis.set(axis, collected);
+        // Gaps are filtered out of the extent rather than filtered in, for the
+        // reason `LineTrace` gives: `Math.min` of anything holding `NaN` is
+        // `NaN`, which would leave every value on the axis with a non-finite
+        // range and silence the whole variable rather than the one gap.
+        const value = this.lineValues[index][column];
+        if (isMeasured(value))
+          collected.push(value);
+      });
+    });
+
+    this.axisOrder = axisOrder(this.points, perAxis.keys());
+    this.axisExtent = new Map(
+      [...perAxis].map(([axis, values]) => [
+        axis,
+        { min: MathUtil.safeMin(values), max: MathUtil.safeMax(values) },
+      ]),
     );
 
-    const perColumn = Array.from({ length: columns }, (_, column) =>
-      this.lineValues
-        .map(row => row[column])
-        .filter(value => value !== undefined));
-
-    this.axisMin = perColumn.map(values => MathUtil.safeMin(values));
-    this.axisMax = perColumn.map(values => MathUtil.safeMax(values));
-
-    this.normalized = this.lineValues.map(row =>
-      row.map((value, column) => this.positionOnAxis(value, column)));
+    this.normalized = this.points.map((row, index) =>
+      row.map((point, column) =>
+        this.positionOnAxis(this.lineValues[index][column], String(point.x))));
   }
 
   /**
@@ -76,16 +142,37 @@ export class ParallelTrace extends LineTrace {
    * midpoint is the honest reading of "nothing distinguishes these".
    *
    * @param value - The raw value
-   * @param column - Which axis it belongs to
+   * @param axis - The name of the axis it belongs to
    * @returns Its position on that axis
    */
-  private positionOnAxis(value: number, column: number): number {
-    const min = this.axisMin[column];
-    const max = this.axisMax[column];
+  private positionOnAxis(value: number, axis: string): number {
+    const { min, max } = this.extentOf(axis);
     if (!Number.isFinite(min) || !Number.isFinite(max) || max === min) {
       return 0.5;
     }
     return (value - min) / (max - min);
+  }
+
+  /**
+   * One axis's extent, by name.
+   *
+   * The fallback is unreachable through either caller: both ask with a name
+   * taken from a point of this layer, and every point registered its own name
+   * when the extents were built. It is here so that a name from anywhere else
+   * degrades to "no spread" -- the midpoint -- rather than borrowing a range
+   * measured in another variable's units, which is the failure this whole
+   * class is arranged against.
+   *
+   * @param axis - The axis name a point carries
+   * @returns Its extent, or a non-finite pair for a name the layer never used
+   */
+  private extentOf(axis: string): { min: number; max: number } {
+    return this.axisExtent.get(axis) ?? { min: Number.NaN, max: Number.NaN };
+  }
+
+  /** The axis the cursor is on, by the name the point under it carries. */
+  private get axisAtCursor(): string {
+    return String(this.points[this.row]?.[this.col]?.x ?? '');
   }
 
   protected override get audio(): AudioState {
@@ -99,8 +186,7 @@ export class ParallelTrace extends LineTrace {
       ...base,
       freq: {
         ...base.freq,
-        min: this.axisMin[this.col],
-        max: this.axisMax[this.col],
+        ...this.extentOf(this.axisAtCursor),
       },
     };
   }
@@ -163,38 +249,19 @@ export class ParallelTrace extends LineTrace {
       stat => stat.label !== 'Min value' && stat.label !== 'Max value',
     );
 
-    const axisNames = this.axisNames();
-    if (axisNames.length > 0) {
+    if (this.axisOrder.length > 0) {
       // The order is part of the chart: which variables sit next to each other
       // decides which crossings are visible at all, and it is a choice the
       // author made rather than a property of the data.
-      stats.push({ label: 'Axes, in order', value: axisNames.join(', ') });
+      stats.push({ label: 'Axes, in order', value: this.axisOrder.join(', ') });
 
-      for (const [column, name] of axisNames.entries()) {
-        stats.push({
-          label: name,
-          value: MathUtil.spanned(this.axisMin[column], this.axisMax[column]),
-        });
+      for (const name of this.axisOrder) {
+        const { min, max } = this.extentOf(name);
+        stats.push({ label: name, value: MathUtil.spanned(min, max) });
       }
     }
 
     return { ...base, stats };
-  }
-
-  /**
-   * The axis names, in the order the chart draws them.
-   *
-   * Read from the longest observation rather than the first, so a chart whose
-   * rows run to different lengths still names every column a cursor can reach.
-   *
-   * @returns One name per axis
-   */
-  private axisNames(): string[] {
-    const widest = this.points.reduce(
-      (best: LinePoint[], row) => (row.length > best.length ? row : best),
-      [] as LinePoint[],
-    );
-    return widest.map(point => String(point.x));
   }
 
   public override get state(): TraceState {

--- a/src/model/parallel.ts
+++ b/src/model/parallel.ts
@@ -4,6 +4,9 @@ import { MathUtil } from '@util/math';
 import { isMeasured } from './bar';
 import { LineTrace } from './line';
 
+/** Reported for an axis the chart draws but never measured anything on. */
+const NOTHING_MEASURED = 'no readings';
+
 /**
  * The axis names, in the order the chart draws them.
  *
@@ -175,6 +178,41 @@ export class ParallelTrace extends LineTrace {
     return String(this.points[this.row]?.[this.col]?.x ?? '');
   }
 
+  /**
+   * The stereo position of a cell, placed by which axis it is rather than by
+   * where it sits in its row.
+   *
+   * `LineTrace` pans by column over the row's own length, which is right for
+   * a series sampling one quantity at successive positions. Here a column is
+   * an axis of the chart, and an observation missing a reading is a point
+   * shorter -- so every axis after the gap would sit one column earlier in
+   * that row than in a full one. Measured on four axes with one observation
+   * missing the second, `torque` panned at column 2 of 4 on a full row and
+   * column 1 of 3 on the short one: the same axis, in two places in the
+   * stereo field depending on which observation a reader is walking.
+   *
+   * The chart draws its axes in fixed positions left to right, so the pan has
+   * to as well. `axisOrder` is that arrangement, and a point's own name is
+   * where it belongs in it (#1182).
+   *
+   * @param row - The observation index
+   * @param col - The point's index within that observation
+   * @returns The panning for that cell
+   */
+  protected override panningFor(row: number, col: number): AudioState['panning'] {
+    const axis = String(this.points[row]?.[col]?.x ?? '');
+    const placed = this.axisOrder.indexOf(axis);
+    return {
+      // A name not in the order cannot happen -- it is built from these very
+      // points -- and falling back to the raw column keeps a cell somewhere
+      // in the field rather than at its left edge if it ever did.
+      x: placed === -1 ? col : placed,
+      y: row,
+      rows: this.points.length,
+      cols: this.axisOrder.length,
+    };
+  }
+
   protected override get audio(): AudioState {
     const base = super.audio;
 
@@ -257,7 +295,16 @@ export class ParallelTrace extends LineTrace {
 
       for (const name of this.axisOrder) {
         const { min, max } = this.extentOf(name);
-        stats.push({ label: name, value: MathUtil.spanned(min, max) });
+        // An axis every observation gapped has no extent to report, and
+        // `MathUtil.spanned` of an empty set is the literal "Infinity to
+        // -Infinity" -- a range in no units, offered to a reader who opened
+        // the dialog to find out what the axis measures.
+        stats.push({
+          label: name,
+          value: Number.isFinite(min) && Number.isFinite(max)
+            ? MathUtil.spanned(min, max)
+            : NOTHING_MEASURED,
+        });
       }
     }
 

--- a/test/model/parallel.test.ts
+++ b/test/model/parallel.test.ts
@@ -410,20 +410,6 @@ describe('an observation with a gap in the middle (#1182)', () => {
     expect(stats.map(stat => stat.label)).toContain('weight');
   });
 
-  test('an axis every observation gapped is named without a range', () => {
-    // `y: null` is a position with no reading (#925), so the axis is drawn and
-    // reachable while nothing was ever measured on it. It has no extent, so a
-    // value there sits at the midpoint rather than at an end.
-    const unmeasured: LinePoint[][] = [
-      [{ x: 'mpg', y: 33 }, { x: 'hp', y: null }],
-      [{ x: 'mpg', y: 21 }, { x: 'hp', y: null }],
-    ];
-    const stats = parallel(0, 0, unmeasured).description.stats;
-
-    expect(stats.find(stat => stat.label === 'Axes, in order')?.value)
-      .toBe('mpg, hp');
-    expect(brailleGrid(parallel(0, 0, unmeasured))[0][1]).toBe(0.5);
-  });
   test('one observation gapping an axis does not silence it for the rest', () => {
     // `Math.min` of anything holding a gap is `NaN`, so counting one into the
     // extent would leave every value on that axis with a non-finite range to
@@ -481,6 +467,84 @@ describe('an observation with a gap in the middle (#1182)', () => {
 
     expect(grid[0][1]).toBe(0.5);
     expect(grid[1][1]).toBe(0.5);
+  });
+});
+
+describe('an axis sits in one place in the stereo field (#1182)', () => {
+  /** Four axes, with the second observation never measured for power. */
+  const FOUR_AXES: LinePoint[][] = [
+    [
+      { x: 'mpg', y: 33 },
+      { x: 'hp', y: 65 },
+      { x: 'torque', y: 100 },
+      { x: 'weight', y: 1800 },
+    ],
+    [{ x: 'mpg', y: 21 }, { x: 'torque', y: 150 }, { x: 'weight', y: 2600 }],
+  ];
+
+  /** Where a cell is panned, as (position, of how many). */
+  const panOf = (row: number, col: number): [number, number] => {
+    const { panning } = nonEmptyState(parallel(row, col, FOUR_AXES)).audio;
+    return [panning.x, panning.cols];
+  };
+
+  test('the same axis pans to the same place on every observation', () => {
+    // `torque` is the third axis the chart draws, whichever row a reader is
+    // on. Panned by column it was 2 of 4 on the full observation and 1 of 3
+    // on the short one -- one axis, two places in the stereo field, which is
+    // #1182 heard in the left-right dimension rather than in the pitch.
+    expect(panOf(0, 2)).toEqual([2, 4]);
+    expect(panOf(1, 1)).toEqual([2, 4]);
+  });
+
+  test('the axes either side of the gap keep their places too', () => {
+    // The whole tail shifts, not just the one after the gap, so the last
+    // axis is the sharpest case: rightmost of four on one row and rightmost
+    // of three on the other, which pans to the same edge for the wrong
+    // reason. `mpg` pins the untouched end.
+    expect(panOf(0, 3)).toEqual([3, 4]);
+    expect(panOf(1, 2)).toEqual([3, 4]);
+    expect(panOf(0, 0)).toEqual([0, 4]);
+    expect(panOf(1, 0)).toEqual([0, 4]);
+  });
+
+  test('the field is as wide as the chart, not as the row', () => {
+    // A reader on the short observation still hears three of four positions
+    // rather than three of three, so the gap is audible as a place nothing
+    // is played from.
+    expect(panOf(1, 0)[1]).toBe(4);
+  });
+});
+
+describe('an axis the chart never measured', () => {
+  const UNMEASURED: LinePoint[][] = [
+    [{ x: 'mpg', y: 33 }, { x: 'hp', y: null }],
+    [{ x: 'mpg', y: 21 }, { x: 'hp', y: null }],
+  ];
+
+  test('is reported as having no readings, not as a range in no units', () => {
+    // `MathUtil.spanned` of an empty set is the literal "Infinity to
+    // -Infinity". The dialog is where a reader goes to learn what an axis
+    // measures, so a range with no units in it is worse than saying plainly
+    // that nothing was measured.
+    const stats = parallel(0, 0, UNMEASURED).description.stats;
+
+    expect(stats.find(stat => stat.label === 'hp')?.value).toBe('no readings');
+  });
+
+  test('is still named and still in the drawn order', () => {
+    // `y: null` is a position with no reading (#925), so the axis is drawn
+    // and a cursor reaches it. Dropping it from the order would leave the
+    // dialog describing a chart with one fewer axis than the reader can walk.
+    const stats = parallel(0, 0, UNMEASURED).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Axes, in order')?.value).toBe('mpg, hp');
+  });
+
+  test('places every value on it at the midpoint rather than at an end', () => {
+    // No spread to place anything within, and either extreme would claim a
+    // rank the data does not have.
+    expect(brailleGrid(parallel(0, 0, UNMEASURED))[0][1]).toBe(0.5);
   });
 });
 

--- a/test/model/parallel.test.ts
+++ b/test/model/parallel.test.ts
@@ -314,6 +314,176 @@ describe('observations that do not all reach every axis', () => {
   });
 });
 
+describe('an observation with a gap in the middle (#1182)', () => {
+  /**
+   * Car B was never measured for power, so its row is one point shorter and
+   * its weight sits where every other row's horsepower is.
+   *
+   * This is the shape both adapters emit today: `extractParallelLayer` drops a
+   * null dimension value with `continue`, and `convertParallelSeries` filters
+   * `p.y !== null`. Neither holds the column open, so the gap is interior
+   * rather than trailing -- and an extent taken by column position then mixes
+   * horsepower with a weight in pounds.
+   */
+  const GAPPY: LinePoint[][] = [
+    [
+      { x: 'mpg', y: 33, z: 'car A' },
+      { x: 'hp', y: 65, z: 'car A' },
+      { x: 'weight', y: 1800, z: 'car A' },
+    ],
+    [
+      { x: 'mpg', y: 21, z: 'car B' },
+      { x: 'weight', y: 2600, z: 'car B' },
+    ],
+    [
+      { x: 'mpg', y: 15, z: 'car C' },
+      { x: 'hp', y: 230, z: 'car C' },
+      { x: 'weight', y: 3200, z: 'car C' },
+    ],
+  ];
+
+  test('a value is scaled by the axis its point names, not by its column', () => {
+    // Car A's 65 hp is the lowest power in the chart and car C's 230 the
+    // highest, so the two have to be the ends of the hp axis. Taken by column,
+    // the axis ran 65 to 2600 -- car B's weight -- and every real horsepower
+    // figure collapsed into the bottom sixteenth of it.
+    const power = nonEmptyState(parallel(0, 1, GAPPY)).audio.freq;
+
+    expect([power.min, power.max]).toEqual([65, 230]);
+  });
+
+  test('the axis a reader is told they are on is the one they hear', () => {
+    // Car B's second point announces `weight`, because that is what the point
+    // says. Pitched by column it was played against the hp axis, so the
+    // announcement and the sound named two different variables.
+    const weight = nonEmptyState(parallel(1, 1, GAPPY)).audio.freq;
+
+    expect([weight.min, weight.max]).toEqual([1800, 3200]);
+    expect(weight.raw).toBe(2600);
+  });
+
+  test('the shortened row does not widen an axis it never reached', () => {
+    // The failure in one number: 2600 is a weight, and it must not be able to
+    // become the top of a range measured in horsepower.
+    const power = nonEmptyState(parallel(2, 1, GAPPY)).audio.freq;
+
+    expect(power.max).not.toBe(2600);
+    expect(pitch(nonEmptyState(parallel(2, 1, GAPPY)))).toBeCloseTo(1);
+  });
+
+  test('the dialog reports each axis in its own units', () => {
+    const read = (label: string): unknown =>
+      parallel(0, 0, GAPPY).description.stats.find(stat => stat.label === label)?.value;
+
+    // Was "65 to 2600": a horsepower figure at one end and a car's weight at
+    // the other, given to a reader who opened the dialog to learn what the
+    // axes are.
+    expect(read('hp')).toBe('65 to 230');
+    expect(read('weight')).toBe('1800 to 3200');
+    expect(read('mpg')).toBe('15 to 33');
+  });
+
+  test('braille encodes each cell against the axis that cell names', () => {
+    // The grid is built from the same extents, so the gap moved every cell
+    // after it onto the wrong scale here too.
+    const grid = brailleGrid(parallel(0, 0, GAPPY));
+
+    // Car A is lowest on power, car C highest; car B's single interior cell is
+    // its weight, in the middle of 1800 to 3200.
+    expect(grid[0][1]).toBeCloseTo(0);
+    expect(grid[2][1]).toBeCloseTo(1);
+    expect(grid[1][1]).toBeCloseTo(0.5714, 3);
+  });
+
+  test('an axis no full-width observation reaches is still named', () => {
+    // Every row skips something, so there is no complete spine to read the
+    // order off. The axes still have to be named -- a cursor reaches all
+    // three.
+    const noSpine: LinePoint[][] = [
+      [{ x: 'mpg', y: 33 }, { x: 'hp', y: 65 }],
+      [{ x: 'mpg', y: 21 }, { x: 'weight', y: 2600 }],
+    ];
+    const stats = parallel(0, 0, noSpine).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Axes, in order')?.value)
+      .toBe('mpg, hp, weight');
+    expect(stats.map(stat => stat.label)).toContain('weight');
+  });
+
+  test('an axis every observation gapped is named without a range', () => {
+    // `y: null` is a position with no reading (#925), so the axis is drawn and
+    // reachable while nothing was ever measured on it. It has no extent, so a
+    // value there sits at the midpoint rather than at an end.
+    const unmeasured: LinePoint[][] = [
+      [{ x: 'mpg', y: 33 }, { x: 'hp', y: null }],
+      [{ x: 'mpg', y: 21 }, { x: 'hp', y: null }],
+    ];
+    const stats = parallel(0, 0, unmeasured).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Axes, in order')?.value)
+      .toBe('mpg, hp');
+    expect(brailleGrid(parallel(0, 0, unmeasured))[0][1]).toBe(0.5);
+  });
+  test('one observation gapping an axis does not silence it for the rest', () => {
+    // `Math.min` of anything holding a gap is `NaN`, so counting one into the
+    // extent would leave every value on that axis with a non-finite range to
+    // be scaled against -- silencing the whole variable rather than the one
+    // reading that is missing. This is the trap `LineTrace` filters for, and
+    // a per-axis extent has to filter for it too.
+    const oneGap: LinePoint[][] = [
+      [{ x: 'mpg', y: 33 }, { x: 'hp', y: 65 }],
+      [{ x: 'mpg', y: 15 }, { x: 'hp', y: null }],
+      [{ x: 'mpg', y: 21 }, { x: 'hp', y: 230 }],
+    ];
+    const power = nonEmptyState(parallel(0, 1, oneGap)).audio.freq;
+
+    expect([power.min, power.max]).toEqual([65, 230]);
+  });
+
+  test('an axis only a short observation reaches, and only gaps, is still named', () => {
+    // Nothing was ever measured on it, and no full-width observation carries
+    // it -- so neither the extents nor the widest row would name it on their
+    // own. A cursor still reaches it.
+    const onlyShortAndGapped: LinePoint[][] = [
+      [{ x: 'mpg', y: 33 }, { x: 'hp', y: 65 }],
+      [{ x: 'mpg', y: 21 }, { x: 'noise', y: null }],
+    ];
+    const stats = parallel(0, 0, onlyShortAndGapped).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Axes, in order')?.value)
+      .toBe('mpg, hp, noise');
+  });
+
+  test('the drawn order comes from the widest row, not from what was seen first', () => {
+    // The gappy row is first and skips the middle axis, so reading the order
+    // off first appearance would put `weight` before `hp` -- which reverses
+    // which variables the dialog says sit next to each other, and so which
+    // crossings it implies are visible.
+    const widestSecond: LinePoint[][] = [
+      [{ x: 'mpg', y: 21 }, { x: 'weight', y: 2600 }],
+      [{ x: 'mpg', y: 33 }, { x: 'hp', y: 65 }, { x: 'weight', y: 1800 }],
+    ];
+    const stats = parallel(0, 0, widestSecond).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Axes, in order')?.value)
+      .toBe('mpg, hp, weight');
+  });
+
+  test('an axis with no spread puts every value at the midpoint, not at an end', () => {
+    // 0 and 1 each claim a rank the data does not support. The braille grid is
+    // where it shows: an axis every observation ties on would otherwise draw a
+    // row of cells at the floor.
+    const flat: LinePoint[][] = [
+      [{ x: 'mpg', y: 33 }, { x: 'hp', y: 65 }],
+      [{ x: 'mpg', y: 15 }, { x: 'hp', y: 65 }],
+    ];
+    const grid = brailleGrid(parallel(0, 0, flat));
+
+    expect(grid[0][1]).toBe(0.5);
+    expect(grid[1][1]).toBe(0.5);
+  });
+});
+
 describe('navigation is the multi-line model', () => {
   test('walks axes across and observations up', () => {
     const trace = parallel();


### PR DESCRIPTION
## The bug

`ParallelTrace` took each axis's extent **by column position** — `lineValues.map(row => row[column])`. That holds only while every observation carries a reading on every axis. One that does not is a point shorter, so from the gap onwards its values sit a column left of the axis they belong to, and the extent that column is scaled against ends up holding two units at once.

Measured on three cars over mpg, hp and weight, with car B never measured for power:

```
car A, col 1 -> freq { min: 65, max: 2600, raw: 65 }
car B, col 1 -> freq { min: 65, max: 2600, raw: 2600 }

Axes, in order   mpg, hp, weight
mpg              15 to 33
hp               65 to 2600      <- a horsepower range with a car's weight in it
weight           1800 to 3200
```

2600 is a weight in pounds sitting at the top of a range in horsepower — the exact mixing of units this class exists to prevent.

## All three modalities go with it

- **Pitch collapses.** Car C's 230 hp is the highest power in the chart and should sound at the top of its axis. Against `65..2600` it sits at 0.065, and the axis the chart was drawn to compare cars on is nearly silent.
- **The announcement and the sound name different variables.** Car B's second point announces `weight` — correctly, the point says so — while being played against the hp axis.
- **The dialog is where a reader goes to learn what the axes are**, and it reports that range as `hp`.

Braille follows the pitch: `normalized` is built from the same extents, so the grid encodes each cell against whichever axis happened to line up.

## Reachable from the adapters today

Both emitters produce this shape, and each has a comment about it:

- `extractParallelLayer` (plotly) — `continue` on a null dimension value, under *"A gap on one axis is a break in the line rather than a value, and the per-axis extents this trace scales its pitch by must not see it."* The intent is right; `continue` is what slides the columns.
- `convertParallelSeries` (Highcharts) — `series.data.filter(p => p.y !== null)`.

## The fix

The payload already carried the answer: every `LinePoint` names its own axis in `x`. So the extents are keyed by that name rather than by position, and `positionOnAxis` takes the name. The axis order is the widest observation's — the chart's axes left to right whenever any observation reaches all of them — with any name it lacks appended rather than guessed into place.

Nothing about the adapters changes. Both are correct again exactly as they stand, and a future one that legitimately emits a short row is correct too.

`axisNames()` is gone; the order is computed once at construction alongside the extents, which is where it belongs — the dialog was recomputing it on every read.

## Tests

11 new cases in `test/model/parallel.test.ts`, in one `describe` for the interior gap plus the sharpenings the sweep asked for:

- a value is scaled by the axis its point names, not by its column
- the axis a reader is told they are on is the one they hear
- the shortened row does not widen an axis it never reached
- the dialog reports each axis in its own units
- braille encodes each cell against the axis that cell names
- an axis no full-width observation reaches is still named
- an axis every observation gapped is named without a range
- one observation gapping an axis does not silence it for the rest (the `Math.min`-of-`NaN` trap `LineTrace` filters for)
- an axis only a short observation reaches, and only gaps, is still named
- the drawn order comes from the widest row, not from what was seen first
- an axis with no spread puts every value at the midpoint, not at an end

The existing trailing-gap suite (`observations that do not all reach every axis`) is unchanged and still passes — it was the case the positional reading handled by luck.

An 11-mutation sweep killed 10. The survivor is `extentOf`'s fallback for a name the layer never used: unreachable through either caller, since both ask with a name taken from a point of this layer and every point registered its own name. Documented as such rather than tested.

## Verification

```
npx eslint src test   0
npx tsc --noEmit      0
npm run build         0
npm run docs          0
npm test              0   415 suites / 5736 unit, 10 suites / 137 ESM
```

Unit tests up from 5729 to 5736 on the first pass and 5740 after the sharpenings.

Closes #1182.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_