### PR TITLE
feat(google-charts): read a Calendar as the heat grid it draws

### DIFF
--- a/docs/google-charts.md
+++ b/docs/google-charts.md
@@ -113,8 +113,22 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
 | Volcano | `ScatterChart` of effect size against significance | `'VolcanoChart'` |
 | Manhattan | `ScatterChart` with one series per chromosome | `'ManhattanChart'` |
 | Tree | `OrgChart` (`orgchart` package) — people joined by manager pointers | `'OrgChart'` |
+| Calendar | `Calendar` (`calendar` package) — a year of days shaded by a value | `'Calendar'` |
 
-**Not supported:** Histogram (Google Charts API doesn't expose bin boundaries), Heatmap (not a native Google Charts type), Calendar.
+**Not supported:** Histogram (Google Charts API doesn't expose bin boundaries), Heatmap (not a native Google Charts type).
+
+> **Calendar note:** a `Calendar` becomes **one heat-grid layer per calendar
+> year its dates span**, because the package restarts its week columns each
+> January — a chart covering 2012 and 2013 draws fourteen cell rows, not seven.
+> Each layer is seven weekday rows (Sunday first, as drawn) by one column per
+> week, named by the Sunday the week begins on; <kbd>Page Down</kbd> moves to
+> the next year. Two absences meet in the grid and mean different things: a day
+> inside the year with no row in the table is drawn as a white cell — no value,
+> but an element to outline — while the slots before January's first weekday
+> and after December's last are not drawn at all, and carry neither. The values
+> come from the DataTable rather than the fills, because the **minimum** value
+> is painted the same `#ffffff` as a day with no data; two rows naming the same
+> day are not summed, and the last one wins, which is what the package draws.
 
 > **Stacking note:** the adapter is handed the chart, the DataTable and the container, but never the draw options — so `isStacked` is invisible to it. That is why a stacked or percent-stacked chart is named by its own `chartType` string rather than detected. Passing `'AreaChart'` for a chart drawn with `isStacked: true` is not a cosmetic mistake: the bands would be announced as independent series, and the running total a sighted reader sees along the top edge would go missing entirely.
 

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -631,6 +631,12 @@ function buildLayers(
     return buildGaugeLayers(dt, container, reading.gaugeOptions);
   }
 
+  // A calendar draws one grid per year its dates span, which is the second
+  // chart answered here rather than in the single-layer switch below.
+  if (chartType === 'Calendar') {
+    return buildCalendarLayers(dt, container);
+  }
+
   return [buildLayer(chart, dt, container, chartType, reading)];
 }
 
@@ -638,7 +644,7 @@ function buildLayer(
   chart: GoogleChart,
   dt: GoogleDataTable,
   container: HTMLElement,
-  chartType: Exclude<GoogleChartType, 'Gauge'>,
+  chartType: Exclude<GoogleChartType, 'Gauge' | 'Calendar'>,
   reading: GoogleChartReadingOptions,
 ): MaidrLayer {
   // Intervals are the one reading model the DataTable itself decides: a
@@ -748,7 +754,7 @@ function buildLayer(
       throw new Error(
         `Unsupported Google Charts type: ${chartType as string}. `
         + 'Supported types: AreaChart, BarChart, BubbleChart, BumpChart, CandlestickChart, '
-        + 'ColumnChart, '
+        + 'Calendar, ColumnChart, '
         + 'DivergingBarChart, DivergingColumnChart, DodgedBarChart, DodgedColumnChart, '
         + 'DotChart, DumbbellChart, FunnelChart, Gantt, Gauge, GeoChart, LineChart, '
         + 'LollipopChart, ManhattanChart, NormalizedAreaChart, OrgChart, PieChart, Sankey, '
@@ -2483,6 +2489,341 @@ function gaugeBands(options: GoogleGaugeOptions, min: number): GaugeBand[] | und
     edge = band.to;
   }
   return bands;
+}
+
+// ---------------------------------------------------------------------------
+// Calendar (a heat grid over dates)
+// ---------------------------------------------------------------------------
+
+/** Row labels, top-first, matching the `S M T W T F S` Google draws. */
+const WEEKDAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+const DAYS_PER_WEEK = 7;
+
+/**
+ * Builds one heat grid per calendar year a Google Charts `Calendar` covers.
+ *
+ * The DataTable is `[date, value]`, and the chart draws it as day cells:
+ * weekday down the page, week across it, one block per year stacked
+ * vertically. That is a `heat` grid, and the two axes are the two the reader
+ * navigates -- <kbd>←</kbd>/<kbd>→</kbd> walks the weeks, <kbd>↑</kbd>/
+ * <kbd>↓</kbd> the weekdays.
+ *
+ * ## One layer per year, not one grid for all of them
+ *
+ * Google restarts the week columns at each January, so two years are two
+ * separate grids that happen to be drawn one above the other -- a chart
+ * spanning 2012 and 2013 has fourteen distinct cell rows, not seven. Stacking
+ * them into one 7-row grid would put two different days in one cell, and
+ * running the weeks straight through would give column 53 of 2012 and column
+ * 0 of 2013 the same reading. Each year is its own layer instead, named by
+ * its year so switching between them says which one you are in (#828).
+ *
+ * ## What a cell says
+ *
+ * The column is the date of the Sunday its week begins on and the row is the
+ * weekday, so every cell's own date is the column's date plus the row's
+ * offset -- uniform across the whole grid, including the first column, whose
+ * Sunday falls in the previous December whenever the year does not start on
+ * one.
+ *
+ * Two different absences meet here, and they are not the same:
+ *
+ *   a day inside the year with no row in the table -- Google draws a white
+ *   cell for it, so there is an element to outline but no value: `null` in
+ *   `points`, a selector in `selectors`;
+ *
+ *   a slot in the rectangle that is not a day at all -- the days before
+ *   January's first weekday and after December's last -- which Google draws
+ *   nothing for: `null` in both.
+ *
+ * The first needs #1191, the second the per-cell selector hole this change
+ * adds beside it. A calendar makes both unavoidable rather than merely
+ * tidy: a two-year chart of ten records is 731 cells with 721 holes.
+ *
+ * ## Why the values cannot come from the drawing
+ *
+ * Measured on `current` (2026-08): the **minimum** value in the range is
+ * painted `#ffffff`, the same white as a day with no row at all. The fills
+ * cannot tell the smallest reading from no reading, so the values are read
+ * from the DataTable and the drawing is used only to locate cells.
+ *
+ * Two rows naming the same date are not summed: measured with `90` then `20`
+ * on one day, the cell drew identically to a lone `20`, so the **last** row
+ * wins and this reads it the same way.
+ *
+ * @param dt        - The DataTable the chart was drawn from
+ * @param container - The DOM container element
+ * @returns One layer per calendar year, earliest first
+ */
+function buildCalendarLayers(
+  dt: GoogleDataTable,
+  container: HTMLElement,
+): MaidrLayer[] {
+  const dateCol = calendarDateColumn(dt);
+  const valueCol = nextDataColumn(dt, dateCol + 1) ?? dateCol + 1;
+  const valueLabel = dt.getColumnLabel(valueCol) || undefined;
+
+  // Last row wins, which is what Google draws.
+  const byDay = new Map<number, number>();
+  for (let r = 0; r < dt.getNumberOfRows(); r++) {
+    const day = dayNumber(dt.getValue(r, dateCol));
+    if (day === null) {
+      continue;
+    }
+    const value = numericValue(dt, r, valueCol);
+    byDay.set(day, value);
+  }
+
+  const years = calendarYears(byDay.keys());
+  if (years.length === 0) {
+    // Nothing dated, so there is no year to draw. The weekday rows are still
+    // the rows a calendar has; it simply has no weeks in it.
+    return [{
+      id: nextId('layer'),
+      type: TraceType.HEATMAP,
+      axes: calendarAxes(valueLabel),
+      data: { x: [], y: [...WEEKDAY_NAMES], points: WEEKDAY_NAMES.map(() => []) },
+    }];
+  }
+
+  const blocks = years.map(year => calendarBlock(year, byDay));
+  const drawn = blocks.reduce((total, block) => total + block.dayCount, 0);
+  const cellSelectors = markCalendarCells(container, drawn);
+
+  let offset = 0;
+  return blocks.map((block) => {
+    const base = offset;
+    offset += block.dayCount;
+    return {
+      id: nextId('layer'),
+      type: TraceType.HEATMAP,
+      title: String(block.year),
+      ...(cellSelectors
+        ? { selectors: calendarSelectors(block, cellSelectors, base) }
+        : {}),
+      axes: calendarAxes(valueLabel),
+      data: { x: block.x, y: [...WEEKDAY_NAMES], points: block.points },
+    };
+  });
+}
+
+/** The three axis names a calendar reads under. */
+function calendarAxes(valueLabel: string | undefined): MaidrLayer['axes'] {
+  return {
+    x: { label: 'Week beginning' },
+    y: { label: 'Day of week' },
+    ...(valueLabel ? { z: { label: valueLabel } } : {}),
+  };
+}
+
+/**
+ * One year's grid: seven weekday rows top-first, one column per week.
+ *
+ * The rectangle is ragged at both ends -- a year beginning on a Wednesday
+ * leaves the first column's Sunday, Monday and Tuesday undrawn -- so the DOM
+ * index of a day counts only the days actually drawn:
+ *
+ *     index = week * 7 + weekday - firstWeekday
+ *
+ * Verified against the DOM on a 2012+2013 chart: `2012-12-31` (a Monday in
+ * week 52 of a year starting Sunday) is index 365, and `2013-02-11` (a Monday
+ * in week 6 of a year starting Tuesday) is index 41 of its own block.
+ */
+function calendarBlock(year: number, byDay: Map<number, number>): CalendarBlock {
+  const firstDay = dayNumberOf(year, 0, 1);
+  const firstWeekday = weekdayOf(firstDay);
+  const dayCount = dayNumberOf(year + 1, 0, 1) - firstDay;
+  const columns = Math.floor((dayCount - 1 + firstWeekday) / DAYS_PER_WEEK) + 1;
+
+  const points: (number | null)[][] = WEEKDAY_NAMES.map(() =>
+    Array.from<number | null>({ length: columns }).fill(null),
+  );
+  for (let day = 0; day < dayCount; day++) {
+    const slot = day + firstWeekday;
+    const value = byDay.get(firstDay + day);
+    points[slot % DAYS_PER_WEEK][Math.floor(slot / DAYS_PER_WEEK)]
+      = value === undefined || !Number.isFinite(value) ? null : value;
+  }
+
+  // The Sunday each column begins on, which is in the previous December for
+  // column 0 of every year that does not start on one.
+  const x = Array.from(
+    { length: columns },
+    (_, week) => isoDay(firstDay + week * DAYS_PER_WEEK - firstWeekday),
+  );
+
+  return { year, firstWeekday, dayCount, columns, points, x };
+}
+
+interface CalendarBlock {
+  year: number;
+  firstWeekday: number;
+  dayCount: number;
+  columns: number;
+  points: (number | null)[][];
+  x: string[];
+}
+
+/**
+ * The per-cell selector grid for one year's block.
+ *
+ * `HeatmapTrace` turns the payload's rows over on construction and then
+ * indexes `selectors[r][c]` by its **own** row, so the grid is laid out
+ * bottom-first here while `points` is top-first -- the same inversion
+ * `heatmapSelectors` and `bindD3Heatmap` carry (#978).
+ *
+ * A slot the year does not reach is `null`: the chart drew no rect there, and
+ * saying so leaves the other days their highlight instead of failing the grid
+ * over a handful of corners.
+ */
+function calendarSelectors(
+  block: CalendarBlock,
+  selectorFor: (index: number) => string,
+  base: number,
+): (string | null)[][] {
+  const rows: (string | null)[][] = [];
+  for (let r = 0; r < DAYS_PER_WEEK; r++) {
+    const weekday = DAYS_PER_WEEK - 1 - r;
+    const row: (string | null)[] = [];
+    for (let week = 0; week < block.columns; week++) {
+      const day = week * DAYS_PER_WEEK + weekday - block.firstWeekday;
+      row.push(day >= 0 && day < block.dayCount ? selectorFor(base + day) : null);
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+/** What each day cell is stamped with, so a selector names one by index. */
+const CALENDAR_DAY_ATTR = 'data-maidr-day';
+
+/**
+ * Stamps every day cell with its position and returns a lookup for one.
+ *
+ * A `Calendar` has no `getChartLayoutInterface()` and its cells carry no id,
+ * class, title or label, so position within the SVG is the only handle --
+ * measured, every day cell of every block is a direct `rect` child of one
+ * `g`, and the only other `rect` in the drawing lives inside a `<pattern>`.
+ * The count is checked against the days the years span before anything is
+ * stamped, so a drawing this no longer describes loses its highlighting
+ * rather than outlining the wrong day.
+ */
+function markCalendarCells(
+  container: HTMLElement,
+  expected: number,
+): ((index: number) => string) | undefined {
+  const svg = container.querySelector('svg');
+  if (!svg) {
+    return undefined;
+  }
+
+  svg.querySelectorAll(`rect[${CALENDAR_DAY_ATTR}]`)
+    .forEach(rect => rect.removeAttribute(CALENDAR_DAY_ATTR));
+
+  const cells = svg.querySelectorAll('g > rect');
+  if (cells.length === 0) {
+    return undefined;
+  }
+  if (cells.length !== expected) {
+    console.warn(
+      `[MAIDR] Calendar day count mismatch: expected ${expected}, found ${cells.length}. `
+      + 'Visual highlighting is disabled for this chart.',
+    );
+    return undefined;
+  }
+
+  cells.forEach((cell, index) => cell.setAttribute(CALENDAR_DAY_ATTR, `${index}`));
+
+  return index => `#${container.id} svg rect[${CALENDAR_DAY_ATTR}="${index}"]`;
+}
+
+/**
+ * The column the dates are in.
+ *
+ * By type rather than by position, so a DataView that put a role column first
+ * still reads; column 0 when nothing declares itself a date, which is where
+ * Google requires it.
+ */
+function calendarDateColumn(dt: GoogleDataTable): number {
+  for (let c = 0; c < dt.getNumberOfColumns(); c++) {
+    const type = dt.getColumnType(c);
+    if (!isRoleColumn(dt, c) && (type === 'date' || type === 'datetime')) {
+      return c;
+    }
+  }
+  return 0;
+}
+
+/** Every calendar year the dated rows fall in, earliest first and gapless. */
+function calendarYears(days: Iterable<number>): number[] {
+  let first = Number.POSITIVE_INFINITY;
+  let last = Number.NEGATIVE_INFINITY;
+  for (const day of days) {
+    first = Math.min(first, day);
+    last = Math.max(last, day);
+  }
+  if (!Number.isFinite(first)) {
+    return [];
+  }
+
+  // Gapless: Google draws a block for every year between the ends, including
+  // one that happens to hold no rows at all.
+  const from = yearOf(first);
+  const years: number[] = [];
+  for (let year = from; year <= yearOf(last); year++) {
+    years.push(year);
+  }
+  return years;
+}
+
+/**
+ * A cell's date as a whole number of days since the epoch, or `null`.
+ *
+ * Counted in **local** time, which is the calendar Google draws: a
+ * `new Date(2012, 0, 1)` is midnight where the reader is, and dividing its
+ * UTC timestamp would land on the previous day for anyone east of Greenwich.
+ */
+function dayNumber(raw: unknown): number | null {
+  // Narrowed before the `Date` rather than after it: `new Date(null)` is the
+  // epoch, not an invalid date, so a row with no date at all would otherwise
+  // land on 1970-01-01 and the chart would grow fifty-odd blocks nobody drew.
+  if (!(raw instanceof Date) && typeof raw !== 'string' && typeof raw !== 'number') {
+    return null;
+  }
+  const date = raw instanceof Date ? raw : new Date(raw);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+  return dayNumberOf(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/** The same count, from a local calendar date. */
+function dayNumberOf(year: number, month: number, day: number): number {
+  return Math.round(Date.UTC(year, month, day) / MS_PER_DAY);
+}
+
+/** Sunday is 0, matching the top row Google draws. */
+function weekdayOf(day: number): number {
+  return new Date(day * MS_PER_DAY).getUTCDay();
+}
+
+function yearOf(day: number): number {
+  return new Date(day * MS_PER_DAY).getUTCFullYear();
+}
+
+/** `YYYY-MM-DD`, which is unambiguous wherever it is read out. */
+function isoDay(day: number): string {
+  return new Date(day * MS_PER_DAY).toISOString().slice(0, 10);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/google-charts/types.ts
+++ b/src/adapters/google-charts/types.ts
@@ -302,6 +302,13 @@ export type GoogleChartType
      * and only the caller knows that is what the steps are.
      */
     | 'SurvivalChart'
+    /**
+     * `google.visualization.Calendar`, from the `calendar` package.
+     *
+     * A year of days shaded by a value, one column per week and one row per
+     * weekday. Read as a heat grid; see `buildCalendarLayer`.
+     */
+    | 'Calendar'
     /** `google.visualization.Timeline`, from the `timeline` package. */
     | 'Timeline'
     /** `google.visualization.TreeMap`, from the `treemap` package. */

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -460,7 +460,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     if (this.highlightValues) {
       this.highlightValues.forEach(row =>
         row.forEach((el) => {
-          const elements = Array.isArray(el) ? el : [el];
+          const elements = Array.isArray(el) ? el : el ? [el] : [];
           elements.forEach((element) => {
             if (Svg.isOwned(element)) {
               element.remove();
@@ -581,10 +581,15 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
       return this.outOfBoundsState;
     }
 
-    return {
-      empty: false,
-      elements: this.highlightValues[this.row][this.col],
-    };
+    // A grid position the chart drew no element at reports the same nothing
+    // an out-of-bounds cursor does, rather than an undefined element the
+    // highlight service would then try to outline.
+    const elements = this.highlightValues[this.row]?.[this.col];
+    if (!elements) {
+      return this.outOfBoundsState;
+    }
+
+    return { empty: false, elements };
   }
 
   /**
@@ -747,8 +752,19 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
 
   protected abstract override get dimension(): Dimension;
 
+  /**
+   * `highlightValues[row][col]`, or `null` for the whole trace when it
+   * highlights nothing.
+   *
+   * A single cell may also be `null`, meaning the chart drew no element
+   * there. That is a narrower claim than the trace-wide `null`: the rest of
+   * the grid still highlights, and only this position falls back to the
+   * out-of-bounds state. A Google Charts calendar is the case it exists for
+   * -- its first and last columns are ragged, so a handful of grid positions
+   * have no rect at all while every other day does (#1174).
+   */
   protected abstract get highlightValues():
-    | (SVGElement[] | SVGElement)[][]
+    | (SVGElement[] | SVGElement | null)[][]
     | null;
 
   /**

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -43,7 +43,16 @@ export class Heatmap extends AbstractTrace {
   protected readonly supportsExtrema = true;
   protected readonly movable: Movable;
   private readonly heatmapValues: number[][];
-  protected readonly highlightValues: SVGElement[][] | null;
+  /**
+   * `highlightValues[r][c]`, or `null` where the chart drew no element.
+   *
+   * A hole is not the same thing as a hole in {@link HeatmapData.points}: a
+   * calendar draws a white cell for a day inside the year that carries no
+   * value -- no value, but an element -- and draws nothing at all for the
+   * ragged slots before its first weekday and after its last. Only the
+   * second kind is `null` here.
+   */
+  protected readonly highlightValues: (SVGElement | null)[][] | null;
   protected highlightCenters:
     | { x: number; y: number; row: number; col: number; element: SVGElement }[]
     | null;
@@ -73,7 +82,9 @@ export class Heatmap extends AbstractTrace {
     this.min = min;
     this.max = max;
 
-    this.highlightValues = this.mapToSvgElements(layer.selectors as string | string[][] | undefined);
+    this.highlightValues = this.mapToSvgElements(
+      layer.selectors as string | (string | null)[][] | undefined,
+    );
     this.highlightCenters = this.mapSvgElementsToCenters();
     this.movable = new MovableGrid<number>(this.heatmapValues);
   }
@@ -165,7 +176,9 @@ export class Heatmap extends AbstractTrace {
     };
   }
 
-  private mapToSvgElements(selector?: string | string[][]): SVGElement[][] | null {
+  private mapToSvgElements(
+    selector?: string | (string | null)[][],
+  ): (SVGElement | null)[][] | null {
     if (!selector) {
       return null;
     }
@@ -181,18 +194,31 @@ export class Heatmap extends AbstractTrace {
       if (selector.length !== numRows) {
         return null;
       }
-      const svgElements: SVGElement[][] = [];
+      const svgElements: (SVGElement | null)[][] = [];
       for (let r = 0; r < numRows; r++) {
         const rowSelectors = selector[r];
         if (!Array.isArray(rowSelectors) || rowSelectors.length !== numCols) {
           return null;
         }
-        const row: SVGElement[] = [];
+        const row: (SVGElement | null)[] = [];
         for (let c = 0; c < numCols; c++) {
+          // A cell the chart drew nothing at. Kept as a hole rather than
+          // failing the grid: a calendar's first and last columns are ragged
+          // -- the slots before January's first weekday and after December's
+          // last are not drawn -- and dropping the whole grid over them would
+          // cost the other 360 days their highlight (#1174).
+          const cellSelector = rowSelectors[c];
+          if (cellSelector === null || cellSelector === undefined) {
+            row.push(null);
+            continue;
+          }
           // Routed through `Svg` rather than `document` so a grid cell holding
           // an unusable selector degrades to "no highlight" instead of throwing.
-          const el = Svg.selectElement<SVGElement>(rowSelectors[c], false);
+          const el = Svg.selectElement<SVGElement>(cellSelector, false);
           if (!el) {
+            // A named selector that resolves to nothing is a mapping the
+            // adapter got wrong, not a cell that was never drawn, so the grid
+            // still fails as a whole.
             return null;
           }
           row.push(el);
@@ -421,7 +447,7 @@ export class Heatmap extends AbstractTrace {
   protected mapSvgElementsToCenters():
     | { x: number; y: number; row: number; col: number; element: SVGElement }[]
     | null {
-    const svgElements: (SVGElement | SVGElement[])[][] | null = this.highlightValues;
+    const svgElements: (SVGElement | SVGElement[] | null)[][] | null = this.highlightValues;
 
     if (!svgElements) {
       return null;

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1376,12 +1376,18 @@ export interface MaidrLayer {
    * element per point; a grid names one per cell of a segmented layer.
    *
    * A grid cell may be `null`, which says the chart drew **no element** for
-   * that cell — a category a series has no bar at. That is different from a
-   * selector that fails to resolve, which is a mistake and declines the whole
-   * grid: without a way to tell the two apart, a producer whose layer has a
-   * gap has to choose between losing the highlight everywhere and inferring
-   * the gaps from the values, and a value of zero is not evidence that a bar
-   * was never drawn (#1002).
+   * that cell — a category a series has no bar at, or a position a heat grid
+   * is not a rectangle at. That is different from a selector that fails to
+   * resolve, which is a mistake and declines the whole grid: without a way to
+   * tell the two apart, a producer whose layer has a gap has to choose between
+   * losing the highlight everywhere and inferring the gaps from the values,
+   * and a value of zero is not evidence that a bar was never drawn (#1002).
+   *
+   * It is also not the same as a `null` in {@link HeatmapData.points}, which
+   * says the chart drew no *value*. A calendar has both, at different cells:
+   * a day inside the year with no row is drawn as a white square, so it has
+   * an element and no value, while the slots outside the year have neither
+   * (#1174).
    */
   selectors?: string | string[] | (string | null)[][] | BoxSelector[] | CandlestickSelector;
   /**

--- a/test/adapters/google-charts/calendar.test.ts
+++ b/test/adapters/google-charts/calendar.test.ts
@@ -1,0 +1,312 @@
+import type { GoogleChart, GoogleDataTable } from '@adapters/google-charts/types';
+import type { HeatmapData } from '@type/grammar';
+import { createMaidrFromGoogleChart } from '@adapters/google-charts/converters';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+type Cell = Date | number | null;
+
+/**
+ * Google's calendar layout: `[date, value]`, and nothing else.
+ */
+function makeCalendarDataTable(
+  rows: Cell[][],
+  labels: string[] = ['', 'Wins'],
+): GoogleDataTable {
+  return {
+    getNumberOfRows: () => rows.length,
+    getNumberOfColumns: () => labels.length,
+    getValue: (r, c) => rows[r][c],
+    getFormattedValue: (r, c) => String(rows[r][c] ?? ''),
+    getColumnLabel: c => labels[c],
+    getColumnType: c => (c === 0 ? 'date' : 'number'),
+    getColumnRole: () => '',
+  };
+}
+
+/**
+ * A drawn calendar: every day cell of every block is a direct `rect` child of
+ * one `g`, which is what the package emits (measured on `current`, 2026-08).
+ * The `<pattern>` rect is there because the real drawing has one and the
+ * locator must not count it.
+ */
+function makeCalendarContainer(dayCount: number): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="cal"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('cal') as HTMLElement;
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  const defs = doc.createElementNS(SVG_NS, 'defs');
+  const pattern = doc.createElementNS(SVG_NS, 'pattern');
+  pattern.appendChild(doc.createElementNS(SVG_NS, 'rect'));
+  defs.appendChild(pattern);
+  svg.appendChild(defs);
+
+  const group = doc.createElementNS(SVG_NS, 'g');
+  for (let day = 0; day < dayCount; day++) {
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('data-day', `${day}`);
+    group.appendChild(rect);
+  }
+  svg.appendChild(group);
+  container.appendChild(svg);
+
+  return container;
+}
+
+/** A calendar has no layout interface; asking for one is a bug. */
+const CALENDAR_CHART: GoogleChart = {
+  getSelection: () => [],
+  setSelection: () => {},
+  getChartLayoutInterface: () => {
+    throw new Error('a calendar has no chart layout interface');
+  },
+};
+
+function build(
+  dt: GoogleDataTable,
+  container: HTMLElement,
+): ReturnType<typeof createMaidrFromGoogleChart>['subplots'][0][0]['layers'] {
+  return createMaidrFromGoogleChart(CALENDAR_CHART, dt, container, {
+    chartType: 'Calendar',
+  }).subplots[0][0].layers;
+}
+
+function grid(layer: { data: unknown }): HeatmapData {
+  return layer.data as HeatmapData;
+}
+
+/**
+ * The value at a payload position.
+ *
+ * `points` is top-first, so row 0 is Sunday -- the row the package draws at
+ * the top of each block.
+ */
+function valueAt(layer: { data: unknown }, row: number, col: number): number | null {
+  return grid(layer).points[row][col];
+}
+
+/**
+ * The selector for the same payload position.
+ *
+ * `HeatmapTrace` turns the rows over on construction and indexes its grid by
+ * its own row, so reading a payload row back means counting from the other
+ * end (#978).
+ */
+function selectorAt(
+  layer: { data: unknown; selectors?: unknown },
+  row: number,
+  col: number,
+): string | null {
+  const selectors = layer.selectors as (string | null)[][];
+  return selectors[grid(layer).points.length - 1 - row][col];
+}
+
+// 2012 began on a Sunday and 2013 on a Tuesday, which is what makes the pair
+// worth using: the first has no ragged head and the second has two days of
+// one.
+const JAN_1_2012 = new Date(2012, 0, 1);
+const DEC_31_2012 = new Date(2012, 11, 31);
+const JAN_1_2013 = new Date(2013, 0, 1);
+const DAYS_2012 = 366;
+const DAYS_2013 = 365;
+
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+afterAll(() => {
+  warnSpy.mockRestore();
+});
+
+describe('createMaidrFromGoogleChart with a Calendar', () => {
+  it('reads a year as a heat grid of weekdays by weeks', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 5]]),
+      makeCalendarContainer(DAYS_2012),
+    );
+
+    expect(layer.type).toBe(TraceType.HEATMAP);
+    // Sunday first, which is the row the package draws at the top.
+    expect(grid(layer).y).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
+    // 366 days from a Sunday spill into a 53rd column holding two of them.
+    expect(grid(layer).points).toHaveLength(7);
+    expect(grid(layer).points[0]).toHaveLength(53);
+  });
+
+  it('names the week by the Sunday it begins on', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 5]]),
+      makeCalendarContainer(DAYS_2012),
+    );
+
+    expect(layer.axes).toEqual({
+      x: { label: 'Week beginning' },
+      y: { label: 'Day of week' },
+      z: { label: 'Wins' },
+    });
+    expect(grid(layer).x[0]).toBe('2012-01-01');
+    expect(grid(layer).x[1]).toBe('2012-01-08');
+    expect(grid(layer).x[52]).toBe('2012-12-30');
+  });
+
+  it('names the first column by a Sunday in the year before, when it is one', () => {
+    const [, layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 5], [JAN_1_2013, 20]]),
+      makeCalendarContainer(DAYS_2012 + DAYS_2013),
+    );
+
+    // 2013 begins on a Tuesday, so its leftmost column begins on the Sunday
+    // of the previous December -- which is where the two undrawn slots above
+    // January 1st are. Naming that column '2013-01-01' instead would put
+    // every cell in it two days out, and the whole grid with it: the date of
+    // a cell is its column plus its row.
+    expect(grid(layer).x[0]).toBe('2012-12-30');
+    expect(grid(layer).x[1]).toBe('2013-01-06');
+    expect(grid(layer).x[52]).toBe('2013-12-29');
+  });
+
+  it('puts each day in the cell the package drew it in', () => {
+    const [layer] = build(
+      makeCalendarDataTable([
+        [JAN_1_2012, 5],
+        [new Date(2012, 0, 9), 12], // a Monday, the second week
+        [DEC_31_2012, 50], // a Monday, the last
+      ]),
+      makeCalendarContainer(DAYS_2012),
+    );
+
+    expect(valueAt(layer, 0, 0)).toBe(5);
+    expect(valueAt(layer, 1, 1)).toBe(12);
+    expect(valueAt(layer, 1, 52)).toBe(50);
+  });
+
+  it('leaves a day the table says nothing about with no value, not a zero', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 5]]),
+      makeCalendarContainer(DAYS_2012),
+    );
+
+    // January 2nd is drawn -- a white cell inside the year -- but the table
+    // gives it no value, and announcing a zero would be a reading the chart
+    // never drew (#1191).
+    expect(valueAt(layer, 1, 0)).toBeNull();
+    expect(selectorAt(layer, 1, 0)).not.toBeNull();
+  });
+
+  it('leaves the slots outside the year with neither a value nor an element', () => {
+    const [, layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 5], [JAN_1_2013, 20]]),
+      makeCalendarContainer(DAYS_2012 + DAYS_2013),
+    );
+
+    // 2013 began on a Tuesday, so its first column's Sunday and Monday are
+    // not days of 2013 and the package draws nothing for them.
+    expect(valueAt(layer, 0, 0)).toBeNull();
+    expect(selectorAt(layer, 0, 0)).toBeNull();
+    expect(valueAt(layer, 1, 0)).toBeNull();
+    expect(selectorAt(layer, 1, 0)).toBeNull();
+
+    // The Tuesday beside them is January 1st, and it is drawn.
+    expect(valueAt(layer, 2, 0)).toBe(20);
+    expect(selectorAt(layer, 2, 0)).not.toBeNull();
+  });
+
+  it('gives each calendar year its own layer, named by the year', () => {
+    const layers = build(
+      makeCalendarDataTable([[DEC_31_2012, 50], [JAN_1_2013, 20]]),
+      makeCalendarContainer(DAYS_2012 + DAYS_2013),
+    );
+
+    expect(layers.map(layer => layer.title)).toEqual(['2012', '2013']);
+    // Stacking them into one seven-row grid would put two different days in
+    // one cell: the package restarts its week columns each January.
+    expect(valueAt(layers[0], 1, 52)).toBe(50);
+    expect(valueAt(layers[1], 2, 0)).toBe(20);
+  });
+
+  it('draws a block for a year in the middle that holds nothing', () => {
+    const layers = build(
+      makeCalendarDataTable([[JAN_1_2012, 5], [new Date(2014, 5, 1), 9]]),
+      makeCalendarContainer(DAYS_2012 + DAYS_2013 + 365),
+    );
+
+    expect(layers.map(layer => layer.title)).toEqual(['2012', '2013', '2014']);
+    expect(grid(layers[1]).points.flat().every(cell => cell === null)).toBe(true);
+  });
+
+  it('counts the day cells from the start of the drawing, block by block', () => {
+    const layers = build(
+      makeCalendarDataTable([[JAN_1_2012, 5], [JAN_1_2013, 20]]),
+      makeCalendarContainer(DAYS_2012 + DAYS_2013),
+    );
+
+    // The DOM order is column-major over the days actually drawn, so the
+    // second block's first day follows the first block's last.
+    expect(selectorAt(layers[0], 0, 0))
+      .toBe('#cal svg rect[data-maidr-day="0"]');
+    expect(selectorAt(layers[0], 1, 52))
+      .toBe(`#cal svg rect[data-maidr-day="${DAYS_2012 - 1}"]`);
+    expect(selectorAt(layers[1], 2, 0))
+      .toBe(`#cal svg rect[data-maidr-day="${DAYS_2012}"]`);
+  });
+
+  it('takes the last of two rows naming the same day', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 90], [JAN_1_2012, 20]]),
+      makeCalendarContainer(DAYS_2012),
+    );
+
+    // Measured: the cell drew identically to a lone 20, so the package is
+    // not summing them.
+    expect(valueAt(layer, 0, 0)).toBe(20);
+  });
+
+  it('reads a day with no value as a hole rather than a NaN', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, null]]),
+      makeCalendarContainer(DAYS_2012),
+    );
+
+    expect(valueAt(layer, 0, 0)).toBeNull();
+  });
+
+  it('drops the highlighting when the drawing holds a different number of cells', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[JAN_1_2012, 5]]),
+      makeCalendarContainer(DAYS_2012 - 1),
+    );
+
+    expect(layer.selectors).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Calendar day count mismatch'),
+    );
+    // The reading survives; only the outline is gone.
+    expect(valueAt(layer, 0, 0)).toBe(5);
+  });
+
+  it('reads a table with no dates as a calendar of no weeks', () => {
+    const [layer] = build(
+      makeCalendarDataTable([[null, 5]]),
+      makeCalendarContainer(0),
+    );
+
+    expect(layer.type).toBe(TraceType.HEATMAP);
+    expect(grid(layer).y).toHaveLength(7);
+    expect(grid(layer).x).toEqual([]);
+    expect(grid(layer).points.every(row => row.length === 0)).toBe(true);
+  });
+});

--- a/test/model/heatmapAbsentElement.test.ts
+++ b/test/model/heatmapAbsentElement.test.ts
@@ -1,0 +1,147 @@
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { Heatmap } from '@model/heatmap';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * A grid position the chart drew no element at (#1174).
+ *
+ * The companion to #1191, and a different absence. That one gave a cell a way
+ * to say it holds no *value*; this one gives it a way to say the chart drew
+ * no *rect* there. A cell can have either, both, or neither: a calendar draws
+ * a white square for a day inside the year that carries no reading -- an
+ * element with no value -- and draws nothing at all for the slots before
+ * January's first weekday, which have neither.
+ *
+ * Before this, a `null` in the selector grid failed `Svg.selectElement` and
+ * the model dropped the whole grid's highlighting. A calendar year that does
+ * not begin on a Sunday and end on a Saturday -- which is six years in seven
+ * at each end -- would therefore have cost all 365 of its days their outline
+ * over a handful of corners that were never drawn.
+ */
+
+function installDom(html: string): void {
+  const dom = new JSDOM(html);
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = dom.window.document;
+  g.SVGElement = dom.window.SVGElement;
+  g.SVGRectElement = dom.window.SVGRectElement ?? dom.window.SVGElement;
+  g.SVGPathElement = dom.window.SVGPathElement ?? class SVGPathElementStub {};
+  g.SVGImageElement = dom.window.SVGImageElement ?? class SVGImageElementStub {};
+}
+
+function uninstallDom(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.document;
+  delete g.SVGElement;
+  delete g.SVGRectElement;
+  delete g.SVGPathElement;
+  delete g.SVGImageElement;
+}
+
+/** Three cells drawn out of a 2x2 rectangle: the top-left one is missing. */
+const RAGGED_SVG = '<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="hm">'
+  + '<rect id="c01"/><rect id="c10"/><rect id="c11"/>'
+  + '</svg>';
+
+/**
+ * `selectors[r][c]` is indexed by the model's own row, which is the reverse of
+ * the payload's -- so the payload's top-left hole is the *last* row here.
+ */
+function layerOf(selectors: (string | null)[][] | undefined): MaidrLayer {
+  return {
+    id: 'hm',
+    type: TraceType.HEATMAP,
+    title: 'test',
+    axes: { x: { label: 'Week' }, y: { label: 'Day' }, z: { label: 'Count' } },
+    ...(selectors ? { selectors } : {}),
+    data: {
+      x: ['w1', 'w2'],
+      y: ['Sun', 'Mon'],
+      points: [[null, 2], [3, 4]],
+    } satisfies HeatmapData,
+  };
+}
+
+const RAGGED_SELECTORS: (string | null)[][] = [
+  // Model row 0 is the payload's bottom row: both drawn.
+  ['#c10', '#c11'],
+  // Model row 1 is the payload's top row, whose first cell was never drawn.
+  [null, '#c01'],
+];
+
+afterEach(() => {
+  uninstallDom();
+});
+
+describe('a heat grid position the chart drew no element at', () => {
+  test('leaves every other cell its highlight', () => {
+    installDom(RAGGED_SVG);
+    const trace = new Heatmap(layerOf(RAGGED_SELECTORS));
+
+    trace.moveToIndex(0, 0);
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+    expect(state.highlight.empty).toBe(false);
+  });
+
+  test('reports nothing to outline at the position itself', () => {
+    installDom(RAGGED_SVG);
+    const trace = new Heatmap(layerOf(RAGGED_SELECTORS));
+
+    // The payload's top-left, which is the model's row 1 column 0.
+    trace.moveToIndex(1, 0);
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+    // Empty rather than an undefined element the highlight service would then
+    // try to outline.
+    expect(state.highlight.empty).toBe(true);
+  });
+
+  test('still announces the cell it cannot outline', () => {
+    installDom(RAGGED_SVG);
+    const trace = new Heatmap(layerOf(RAGGED_SELECTORS));
+
+    trace.moveToIndex(1, 0);
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+    // The reading is the trace's job and the outline is the drawing's; a
+    // position with no rect still has a row, a column and (here) no value.
+    expect(state.text.main?.value).toBe('w1');
+    expect(state.text.cross?.value).toBe('Sun');
+    expect(Number.isFinite(state.text.z?.value as number)).toBe(false);
+  });
+
+  test('drops the whole grid when a named selector resolves to nothing', () => {
+    installDom(RAGGED_SVG);
+    const trace = new Heatmap(layerOf([
+      ['#c10', '#c11'],
+      // Not a hole -- a claim about an element that is not there, which is a
+      // mapping the adapter got wrong rather than a cell nobody drew.
+      ['#nope', '#c01'],
+    ]));
+
+    trace.moveToIndex(0, 0);
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a populated state');
+    }
+    expect(state.highlight.empty).toBe(true);
+  });
+
+  test('survives being disposed', () => {
+    installDom(RAGGED_SVG);
+    const trace = new Heatmap(layerOf(RAGGED_SELECTORS));
+
+    // `dispose` walks every cell looking for elements MAIDR owns, and a hole
+    // is not one.
+    expect(() => trace.dispose()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1174. Closes #1193.

The second of the two types #1174 found declined by omission. `createMaidrFromGoogleChart` threw on `Calendar`; it now reads one heat grid per calendar year.

Two commits, because they are two claims: the core gains a way to say a grid cell has no drawn element, and the adapter uses it.

## `feat(heatmap): let a grid say a cell has no drawn element` (#1193)

#1191 gave a heat cell a way to say it holds no **value**. It had none for saying the chart drew no **element** there, and a calendar has both, at different cells:

| | `points[r][c]` | `selectors[r][c]` |
|---|---|---|
| a day inside the year with a reading | the number | the rect |
| a day inside the year with no row in the table | `null` — Google draws a **white** square | the rect |
| a slot outside the year | `null` | **nothing drawn** |

`MaidrLayer.selectors` was already typed `(string | null)[][]` and the grammar already documented the `null` (#1002); `HeatmapTrace` did not honour it, and any cell that failed to resolve returned `null` for the *whole grid*. Six years in seven begin on something other than a Sunday, so a calendar would routinely have lost all 365 of a year's outlines over a handful of corners nobody drew.

A declared hole is now a hole, and the cursor there reports the same nothing an out-of-bounds cursor does. A **named** selector that resolves to nothing still declines the whole grid — that is a mapping the adapter got wrong, not a cell that was never drawn, and it should stay loud.

## `feat(google-charts): read a Calendar as the heat grid it draws` (#1174)

One layer **per calendar year**, not one grid for all of them: Google restarts its week columns each January, so a chart covering 2012 and 2013 has fourteen cell rows rather than seven. Stacking them would put two different days in one cell. Each layer is seven weekday rows (Sunday first, as drawn), one column per week named by the Sunday it begins on, titled by its year so <kbd>Page Down</kbd> says which one you land in.

### Measured, not assumed

Driven through Playwright/Chromium against the real `calendar` package (gstatic fetched server-side), and three findings shaped the reading:

- **The minimum value is painted `#ffffff`** — the same white as a day with no row at all. The fills cannot tell the smallest reading from no reading, so the values come from the DataTable and the drawing is used only to locate cells.
- **Two rows naming the same day are not summed.** Measured with `90` then `20` on one day: the cell drew identically to a lone `20`, so the **last** row wins.
- **DOM order is column-major over the days actually drawn, ragged at both ends**, so a day's index within its block is `week * 7 + weekday - firstWeekday`. Every day cell of every block is a direct `rect` child of one `<g>`; the only other `rect` lives inside a `<pattern>`.

Verified end to end against a live 2012+2013 chart — every emitted selector resolves to the rect at the coordinates its cell claims:

```
2012-01-01 (Sun, week 0)   -> x=47,  y=41    first cell of block 1
2012-12-31 (Mon, week 52)  -> x=671, y=53
2013-01-01 (Tue, week 0)   -> x=47,  y=173   first cell of block 2
2013-02-11 (Mon, week 6)   -> x=119, y=161
2013-12-31 (Tue, week 52)  -> x=671, y=173
2013 week 0, Sun and Mon   -> no selector, no value (outside the year)
2012-01-02 (Mon, week 0)   -> a rect, and no value

stamped 731 == 731 drawn      unresolved selectors: 0
nulls per block: 5 (2012), 6 (2013)   == 371 - 366, 371 - 365
```

`Calendar` has no `getChartLayoutInterface()` and its cells carry no id, class, title or label, so position in that group is the only handle; the count is checked against the days the years span before anything is stamped, and a drawing this no longer describes loses its highlighting rather than outlining the wrong day.

## Checks

```
npx eslint src test    clean
npx tsc --noEmit       clean
npm test               425 suites / 5837 tests passed (unit), 10 / 137 (esm)
npm run build          complete
npm run docs           complete
```

Mutation sweep over the reading and the core change: **16/16 caught** — including the two the first pass found, the ragged-head column names (the tests only covered a year starting on a Sunday, where the mutation is a no-op) and the cell-count mismatch guard.

`docs/google-charts.md` gains a Calendar row, drops it from the "Not supported" line, and carries a note on the per-year layers and the two absences.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_