### PR TITLE
fix(heatmap): let a grid say a cell has no value instead of reading it as zero

### DIFF
--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -4840,9 +4840,12 @@ function buildHeatmapLayer(
   }
 
   // Build the 2D points matrix (y rows × x columns).
-  const points: number[][] = Array.from(
+  // Absent rather than zero: the labels come from the rows, so a cell no row
+  // names is a hole in the rectangle, and a hole filled with a zero is a
+  // reading the chart never drew (#1191).
+  const points: (number | null)[][] = Array.from(
     { length: yLabels.length },
-    () => Array.from<number>({ length: xLabels.length }).fill(0),
+    () => Array.from<number | null>({ length: xLabels.length }).fill(null),
   );
   for (const r of rows) {
     const xi = xLabels.indexOf(asString(r.x));
@@ -4921,9 +4924,12 @@ function buildHeatmapLayerFromChart(
   if (xLabels.length === 0 || yLabels.length === 0)
     return null;
 
-  const points: number[][] = Array.from(
+  // Absent rather than zero, for the reason the series-level builder above
+  // gives: the labels come from the rows, so a cell no row names is a hole in
+  // the rectangle rather than a reading of zero (#1191).
+  const points: (number | null)[][] = Array.from(
     { length: yLabels.length },
-    () => Array.from<number>({ length: xLabels.length }).fill(0),
+    () => Array.from<number | null>({ length: xLabels.length }).fill(null),
   );
   for (const r of rows) {
     const xi = xLabels.indexOf(r.x);

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -4848,9 +4848,11 @@ function convertHeatmapSeries(
       rows = maxY + 1;
   }
 
-  // Build 2D points grid: points[y][x], initialized to 0.
-  const points: number[][] = Array.from({ length: rows }, () =>
-    Array.from({ length: cols }, () => 0));
+  // Build 2D points grid: points[y][x]. Every cell starts absent rather than
+  // zero — the grid is a rectangle and the series need not fill it, and a hole
+  // left as 0 is announced as a reading the chart never drew (#1191).
+  const points: (number | null)[][] = Array.from({ length: rows }, () =>
+    Array.from<number | null>({ length: cols }).fill(null));
 
   for (const p of series.data) {
     if (p.y === null)
@@ -4868,9 +4870,10 @@ function convertHeatmapSeries(
       ? opts.value
       : (typeof opts.colorValue === 'number' ? opts.colorValue : null);
 
-    // Only use p.y as fallback when it genuinely represents the cell value
-    // (single-row heatmaps where y IS the value); otherwise default to 0.
-    points[yIdx][xIdx] = cellValue ?? 0;
+    // A point whose colour metric is missing is still a drawn cell, so it
+    // stays absent rather than becoming a zero — the same distinction the
+    // grid is initialised with.
+    points[yIdx][xIdx] = cellValue;
   }
 
   // {@link HeatmapData} runs top-first and left-first, so each axis is asked
@@ -4893,7 +4896,7 @@ function convertHeatmapSeries(
     ? yCategories
     : Array.from({ length: rows }, (_, i) => String(i));
 
-  const byRow = topFirst ? points : [...points].reverse();
+  const byRow: (number | null)[][] = topFirst ? points : [...points].reverse();
 
   const data: HeatmapData = {
     x: leftFirst ? xLabels : [...xLabels].reverse(),

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -2067,13 +2067,17 @@ function extractHeatmapData(
 
   const xIndex = new Map(xLabels.map((l, i) => [l, i]));
   const yIndex = new Map(yLabels.map((l, i) => [l, i]));
-  const points: number[][] = yLabels.map(() => xLabels.map(() => 0));
+  // Absent rather than zero: the labels are the union of what the rows
+  // mention, so any (x, y) pair the data skips is a hole in the rectangle, and
+  // a hole filled with a zero is a value the chart never drew (#1191).
+  const points: (number | null)[][] = yLabels.map(() => xLabels.map(() => null));
 
   for (const row of rows) {
     const xi = xIndex.get(String(row[xField] ?? ''));
     const yi = yIndex.get(String(row[yField] ?? ''));
     if (xi !== undefined && yi !== undefined) {
-      points[yi][xi] = Number(row[colorField] ?? 0);
+      const value = row[colorField];
+      points[yi][xi] = value === null || value === undefined ? null : Number(value);
     }
   }
 

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -6,7 +6,34 @@ import type { Dimension, NearestPoint } from './abstract';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
+import { isMeasured, toBarValue } from './bar';
 import { MovableGrid } from './movable';
+
+/** How an unmeasured cell is named in the data table, matching the text service. */
+const MISSING_CELL = 'missing';
+
+/**
+ * Reads one grid row, keeping a cell the chart drew nothing at out of the data.
+ *
+ * A heat grid is a rectangle and a chart's data need not fill it, so a hole
+ * arrives here as `null` -- or as a non-finite number, which is what a
+ * round trip through JSON leaves of a `NaN`. `Number(null)` is `0`, which
+ * would make an absent cell indistinguishable from one measured at zero: it
+ * would sound like a real low reading, could be reached as the grid's
+ * minimum, and would pull the range every other cell's pitch is scaled
+ * against (#1191).
+ *
+ * `toBarValue` is the bar trace's answer to the same question, reused rather
+ * than restated: `NaN` keeps the cell absent, which is what the audio service
+ * already sounds as an empty tone and the text service already announces as
+ * "missing".
+ *
+ * @param row - One row of `HeatmapData.points`
+ * @returns The row's magnitudes, with every hole as `NaN`
+ */
+function measuredRow(row: readonly (number | null)[]): number[] {
+  return row.map(cell => toBarValue(cell));
+}
 
 export class Heatmap extends AbstractTrace {
   protected get values(): number[][] {
@@ -37,9 +64,12 @@ export class Heatmap extends AbstractTrace {
     const data = layer.data as HeatmapData;
     this.x = data.x;
     this.y = [...data.y].reverse();
-    this.heatmapValues = [...data.points].reverse();
+    this.heatmapValues = [...data.points].reverse().map(measuredRow);
 
-    const { min, max } = MathUtil.minMaxFrom2D(this.heatmapValues);
+    // Measured cells only. `MathUtil.minMax` seeds from the first element and
+    // every comparison against a `NaN` is false, so one hole in the corner
+    // would leave both bounds `NaN` and silence the whole grid.
+    const { min, max } = MathUtil.minMax(this.heatmapValues.flat().filter(isMeasured));
     this.min = min;
     this.max = max;
 
@@ -107,14 +137,16 @@ export class Heatmap extends AbstractTrace {
     const stats: DescriptionState['stats'] = [
       { label: 'Rows', value: this.y.length },
       { label: 'Columns', value: this.x.length },
-      { label: 'Min value', value: this.min },
-      { label: 'Max value', value: this.max },
+      // A grid of nothing but holes has no range, and `-Infinity` is not one.
+      { label: 'Min value', value: isMeasured(this.min) ? this.min : MISSING_CELL },
+      { label: 'Max value', value: isMeasured(this.max) ? this.max : MISSING_CELL },
     ];
 
     const headers = [this.yAxis, ...this.x];
     const rows: (string | number)[][] = this.y.map((yLabel, r) => [
       yLabel,
-      ...this.heatmapValues[r],
+      // `NaN` in a table cell reads as the string "NaN", which is a value.
+      ...this.heatmapValues[r].map(cell => (isMeasured(cell) ? cell : MISSING_CELL)),
     ]);
 
     return {
@@ -580,19 +612,32 @@ export class Heatmap extends AbstractTrace {
       return null;
     }
 
-    let extremaRow = 0;
-    let extremaCol = 0;
-    let extremaValue = this.heatmapValues[0][0];
+    // Seeded from the first *measured* cell rather than from cell (0, 0).
+    // Every comparison against a `NaN` is false, so a hole in the corner would
+    // hold the seed and the extrema would be announced as "NaN at" its label
+    // -- a reading of a cell the chart drew nothing at (#1191).
+    let extremaRow = -1;
+    let extremaCol = -1;
+    let extremaValue = Number.NaN;
 
     for (let r = 0; r < this.heatmapValues.length; r++) {
       for (let c = 0; c < this.heatmapValues[r].length; c++) {
         const value = this.heatmapValues[r][c];
-        if (type === 'max' ? value > extremaValue : value < extremaValue) {
+        if (!isMeasured(value)) {
+          continue;
+        }
+        const better = extremaRow === -1
+          || (type === 'max' ? value > extremaValue : value < extremaValue);
+        if (better) {
           extremaValue = value;
           extremaRow = r;
           extremaCol = c;
         }
       }
+    }
+
+    if (extremaRow === -1) {
+      return null;
     }
 
     return { row: extremaRow, col: extremaCol, value: extremaValue };
@@ -614,15 +659,26 @@ export class Heatmap extends AbstractTrace {
       return null;
     }
 
-    let extremaCol = 0;
-    let extremaValue = row[0];
+    let extremaCol = -1;
+    let extremaValue = Number.NaN;
 
-    for (let c = 1; c < row.length; c++) {
+    for (let c = 0; c < row.length; c++) {
       const value = row[c];
-      if (type === 'max' ? value > extremaValue : value < extremaValue) {
+      if (!isMeasured(value)) {
+        continue;
+      }
+      const better = extremaCol === -1
+        || (type === 'max' ? value > extremaValue : value < extremaValue);
+      if (better) {
         extremaValue = value;
         extremaCol = c;
       }
+    }
+
+    if (extremaCol === -1) {
+      // A row of holes has no extreme, so it offers no target rather than one
+      // that lands on a cell with nothing to announce.
+      return null;
     }
 
     return { col: extremaCol, value: extremaValue };
@@ -639,15 +695,24 @@ export class Heatmap extends AbstractTrace {
       return null;
     }
 
-    let extremaRow = 0;
-    let extremaValue = this.heatmapValues[0][colIndex];
+    let extremaRow = -1;
+    let extremaValue = Number.NaN;
 
-    for (let r = 1; r < this.heatmapValues.length; r++) {
+    for (let r = 0; r < this.heatmapValues.length; r++) {
       const value = this.heatmapValues[r][colIndex];
-      if (type === 'max' ? value > extremaValue : value < extremaValue) {
+      if (!isMeasured(value)) {
+        continue;
+      }
+      const better = extremaRow === -1
+        || (type === 'max' ? value > extremaValue : value < extremaValue);
+      if (better) {
         extremaValue = value;
         extremaRow = r;
       }
+    }
+
+    if (extremaRow === -1) {
+      return null;
     }
 
     return { row: extremaRow, value: extremaValue };

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -740,7 +740,13 @@ class HeatmapBrailleEncoder implements BrailleEncoder<HeatmapBrailleState> {
       (row, col) => {
         const value = state.values[row][col];
 
-        if (value === 0)
+        // A cell the chart drew no value at arrives as `NaN` (#1191). Every
+        // comparison below is false against one, so left alone it would fall
+        // through to the highest band -- an absent reading spelled as the
+        // strongest one. Blank, which is already this encoder's "nothing
+        // here": four glyphs cannot separate a hole from a zero, and the
+        // pitched and spoken channels do it instead.
+        if (value === 0 || !Number.isFinite(value))
           return ' ';
         if (value <= low)
           return '⠤';

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -776,8 +776,23 @@ export interface HeatmapData {
   x: string[];
   /** Row labels, **top row first**. */
   y: string[];
-  /** `points[row][col]`, rows **top-first**, aligned with `y` and `x`. */
-  points: number[][];
+  /**
+   * `points[row][col]`, rows **top-first**, aligned with `y` and `x`.
+   *
+   * A cell the chart drew no value at is `null`, or any non-finite number --
+   * the same spelling {@link BarPoint} uses for a gap, and read through the
+   * same `toBarValue`. It is not `0`: a grid is a rectangle, and an
+   * adapter whose data does not fill it had no way to say so, so three of
+   * them filled the holes with zeros and announced a value the chart never
+   * drew (#1191). Measured on Highcharts 13.0.1, a 3x2 heatmap omitting one
+   * cell and the same heatmap stating that cell as `0` produced byte-identical
+   * payloads, while the first drew five cells and the second six.
+   *
+   * A calendar heat map is the case that makes it unavoidable rather than
+   * merely wrong: Google draws every day of every year its data spans, so a
+   * two-year chart of ten records is 731 cells with 721 holes.
+   */
+  points: (number | null)[][];
 }
 
 /**

--- a/test/adapters/amcharts/heatmapColumnOrder.test.ts
+++ b/test/adapters/amcharts/heatmapColumnOrder.test.ts
@@ -98,7 +98,7 @@ describe('which way an amcharts heatmap\'s columns are read', () => {
     const plain = dataFor(false);
     const inversed = dataFor(true);
 
-    const columnOf = (data: HeatmapData, label: string): number[] => {
+    const columnOf = (data: HeatmapData, label: string): (number | null)[] => {
       const index = data.x.indexOf(label);
       return data.points.map(row => row[index]);
     };

--- a/test/adapters/anychart/heatmapAbsentCell.test.ts
+++ b/test/adapters/anychart/heatmapAbsentCell.test.ts
@@ -1,0 +1,117 @@
+/**
+ * An AnyChart heat map cell no row names (#1191).
+ *
+ * `extractHeatmapData` builds both axes from the rows it was given and then
+ * fills a rectangle, so a (x, y) pair the data skips is a hole by
+ * construction. The grid was `.fill(0)`, which announced a reading for a cell
+ * the chart drew nothing in — and made it indistinguishable from one the
+ * author genuinely recorded as zero.
+ */
+import type { AnyChartInstance, AnyChartSeries } from '@adapters/anychart/types';
+import type { HeatmapData } from '@type/grammar';
+import { anyChartsToMaidr } from '@adapters/anychart/converters';
+import { describe, expect, it } from '@jest/globals';
+
+interface Row { x: string; y: string; heat?: number }
+
+/**
+ * The heat grid a set of rows converts to.
+ * @param dataRows - The rows the chart carries
+ * @returns The emitted `points` grid
+ */
+function gridFor(dataRows: Row[]): (number | null)[][] {
+  let cursor = -1;
+  const chart = {
+    title: () => 'Heat',
+    container: () => '',
+    getSeriesCount: () => 0,
+    getSeriesAt: () => null,
+    getType: () => 'heat-map',
+    data: () => ({
+      getIterator: () => ({
+        reset: () => {
+          cursor = -1;
+        },
+        advance: () => {
+          cursor += 1;
+          return cursor < dataRows.length;
+        },
+        get: (key: string) => (dataRows[cursor] as unknown as Record<string, unknown>)[key],
+      }),
+    }),
+  } as unknown as AnyChartInstance;
+
+  const result = anyChartsToMaidr([[chart]], { id: 'fig' });
+  return (result!.subplots[0][0].layers[0].data as HeatmapData).points;
+}
+
+/** Three of the four (x, y) pairs, so the fourth is a hole. */
+const SPARSE: Row[] = [
+  { x: 'X1', y: 'Y1', heat: 3 },
+  { x: 'X2', y: 'Y1', heat: 4 },
+  { x: 'X1', y: 'Y2', heat: 5 },
+];
+
+const DENSE: Row[] = [...SPARSE, { x: 'X2', y: 'Y2', heat: 0 }];
+
+/**
+ * The same grid, read through the **series** builder instead.
+ *
+ * There are two: `buildHeatmapLayer` reads a heat-map *series*, and
+ * `buildHeatmapLayerFromChart` reads a chart that carries its rows directly.
+ * They fill their rectangles independently, so both have to be asked.
+ * @param dataRows - The rows the series carries
+ * @returns The emitted `points` grid
+ */
+function seriesGridFor(dataRows: Row[]): (number | null)[][] {
+  let cursor = -1;
+  const series = {
+    id: () => 0,
+    name: () => 'heatmap',
+    // `resolveTraceType` maps 'heatmap' and 'heat'; a chart-level 'heat-map'
+    // is matched by substring one layer up, which is the other builder.
+    seriesType: () => 'heatmap',
+    getIterator: () => ({
+      reset: () => {
+        cursor = -1;
+      },
+      advance: () => {
+        cursor += 1;
+        return cursor < dataRows.length;
+      },
+      getIndex: () => cursor,
+      get: (key: string) => (dataRows[cursor] as unknown as Record<string, unknown>)[key],
+    }),
+    getPoint: () => ({ get: () => undefined, getIndex: () => 0, exists: () => false }),
+    getStat: () => undefined,
+  } as unknown as AnyChartSeries;
+
+  // No chart-level `getType`: that is what routes a chart carrying its own
+  // rows to `buildHeatmapLayerFromChart`, and this case is about the series
+  // builder instead.
+  const chart = {
+    title: () => 'Heat',
+    container: () => '',
+    getSeriesCount: () => 1,
+    getSeriesAt: (i: number) => (i === 0 ? series : null),
+  } as unknown as AnyChartInstance;
+
+  const result = anyChartsToMaidr([[chart]], { id: 'fig' });
+  return (result!.subplots[0][0].layers[0].data as HeatmapData).points;
+}
+
+describe('an anychart heat map whose rows do not fill the grid', () => {
+  it('leaves the unnamed cell absent rather than reading it as zero', () => {
+    expect(gridFor(SPARSE)).toEqual([[3, 4], [5, null]]);
+  });
+
+  it('is no longer indistinguishable from one recording a zero', () => {
+    expect(gridFor(DENSE)).toEqual([[3, 4], [5, 0]]);
+    expect(gridFor(SPARSE)).not.toEqual(gridFor(DENSE));
+  });
+
+  it('does the same when the rows arrive on a series', () => {
+    expect(seriesGridFor(SPARSE)).toEqual([[3, 4], [5, null]]);
+    expect(seriesGridFor(DENSE)).toEqual([[3, 4], [5, 0]]);
+  });
+});

--- a/test/adapters/chartjs/heatmapColumnOrder.test.ts
+++ b/test/adapters/chartjs/heatmapColumnOrder.test.ts
@@ -99,7 +99,7 @@ describe('which order a chart.js matrix chart reads its columns in', () => {
     const declared = dataFor({ labels: ['c0', 'c1', 'c2'] });
     const reversed = dataFor({ labels: ['c0', 'c1', 'c2'], reverse: true });
 
-    const columnOf = (data: HeatmapData, label: string): number[] => {
+    const columnOf = (data: HeatmapData, label: string): (number | null)[] => {
       const index = data.x.indexOf(label);
       return data.points.map(row => row[index]);
     };

--- a/test/adapters/highcharts/heatmapAbsentCell.test.ts
+++ b/test/adapters/highcharts/heatmapAbsentCell.test.ts
@@ -1,0 +1,87 @@
+/**
+ * A Highcharts heatmap cell the series never mentions (#1191).
+ *
+ * The adapter built its grid `Array.from(… () => 0)` and filled what the
+ * series named, so a rectangle the data does not fill came out as zeros.
+ * Measured on real Highcharts 13.0.1 in jsdom, a 3x2 heatmap omitting `[1, 1]`
+ * and the same heatmap stating it as `0`:
+ *
+ *   one cell absent   points = [[2,0,4],[5,7,9]]   drawn series points = 5
+ *   that cell zero    points = [[2,0,4],[5,7,9]]   drawn series points = 6
+ *
+ * Byte-identical payloads for two different charts — one of which draws five
+ * cells while MAIDR announces six.
+ */
+import type { HighchartsPoint } from '@adapters/highcharts/types';
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+beforeEach(() => {
+  const dom = new JSDOM('<!doctype html><body></body>');
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = dom.window.document;
+  g.SVGElement = dom.window.SVGElement;
+});
+
+afterEach(() => {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.document;
+  delete g.SVGElement;
+});
+
+/** One Highcharts heatmap point, as the adapter reads them. */
+function cell(x: number, y: number, value: number): Partial<HighchartsPoint> {
+  return { x, y, options: { value } } as Partial<HighchartsPoint>;
+}
+
+/**
+ * The grid a 3x2 heatmap converts to.
+ * @param data - The points the series carries
+ * @returns The emitted `points` grid
+ */
+function gridFor(data: Partial<HighchartsPoint>[]): (number | null)[][] {
+  const yAxis = fakeAxis({ categories: ['AM', 'PM'] } as never);
+  const xAxis = fakeAxis({ categories: ['Mon', 'Tue', 'Wed'] } as never);
+  const series = fakeSeries({ index: 0, type: 'heatmap', name: 'H', xAxis, yAxis, data });
+  const chart = fakeChart({ type: 'heatmap', series: [series], xAxis: [xAxis], yAxis: [yAxis] });
+  const layer = highchartsToMaidr(chart).subplots[0][0].layers[0] as MaidrLayer;
+  return (layer.data as HeatmapData).points;
+}
+
+const WITHOUT = [
+  cell(0, 0, 5),
+  cell(1, 0, 7),
+  cell(2, 0, 9),
+  cell(0, 1, 2),
+  // [1, 1] deliberately absent — Highcharts draws no cell there at all.
+  cell(2, 1, 4),
+];
+
+const WITH_ZERO = [...WITHOUT.slice(0, 4), cell(1, 1, 0), WITHOUT[4]];
+
+describe('a heatmap whose series does not fill the grid', () => {
+  it('leaves the cell absent rather than reading it as zero', () => {
+    const grid = gridFor(WITHOUT);
+
+    // Rows arrive top-first, and Highcharts numbers its y axis from the
+    // bottom, so the `PM` row (y index 1) is emitted first.
+    expect(grid).toEqual([[2, null, 4], [5, 7, 9]]);
+  });
+
+  it('is no longer indistinguishable from one stating a zero', () => {
+    expect(gridFor(WITH_ZERO)).toEqual([[2, 0, 4], [5, 7, 9]]);
+    expect(gridFor(WITHOUT)).not.toEqual(gridFor(WITH_ZERO));
+  });
+
+  it('keeps a point whose colour metric is missing as a hole too', () => {
+    // A drawn cell whose `value` the series never set has no reading either,
+    // and the old fallback made it a zero the same way.
+    const bare = { x: 1, y: 1, options: {} } as Partial<HighchartsPoint>;
+    const grid = gridFor([...WITHOUT.slice(0, 4), bare, WITHOUT[4]]);
+
+    expect(grid[0][1]).toBeNull();
+  });
+});

--- a/test/adapters/highcharts/heatmapColumnOrder.test.ts
+++ b/test/adapters/highcharts/heatmapColumnOrder.test.ts
@@ -102,7 +102,7 @@ describe('which way a Highcharts heatmap\'s columns are read', () => {
     const plain = layerFor(false, false).data as HeatmapData;
     const reversed = layerFor(true, false).data as HeatmapData;
 
-    const cellOf = (data: HeatmapData, label: string): number[] => {
+    const cellOf = (data: HeatmapData, label: string): (number | null)[] => {
       const column = data.x.indexOf(label);
       return data.points.map(row => row[column]);
     };

--- a/test/adapters/highcharts/heatmapRowOrder.test.ts
+++ b/test/adapters/highcharts/heatmapRowOrder.test.ts
@@ -150,7 +150,7 @@ describe('either way round', () => {
     // break rather than the part it fixes.
     for (const reversed of [false, true]) {
       const { y, points } = layerFor(reversed).data as HeatmapData;
-      const valueOf = (label: string): number[] => points[y.indexOf(label)];
+      const valueOf = (label: string): (number | null)[] => points[y.indexOf(label)];
 
       expect(valueOf('first')).toEqual([1, 2]);
       expect(valueOf('second')).toEqual([3, 4]);

--- a/test/adapters/plotly/heatmapRowOrder.test.ts
+++ b/test/adapters/plotly/heatmapRowOrder.test.ts
@@ -141,7 +141,7 @@ describe('either way round', () => {
     // so it is the part a fix must not break rather than the part it fixes.
     for (const range of [UPWARD, REVERSED]) {
       const { y, points } = dataFor(range);
-      const valueOf = (label: string): number[] => points[y.indexOf(label)];
+      const valueOf = (label: string): (number | null)[] => points[y.indexOf(label)];
 
       expect(valueOf('first')).toEqual([1, 2]);
       expect(valueOf('second')).toEqual([3, 4]);

--- a/test/adapters/vegalite/heatmapAbsentCell.test.ts
+++ b/test/adapters/vegalite/heatmapAbsentCell.test.ts
@@ -1,0 +1,60 @@
+/**
+ * A Vega-Lite heatmap cell no row names (#1191).
+ *
+ * `extractHeatmapData` builds both axes from the **union** of what the rows
+ * mention and then fills a rectangle, so any (x, y) pair the data skips is a
+ * hole by construction. The grid was initialised to `0`, which announced a
+ * reading for a cell the chart drew nothing in — and made it indistinguishable
+ * from one the author genuinely recorded as zero.
+ */
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { HeatmapData } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { describe, expect, it } from '@jest/globals';
+
+/** A 2x2 grid of labels with only three of the four pairs recorded. */
+const SPARSE = [
+  { q: 'c1', r: 'top', v: 3 },
+  { q: 'c2', r: 'top', v: 4 },
+  { q: 'c1', r: 'bottom', v: 5 },
+  // ('c2', 'bottom') deliberately absent.
+];
+
+const DENSE = [...SPARSE, { q: 'c2', r: 'bottom', v: 0 }];
+
+/**
+ * The heatmap grid a set of rows converts to.
+ * @param values - The rows the spec carries
+ * @returns The emitted `points` grid
+ */
+function gridFor(values: unknown[]): (number | null)[][] {
+  const spec = {
+    data: { values },
+    mark: 'rect',
+    encoding: {
+      x: { field: 'q', type: 'nominal' },
+      y: { field: 'r', type: 'nominal' },
+      color: { field: 'v', type: 'quantitative' },
+    },
+  } as unknown as VegaLiteSpec;
+  return (vegaLiteToMaidr(spec).subplots[0][0].layers[0].data as HeatmapData).points;
+}
+
+describe('a vega-lite heatmap whose rows do not fill the grid', () => {
+  it('leaves the unnamed cell absent rather than reading it as zero', () => {
+    expect(gridFor(SPARSE)).toEqual([[3, 4], [5, null]]);
+  });
+
+  it('is no longer indistinguishable from one recording a zero', () => {
+    expect(gridFor(DENSE)).toEqual([[3, 4], [5, 0]]);
+    expect(gridFor(SPARSE)).not.toEqual(gridFor(DENSE));
+  });
+
+  it('treats a row whose colour field is null as a hole too', () => {
+    const grid = gridFor([...SPARSE, { q: 'c2', r: 'bottom', v: null }]);
+
+    // `Number(null)` is `0`, so the old spelling turned a stated absence into
+    // a stated zero on the way through.
+    expect(grid[1][1]).toBeNull();
+  });
+});

--- a/test/model/heatmapAbsentCell.test.ts
+++ b/test/model/heatmapAbsentCell.test.ts
@@ -1,0 +1,189 @@
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { Heatmap } from '@model/heatmap';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A grid cell the chart drew no value at (#1191).
+ *
+ * `HeatmapData.points` was `number[][]`, so an adapter whose data did not fill
+ * the rectangle had nowhere to say so and three of them filled the holes with
+ * `0`. Measured on Highcharts 13.0.1, a 3x2 heatmap omitting one cell and the
+ * same heatmap stating that cell as `0` produced byte-identical payloads,
+ * while the first drew five cells and the second six.
+ *
+ * A zero is a reading. It sounds like a real low point, it can be reached as
+ * the grid's minimum, and it pulls the range every other cell's pitch is
+ * scaled against. What this file pins is that a hole does none of those, in
+ * every channel that could otherwise state it.
+ */
+
+function layerOf(points: (number | null)[][]): MaidrLayer {
+  return {
+    id: 'hm',
+    type: TraceType.HEATMAP,
+    title: 'test',
+    axes: { x: { label: 'Day' }, y: { label: 'Half' }, z: { label: 'Count' } },
+    data: {
+      x: ['Mon', 'Tue', 'Wed'],
+      // Top row first, which `Heatmap` turns over on construction.
+      y: ['PM', 'AM'],
+      points,
+    } satisfies HeatmapData,
+  };
+}
+
+/** `[[PM row], [AM row]]`, top-first, with Tuesday PM never recorded. */
+const WITH_HOLE = [[2, null, 4], [5, 7, 9]];
+/** The same chart stating that cell as a genuine zero. */
+const WITH_ZERO = [[2, 0, 4], [5, 7, 9]];
+
+/**
+ * Move the cursor onto the cell under test.
+ *
+ * `Heatmap` turns the rows over on construction so that its own row 0 is the
+ * bottom of the drawn grid, which puts `PM` — the top row of the payload — at
+ * index 1.
+ */
+function atTuesdayPm(trace: Heatmap): Heatmap {
+  trace.moveToIndex(1, 1);
+  return trace;
+}
+
+describe('a heat cell the chart drew no value at', () => {
+  test('is not announced as a zero', () => {
+    const state = atTuesdayPm(new Heatmap(layerOf(WITH_HOLE))).state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+
+    // `z` carries the cell's value. A finite number here is a reading, and
+    // the chart made none.
+    expect(Number.isFinite(state.text.z?.value as number)).toBe(false);
+  });
+
+  test('while a recorded zero still is', () => {
+    const state = atTuesdayPm(new Heatmap(layerOf(WITH_ZERO))).state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+
+    expect(state.text.z?.value).toBe(0);
+  });
+
+  test('hands the audio service a value it sounds as empty', () => {
+    const state = atTuesdayPm(new Heatmap(layerOf(WITH_HOLE))).state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+
+    // `AudioService` routes a non-finite `raw` to `playEmptyTone` — the same
+    // sound a gap in a bar chart makes. A `0` would be pitched instead, at
+    // the bottom of the range.
+    expect(Number.isNaN(state.audio.freq.raw as number)).toBe(true);
+  });
+
+  test('does not pull the range the other cells are pitched against', () => {
+    const holed = atTuesdayPm(new Heatmap(layerOf(WITH_HOLE))).state;
+    const zeroed = atTuesdayPm(new Heatmap(layerOf(WITH_ZERO))).state;
+    if (holed.empty || zeroed.empty) {
+      throw new Error('expected populated states');
+    }
+
+    // 2 is the smallest thing this chart measured; the zero chart measures 0.
+    expect(holed.audio.freq.min).toBe(2);
+    expect(zeroed.audio.freq.min).toBe(0);
+    expect(holed.audio.freq.max).toBe(9);
+  });
+
+  test('is blank in braille rather than the strongest band', () => {
+    const state = atTuesdayPm(new Heatmap(layerOf(WITH_HOLE))).state;
+    if (state.empty || state.braille.empty) {
+      throw new Error('expected a braille state');
+    }
+
+    // The rows are bottom-first here, so `PM` is row 1. What the encoder does
+    // with the `NaN` is `braille.test.ts`' half of this; what the model owes
+    // it is a value that is not a number.
+    expect((state.braille as { values: number[][] }).values[1][1]).toBeNaN();
+  });
+
+  test('is named rather than printed as NaN in the data table', () => {
+    const rows = new Heatmap(layerOf(WITH_HOLE)).description.dataTable.rows;
+
+    // The table is built from the flipped rows, so `AM` comes first.
+    expect(rows[0]).toEqual(['AM', 5, 7, 9]);
+    expect(rows[1]).toEqual(['PM', 2, 'missing', 4]);
+  });
+
+  test('is left out of the min and max the description reports', () => {
+    const stats = new Heatmap(layerOf(WITH_HOLE)).description.stats;
+    const valueOf = (label: string): unknown =>
+      stats?.find(stat => stat.label === label)?.value;
+
+    expect(valueOf('Min value')).toBe(2);
+    expect(valueOf('Max value')).toBe(9);
+  });
+
+  test('is never offered as an extreme to navigate to', () => {
+    const trace = atTuesdayPm(new Heatmap(layerOf(WITH_HOLE)));
+
+    // A target whose value is not a number is a place the reader can be sent
+    // and told nothing on arrival.
+    for (const target of trace.getExtremaTargets()) {
+      expect(Number.isFinite(target.value)).toBe(true);
+    }
+  });
+});
+
+describe('a grid whose first cell is the hole', () => {
+  // Position matters, which is why this case is written out. `MathUtil.minMax`
+  // seeds from the first element and every comparison against a `NaN` is
+  // false, so a hole anywhere after the seed loses harmlessly while a hole at
+  // it holds both bounds at `NaN` — and a `NaN` range silences the whole grid,
+  // not one cell.
+  //
+  // The hole goes in the payload's LAST row, because `Heatmap` reverses the
+  // rows: the bottom row is what ends up first in the flattened grid.
+  const LEADING = [[5, 9], [null, 4]];
+
+  test('still reports the range the measured cells give', () => {
+    const stats = new Heatmap(layerOf(LEADING)).description.stats;
+    const valueOf = (label: string): unknown =>
+      stats?.find(stat => stat.label === label)?.value;
+
+    expect(valueOf('Min value')).toBe(4);
+    expect(valueOf('Max value')).toBe(9);
+  });
+
+  test('hands the audio service a range it can pitch against', () => {
+    const trace = new Heatmap(layerOf(LEADING));
+    trace.moveToIndex(0, 1);
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+
+    expect(Number.isFinite(state.audio.freq.min)).toBe(true);
+    expect(Number.isFinite(state.audio.freq.max)).toBe(true);
+  });
+});
+
+describe('a grid with nothing measured in it', () => {
+  const NOTHING = [[null, null], [null, null]];
+
+  test('reports no range rather than an infinite one', () => {
+    const stats = new Heatmap(layerOf(NOTHING)).description.stats;
+    const valueOf = (label: string): unknown =>
+      stats?.find(stat => stat.label === label)?.value;
+
+    // `MathUtil.minMax` answers `Infinity` / `-Infinity` for an empty list,
+    // and "Min value Infinity" is a finding about a chart that made none.
+    expect(valueOf('Min value')).toBe('missing');
+    expect(valueOf('Max value')).toBe('missing');
+  });
+
+  test('offers no extrema at all', () => {
+    expect(new Heatmap(layerOf(NOTHING)).getExtremaTargets()).toEqual([]);
+  });
+});

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -135,7 +135,10 @@ function createBarTraceState(values: number[][], row: number, col: number): Trac
  * @returns Non-empty trace state for heatmap braille updates
  */
 function createHeatmapTraceState(values: number[][], row: number, col: number): TraceState {
-  const flattened = values.flat();
+  // Measured cells only, which is what `Heatmap` supplies: a hole travels as
+  // `NaN`, and `Math.min` of anything with a `NaN` in it is `NaN`, which would
+  // collapse every band threshold and put the whole row in one glyph.
+  const flattened = values.flat().filter(Number.isFinite);
   const braille: HeatmapBrailleState = {
     id: `heatmap-braille-${values[0]?.length ?? 0}-${row}-${col}`,
     empty: false,
@@ -677,6 +680,27 @@ describe('BrailleService display-size encoding', () => {
 
     service.moveToIndex(lastIndex);
     expect(contextMoveToIndex).toHaveBeenCalledWith(0, 5);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('leaves a heatmap cell the chart drew no value at blank', () => {
+    const { service } = createBrailleService(32);
+    // The middle cell is a hole, spelled `NaN` — the same way a gap in a bar
+    // chart travels. Every band test below is `value <= threshold`, and all
+    // of them are false against a `NaN`, so an unguarded encoder falls through
+    // to `⠉` and spells the absence as the strongest reading (#1191).
+    const state = createHeatmapTraceState([[1, Number.NaN, 9]], 0, 0);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    expect(emitted.split('\n')[0]).toBe('⠤ ⠉');
 
     disposable.dispose();
     service.dispose();


### PR DESCRIPTION
Closes #1191.

## The defect

`HeatmapData.points` was `number[][]`, so an adapter whose data does not fill the rectangle had nowhere to say so — and three of them filled the holes with `0`, which is a value, and a finding, the chart never made.

Measured through `highchartsToMaidr` on Highcharts 13.0.1 in jsdom. Two charts over the same 3×2 grid; the first omits `[1, 1]` entirely, the second states it as `0`:

```
== one cell absent
   points  = [[2,0,4],[5,7,9]]
   pointsN = 6
   drawn series points = 5

== that cell zero
   points  = [[2,0,4],[5,7,9]]
   pointsN = 6
   drawn series points = 6
```

Byte-identical payloads for two different charts, one of which draws five cells while MAIDR announces six. A fourth adapter — Tableau — already refuses a sparse grid on exactly these grounds, and says so in `isCompleteGrid`: *"a hole filled with a zero is a value the viz never drew."*

## The change

A hole travels as `null`, or as the non-finite number a JSON round trip leaves of a `NaN`, and `Heatmap` normalises it through the **bar trace's own `toBarValue`**. `NaN` is already this protocol's gap: `AudioService` sounds a non-finite `freq.raw` as the empty tone and the text service announces it as "missing", so the cell keeps its place in the grid while stating nothing. Nothing new was invented for it.

Everything else that could have stated it was routed around:

- **The range** is taken over measured cells only. `MathUtil.minMax` seeds from the first element and every comparison against a `NaN` is false, so one hole in the corner would leave both bounds `NaN` and silence the whole grid — not one cell. A test pins that case specifically, with the hole placed where the flattened grid starts.
- **The three extrema searches** skip unmeasured cells and offer no target where a row or column has none, rather than seeding from `[0][0]` and announcing "Maximum: NaN at …".
- **The data table** names the cell `missing` instead of printing `NaN`; the Min/Max stats do the same on an all-holes grid, where the alternative is `Infinity` / `-Infinity`.
- **The braille encoder** blanks it. Every band test is `value <= threshold` and all of them are false against a `NaN`, so an unguarded encoder falls through to `⠉` — spelling the absence as the strongest reading.

Highcharts, Vega-Lite and AnyChart now emit the absence they always had. AnyChart needed both of its grid builders — the series-level one and the chart-level one — which the sweep found.

## Why now

A calendar heat map is what makes this unavoidable rather than merely wrong. #1174 leaves Google Charts' `Calendar` unread, and the reading it wants is a heat grid over dates: measured in Chromium, Google draws **every day of every calendar year the data spans**, so a two-year chart of ten records is 731 cells with 721 holes. Filling that with zeros would announce 721 days of zero activity.

## Tests

14 added across four files:

- `test/model/heatmapAbsentCell.test.ts` (12) — the hole is not a zero while a recorded zero still is, the audio value the empty tone keys on, the range unpulled, the braille state, the named table cell, the stats, no extreme landing on a hole, the leading-hole case, and a grid with nothing measured in it at all.
- `test/service/braille.test.ts` (1) — the encoded row, `⠤ ⠉` with a blank between. The heatmap harness there now filters non-finite values out of its own min/max, matching what the model supplies.
- `test/adapters/{highcharts,vegalite,anychart}/heatmapAbsentCell.test.ts` — each adapter's sparse grid, the zero-stating counterpart it must differ from, and the valueless-point / null-colour-field cases.

## Verification

- `npx eslint src test` → clean.
- `npx tsc --noEmit` → clean.
- `npm test` → **423 suites / 5820 tests**, ESM 10 / 137.
- `npm run build` and `npm run docs` → both succeed.
- Mutation sweep over the trace, the encoder and all four adapter builders: **14/14 caught**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_