### PR TITLE
feat(echarts): add an adapter for cartesian ECharts charts

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -101,3 +101,28 @@ One consequence worth knowing: **a series painted pure black loses its
 highlighting.** Its marks are indistinguishable from the furniture, so they are
 excluded, the count check fails, and the chart reads without an outline. That
 is the conservative failure, not a silent wrong one.
+
+### Which shape each layer's selectors take
+
+A selector that resolves the right element is only half of it: each trace
+class accepts a different **shape**, and a layer whose selectors are
+individually right and collectively the wrong shape resolves nothing at all,
+silently.
+
+| layer | shape | what reads it |
+|---|---|---|
+| `bar` | one selector per bar | `AbstractBarPlot`'s array branch |
+| `stacked`, `dodged` | a row of selectors per series | `SegmentedTrace.mapGridToSvgElements` |
+| `scatter` | **one** selector naming the whole series | `ScatterTrace`, which casts `layer.selectors` to `string` |
+| `line`, `area` | one selector per series | `LineTrace.mapToSvgElements` |
+
+So the marks are stamped twice in one pass — once per mark and once per
+series — and each layer takes the address its own trace can use.
+
+A scatter needs one more thing from the model. ECharts does not move its
+symbols into place; it scales them there, with
+`transform="matrix(s, 0, 0, s, e, f)"` over a unit shape whose `d` always
+begins `M1 0`. `ScatterTrace` recovers a mark's position from the DOM rather
+than from the data's order, and it now reads that matrix — without it every
+symbol reported the same coordinate and the whole scatter grouped into one
+column (#1197).

--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -1,0 +1,103 @@
+# Apache ECharts
+
+MAIDR reads a rendered [Apache ECharts](https://echarts.apache.org/) chart and
+makes it navigable with audio sonification, text descriptions, braille output
+and keyboard navigation.
+
+Measured against **echarts 6.1.0**.
+
+## Quick start
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/echarts@6/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/echarts.js"></script>
+<div id="chart" style="width: 600px; height: 400px"></div>
+<script>
+  const container = document.querySelector('#chart');
+  const chart = echarts.init(container, null, { renderer: 'svg' });
+
+  chart.setOption({
+    title: { text: 'Daily Visitors' },
+    xAxis: { type: 'category', data: ['Mon', 'Tue', 'Wed'], name: 'Day' },
+    yAxis: { name: 'Visitors' },
+    series: [{ type: 'bar', name: 'Visitors', data: [120, 240, 180] }],
+  });
+
+  chart.on('finished', function once() {
+    chart.off('finished', once);
+    const maidr = maidrECharts.createMaidrFromEChart(chart, container);
+    container.setAttribute('maidr', JSON.stringify(maidr));
+  });
+</script>
+```
+
+Two things this example does on purpose:
+
+- **`renderer: 'svg'`.** ECharts defaults to canvas, which draws no elements to
+  point at. A canvas chart still reads — audio, text and braille all come from
+  the chart's model — but it highlights nothing.
+- **Calling after `finished`.** The adapter locates marks in the drawn SVG, so
+  it has to run after ECharts has drawn.
+
+## Supported series types
+
+| ECharts `series.type` | Read as | Notes |
+|---|---|---|
+| `bar` | `bar` | One series. `yAxis: {type: 'category'}` makes it horizontal |
+| `bar` ×N sharing a `stack` | `stacked_bar` | Each point carries its series name |
+| `bar` ×N without a `stack` | `dodged_bar` | |
+| `line` | `line` | |
+| `line` + `areaStyle` | `area` | The fill is what makes it an area |
+| `line` + `step` | `line` + `stepDirection` | `'start'` → `vh`, `'end'`/`'middle'` → `hv` |
+| `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
+
+**Not yet supported:** `pie`, `boxplot`, `candlestick`, `heatmap`, `radar`,
+`funnel`, `gauge`, `treemap`, `sunburst`, `sankey`, `graph`, `parallel`,
+`themeRiver`, `pictorialBar`. Each of these is *refused by name* rather than
+mapped onto whichever trace is closest — most have a MAIDR trace waiting for
+them, and each wants its own measured layout first. See
+[#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
+
+> **Orientation note:** ECharts has no "horizontal" option. A bar chart is
+> turned on its side by making the **y** axis the categorical one, and that is
+> the only thing that says so — so the adapter reads the orientation from which
+> axis is `type: 'category'`, and moves the magnitude onto the axis that
+> carries it.
+
+> **Gap note:** a datum with no value draws nothing. In a bar chart that
+> category is left out of the reading entirely, because there is no bar to
+> announce or outline; in a line chart it is kept, with no reading, so the
+> samples either side stay in their places rather than the series closing over
+> the hole.
+
+## Highlighting
+
+ECharts gives a reading almost nothing to address by. Measured on 6.1.0: the
+SVG is one flat `<g>` with **no ids, no `data-*` attributes** and only
+generated `zr0-cls-N` classes; `dataIndex` is not set on the traversed zrender
+elements in the production build; and the element-to-DOM-node mapping is not
+exposed by any public property.
+
+What the drawing does give is a clean separation by paint, with marks
+contiguous in data order:
+
+| what | fill | stroke |
+|---|---|---|
+| gridline, axis line | `none` | grey, unweighted |
+| bar / scatter mark | the series colour | — |
+| line | `none` | the series colour, `stroke-width: 2` |
+| area fill | the series colour | none |
+| hover symbol | white | the series colour |
+| border artefact, axis-name background | black | — |
+
+So the adapter finds marks by their paint, **checks the count against what the
+model says was drawn**, stamps them, and builds selectors from the stamps. If
+the counts disagree it drops the highlighting for that chart rather than
+outlining the wrong datum — the same discipline the Google Charts Calendar
+uses.
+
+One consequence worth knowing: **a series painted pure black loses its
+highlighting.** Its marks are indistinguishable from the furniture, so they are
+excluded, the count check fails, and the chart reads without an outline. That
+is the conservative failure, not a silent wrong one.

--- a/docs/template.html
+++ b/docs/template.html
@@ -464,6 +464,7 @@
             <a href="{{BASE_PATH}}d3.html" class="{{D3_ACTIVE}}" role="menuitem">D3.js</a>
             <a href="{{BASE_PATH}}vegalite.html" class="{{VEGALITE_ACTIVE}}" role="menuitem">Vega-Lite</a>
             <a href="{{BASE_PATH}}amcharts.html" class="{{AMCHARTS_ACTIVE}}" role="menuitem">amCharts</a>
+            <a href="{{BASE_PATH}}echarts.html" class="{{ECHARTS_ACTIVE}}" role="menuitem">Apache ECharts</a>
             <a href="{{BASE_PATH}}frappe.html" class="{{FRAPPE_ACTIVE}}" role="menuitem">Frappe Charts</a>
             <a href="{{BASE_PATH}}observable.html" class="{{OBSERVABLE_ACTIVE}}" role="menuitem">Observable Plot</a>
             <a href="{{BASE_PATH}}victory.html" class="{{VICTORY_ACTIVE}}" role="menuitem">Victory</a>

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
       "import": "./dist/amcharts.mjs",
       "default": "./dist/amcharts.js"
     },
+    "./echarts": {
+      "types": "./dist/echarts.d.mts",
+      "import": "./dist/echarts.mjs",
+      "default": "./dist/echarts.js"
+    },
     "./frappe": {
       "types": "./dist/frappe.d.mts",
       "import": "./dist/frappe.mjs",

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -58,6 +58,7 @@ const PAGE_DESCRIPTIONS = {
   'chartjs': 'How to make Chart.js charts accessible with MAIDR — support for bar, line, scatter, stacked, dodged, box plot, candlestick, heatmap (matrix), and pie / doughnut chart types.',
   'amcharts': 'How to make amCharts 5 charts accessible with MAIDR — support for bar, dodged, stacked, normalized, line, histogram, heatmap, and pie chart types.',
   'observable': 'How to make Observable Plot charts accessible with MAIDR — zero-configuration binding for bar, stacked bar, histogram, scatter, dot, line, area, and faceted plots, including the {ojs} cells of a Quarto document.',
+  'echarts': 'How to make Apache ECharts accessible with MAIDR — support for bar, stacked bar, dodged bar, line, area, step, and scatter series.',
   'frappe': 'How to make Frappe Charts accessible with MAIDR — support for bar, line, multi-line, scatter, mixed axis (bar + line), pie, and donut chart types.',
   'victory': 'How to make Victory charts accessible with MAIDR — support for bar, line, scatter, stacked, histogram, box plot, candlestick, and pie chart types.',
   'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, step, scatter, box, heatmap, candlestick, and pie chart types via a one-line binder.',
@@ -151,6 +152,7 @@ function generatePage({ title, content, activePage, basePath = '', slug = '', og
     .replace(/\{\{VEGALITE_ACTIVE\}\}/g, () => activePage === 'vegalite' ? 'active' : '')
     .replace(/\{\{CHARTJS_ACTIVE\}\}/g, () => activePage === 'chartjs' ? 'active' : '')
     .replace(/\{\{AMCHARTS_ACTIVE\}\}/g, () => activePage === 'amcharts' ? 'active' : '')
+    .replace(/\{\{ECHARTS_ACTIVE\}\}/g, () => activePage === 'echarts' ? 'active' : '')
     .replace(/\{\{FRAPPE_ACTIVE\}\}/g, () => activePage === 'frappe' ? 'active' : '')
     .replace(/\{\{OBSERVABLE_ACTIVE\}\}/g, () => activePage === 'observable' ? 'active' : '')
     .replace(/\{\{VICTORY_ACTIVE\}\}/g, () => activePage === 'victory' ? 'active' : '')
@@ -307,6 +309,20 @@ if (fs.existsSync(observableMdPath)) {
 `;
   const observablePage = generatePage({ title: 'Observable Plot', content: observableHtml, activePage: 'observable', slug: 'observable.html', ogType: 'article' });
   fs.writeFileSync(path.join(SITE_DIR, 'observable.html'), observablePage);
+}
+
+// Build echarts.html from docs/echarts.md
+console.log('Building echarts.html from docs/echarts.md...');
+const echartsMdPath = path.join(ROOT, 'docs', 'echarts.md');
+if (fs.existsSync(echartsMdPath)) {
+  const echartsMd = fs.readFileSync(echartsMdPath, 'utf-8');
+  const echartsHtml = `
+<div class="content">
+  ${renderMarkdown(echartsMd)}
+</div>
+`;
+  const echartsPage = generatePage({ title: 'Apache ECharts', content: echartsHtml, activePage: 'echarts', slug: 'echarts.html', ogType: 'article' });
+  fs.writeFileSync(path.join(SITE_DIR, 'echarts.html'), echartsPage);
 }
 
 // Build frappe.html from docs/frappe.md

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -230,6 +230,24 @@ export const builds = [
     },
   },
   {
+    name: 'echarts',
+    entry: 'src/adapters/echarts/index.ts',
+    libName: 'maidrECharts',
+    formats: ['es', 'umd'],
+    fileName: format => format === 'es' ? 'echarts.mjs' : 'echarts.js',
+    emptyOutDir: false,
+    // ECharts itself is never imported -- the adapter reads the model off the
+    // live instance the host page already created -- so there is nothing to
+    // externalise.
+    external: [],
+    useReact: false,
+    useDts: true,
+    aliases: {
+      '@adapters': path.resolve(rootDir, 'src/adapters'),
+      '@type': path.resolve(rootDir, 'src/type'),
+    },
+  },
+  {
     name: 'd3',
     entry: 'src/adapters/d3/index.ts',
     libName: 'maidrD3',

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -1,0 +1,426 @@
+import type {
+  BarPoint,
+  LinePoint,
+  Maidr,
+  MaidrLayer,
+  MaidrSubplot,
+  ScatterPoint,
+  SegmentedPoint,
+} from '@type/grammar';
+import type {
+  EChartsComponentModel,
+  EChartsInstance,
+  EChartsList,
+  EChartsModel,
+  EChartsSeriesModel,
+} from './types';
+import { Orientation, TraceType } from '@type/grammar';
+import { markPerDatum, markPerSeries } from './selectors';
+
+/**
+ * Options accepted by {@link createMaidrFromEChart}.
+ */
+export interface EChartsAdapterOptions {
+  /** The figure's id. Defaults to the container's, then to a generated one. */
+  id?: string;
+  /** The figure's title. Defaults to the chart's own `title.text`. */
+  title?: string;
+}
+
+let generated = 0;
+
+function nextId(prefix: string): string {
+  generated += 1;
+  return `${prefix}-${generated}`;
+}
+
+/**
+ * The series types this tier reads.
+ *
+ * ECharts draws seventeen. Every other one -- `pie`, `boxplot`,
+ * `candlestick`, `heatmap`, `radar`, `funnel`, `gauge`, `treemap`,
+ * `sunburst`, `sankey`, `graph`, `parallel`, `themeRiver`, `pictorialBar` --
+ * is left unread by name rather than mapped onto whichever trace is closest.
+ * Most of them have a trace waiting and are the later tiers of #1195; each
+ * wants its own measured layout before it claims to be readable.
+ */
+const READ: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
+
+/**
+ * Converts a rendered ECharts instance into a MAIDR figure.
+ *
+ * Read from the chart's **model** rather than from its geometry:
+ * `getModel()` resolves every default the author did not write, so the
+ * values, the series names, the axis names and the stacking are all
+ * available without measuring a pixel. The drawing is consulted only to
+ * locate marks -- see `selectors.ts` for why that is the harder half.
+ *
+ * @param chart     - The instance returned by `echarts.init`
+ * @param container - The element it was rendered into
+ * @param options   - Overrides for the figure's id and title
+ * @returns The MAIDR figure
+ * @throws When no series the adapter reads is present
+ */
+export function createMaidrFromEChart(
+  chart: EChartsInstance,
+  container: HTMLElement,
+  options: EChartsAdapterOptions = {},
+): Maidr {
+  if (!container.id) {
+    container.id = nextId('maidr-echarts');
+  }
+
+  const model = chart.getModel();
+  const series: EChartsSeriesModel[] = [];
+  model.eachSeries(seriesModel => series.push(seriesModel));
+
+  const readable = series.filter(seriesModel => READ.has(seriesModel.subType));
+  if (readable.length === 0) {
+    const seen = series.map(seriesModel => seriesModel.subType).join(', ') || 'none';
+    throw new Error(
+      `Unsupported ECharts series type(s): ${seen}. `
+      + `Supported types: ${[...READ].join(', ')}.`,
+    );
+  }
+
+  const axes = axisNames(model);
+  const layers = buildLayers(readable, axes, container);
+  const title = options.title ?? componentText(model, 'title', 'text');
+  const subplot: MaidrSubplot = { layers };
+
+  return {
+    id: options.id ?? container.id,
+    ...(title ? { title } : {}),
+    subplots: [[subplot]],
+  };
+}
+
+/**
+ * Which way the chart is drawn, and what each axis is called.
+ *
+ * ECharts has no "horizontal" option: a bar chart is turned on its side by
+ * making the **y** axis the categorical one, which is how the model reports
+ * it and the only thing that says so. Measured on a horizontal bar, the
+ * series' own values come back `[magnitude, categoryIndex]` -- already in
+ * axis terms -- so the orientation decides which of the pair is the reading
+ * rather than requiring the payload to be turned over afterwards.
+ */
+interface Axes {
+  x: string;
+  y: string;
+  horizontal: boolean;
+}
+
+function axisNames(model: EChartsModel): Axes {
+  const x = firstComponent(model, 'xAxis');
+  const y = firstComponent(model, 'yAxis');
+
+  return {
+    x: text(x?.get('name')),
+    y: text(y?.get('name')),
+    horizontal: text(y?.get('type')) === 'category',
+  };
+}
+
+function firstComponent(
+  model: EChartsModel,
+  mainType: string,
+): EChartsComponentModel | undefined {
+  let first: EChartsComponentModel | undefined;
+  model.eachComponent({ mainType }, (component, index) => {
+    if (index === 0) {
+      first = component;
+    }
+  });
+  return first;
+}
+
+function componentText(model: EChartsModel, mainType: string, key: string): string {
+  return text(firstComponent(model, mainType)?.get(key));
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * One layer per reading, in the order the series were declared.
+ *
+ * Bar series are gathered rather than emitted one by one: two of them are a
+ * dodged* chart and two sharing a `stack` are a *stacked* one, and both are
+ * a single layer whose points carry their series name. Lines and scatters
+ * stay one layer each, which is what they are.
+ */
+function buildLayers(
+  series: EChartsSeriesModel[],
+  axes: Axes,
+  container: HTMLElement,
+): MaidrLayer[] {
+  const bars = series.filter(seriesModel => seriesModel.subType === 'bar');
+  const others = series.filter(seriesModel => seriesModel.subType !== 'bar');
+
+  // Every per-datum mark of the chart is painted alike and only its position
+  // tells it apart, so they are located once for all of them, in the order
+  // the series were declared.
+  const marked = series.filter(seriesModel => seriesModel.subType !== 'line');
+  const perDatum = markPerDatum(
+    container,
+    marked.map(seriesModel => drawnCount(seriesModel.getData(), axes.horizontal)),
+  );
+  const selectorFor = (seriesModel: EChartsSeriesModel): string[] | undefined =>
+    perDatum?.[marked.indexOf(seriesModel)];
+
+  const layers: MaidrLayer[] = [];
+  if (bars.length > 0) {
+    layers.push(barLayer(bars, axes, selectorFor));
+  }
+
+  const lines = others.filter(seriesModel => seriesModel.subType === 'line');
+  const polylines = markPerSeries(container, lines.length);
+  for (const seriesModel of others) {
+    layers.push(
+      seriesModel.subType === 'line'
+        ? lineLayer(seriesModel, axes, polylines?.[lines.indexOf(seriesModel)])
+        : scatterLayer(seriesModel, axes, selectorFor(seriesModel)),
+    );
+  }
+
+  return layers;
+}
+
+/**
+ * How many marks a series actually drew.
+ *
+ * A datum with no value draws nothing -- measured, a three-category bar with
+ * one `null` puts **two** rects on the page -- so counting the data list
+ * would make every count check fail on a chart with a gap, and drop the
+ * highlighting with it (#1002).
+ */
+function drawnCount(data: EChartsList, horizontal: boolean): number {
+  let drawn = 0;
+  for (let index = 0; index < data.count(); index++) {
+    if (measured(magnitudeOf(data, index, horizontal))) {
+      drawn += 1;
+    }
+  }
+  return drawn;
+}
+
+function measured(value: number | null): value is number {
+  return value !== null && Number.isFinite(value);
+}
+
+/** The dimension a cartesian series' reading lives on. */
+function magnitudeOf(
+  data: EChartsList,
+  index: number,
+  horizontal: boolean,
+): number | null {
+  const dimension = data.dimensions[horizontal ? 0 : 1];
+  const value = data.get(dimension, index);
+
+  return typeof value === 'number' ? value : null;
+}
+
+/**
+ * What a point sits at.
+ *
+ * `getName` answers on a category axis and returns the empty string on a
+ * value axis, so an empty name is "this axis carries numbers" rather than
+ * "this point is unnamed" -- and the position is then the coordinate itself.
+ *
+ * Which coordinate needs no deciding; see the comment at the fallback.
+ */
+function positionOf(data: EChartsList, index: number): string | number {
+  const name = data.getName(index);
+  if (name) {
+    return name;
+  }
+
+  // Always x. Reaching here means the point carries no category name, which
+  // means neither axis is categorical -- and a chart is only "horizontal"
+  // because its **y** axis is the categorical one. So the two cannot both be
+  // true, and asking which axis to read would be a branch nothing can take.
+  const value = data.get(data.dimensions[0], index);
+
+  return typeof value === 'number' ? value : index;
+}
+
+/**
+ * The series' name, when the author wrote one.
+ *
+ * `seriesModel.name` is always resolved -- ECharts invents one for a series
+ * declared without a name -- so emitting it would name a layer after an
+ * internal counter. The **option** is the thing that says whether an author
+ * wrote anything: measured, `get('name')` is `undefined` on the same series
+ * whose `.name` had already become an invented string.
+ */
+function authoredName(seriesModel: EChartsSeriesModel): string {
+  return text(seriesModel.get('name'));
+}
+
+function axisConfig(axes: Axes): MaidrLayer['axes'] {
+  return {
+    x: { label: axes.x || undefined },
+    y: { label: axes.y || undefined },
+  };
+}
+
+function barLayer(
+  bars: EChartsSeriesModel[],
+  axes: Axes,
+  selectorFor: (seriesModel: EChartsSeriesModel) => string[] | undefined,
+): MaidrLayer {
+  const orientation = axes.horizontal ? Orientation.HORIZONTAL : Orientation.VERTICAL;
+  const selectors = bars.map(selectorFor);
+  const highlight = selectors.every((list): list is string[] => list !== undefined)
+    ? selectors.flat()
+    : undefined;
+
+  // One bar series is a plain bar chart; several are segmented, and `stack`
+  // is the one thing that says which kind.
+  if (bars.length === 1) {
+    const data = bars[0].getData();
+    const points: BarPoint[] = [];
+    for (let index = 0; index < data.count(); index++) {
+      const value = magnitudeOf(data, index, axes.horizontal);
+      if (!measured(value)) {
+        continue;
+      }
+      const position = positionOf(data, index);
+      points.push(
+        axes.horizontal ? { x: value, y: position } : { x: position, y: value },
+      );
+    }
+
+    const name = authoredName(bars[0]);
+
+    return {
+      id: nextId('layer'),
+      type: TraceType.BAR,
+      orientation,
+      ...(name ? { name } : {}),
+      ...(highlight ? { selectors: highlight } : {}),
+      axes: axisConfig(axes),
+      data: points,
+    };
+  }
+
+  const stacked = bars.some(seriesModel => Boolean(seriesModel.get('stack')));
+  const data: SegmentedPoint[][] = bars.map((seriesModel, order) => {
+    const list = seriesModel.getData();
+    const fill = authoredName(seriesModel) || `Series ${order + 1}`;
+    const points: SegmentedPoint[] = [];
+    for (let index = 0; index < list.count(); index++) {
+      const value = magnitudeOf(list, index, axes.horizontal);
+      if (!measured(value)) {
+        continue;
+      }
+      const position = positionOf(list, index);
+      points.push(
+        axes.horizontal
+          ? { x: value, y: position, z: fill }
+          : { x: position, y: value, z: fill },
+      );
+    }
+    return points;
+  });
+
+  return {
+    id: nextId('layer'),
+    type: stacked ? TraceType.STACKED : TraceType.DODGED,
+    orientation,
+    ...(highlight ? { selectors: highlight } : {}),
+    axes: axisConfig(axes),
+    data,
+  };
+}
+
+function lineLayer(
+  seriesModel: EChartsSeriesModel,
+  axes: Axes,
+  selector: string | undefined,
+): MaidrLayer {
+  const data = seriesModel.getData();
+  const points: LinePoint[] = [];
+  for (let index = 0; index < data.count(); index++) {
+    const value = magnitudeOf(data, index, axes.horizontal);
+    points.push({
+      x: positionOf(data, index),
+      // Positioned but not measured, which `LinePoint` can say and
+      // `BarPoint` cannot: the gap keeps the samples either side of it in
+      // their places instead of closing over it, and it is not a zero (#925).
+      y: measured(value) ? value : null,
+    });
+  }
+
+  // `areaStyle` is what fills the band under the curve, so it is what makes
+  // the chart an area chart rather than a line one -- read off the resolved
+  // option so an author cannot mislabel one as the other.
+  const area = Boolean(seriesModel.get('areaStyle'));
+  const step = seriesModel.get('step');
+  const name = authoredName(seriesModel);
+
+  return {
+    id: nextId('layer'),
+    type: area ? TraceType.AREA : TraceType.LINE,
+    ...(name ? { name } : {}),
+    ...(selector ? { selectors: selector } : {}),
+    // A staircase holds its value across the interval and then jumps, which
+    // the trace reads from `stepDirection` -- ECharts spells the same choices
+    // `'start'`, `'middle'` and `'end'`.
+    ...(typeof step === 'string' ? { stepDirection: stepDirectionOf(step) } : {}),
+    axes: axisConfig(axes),
+    data: [points],
+  };
+}
+
+/**
+ * ECharts' step spelling, in the grammar's own terms.
+ *
+ * `'start'` jumps at the sample and holds to the next, which is a vertical
+ * riser then a horizontal hold; `'end'` holds first and jumps at the next
+ * sample. `'middle'` splits the difference and has no spelling of its own
+ * here -- it is read as the hold-then-jump it more nearly is.
+ */
+function stepDirectionOf(step: string): 'vh' | 'hv' {
+  return step === 'start' ? 'vh' : 'hv';
+}
+
+function scatterLayer(
+  seriesModel: EChartsSeriesModel,
+  axes: Axes,
+  selectors: string[] | undefined,
+): MaidrLayer {
+  const data = seriesModel.getData();
+  // A `symbolSize` reading a third column shows up as an extra dimension,
+  // measured -- `['x', 'y', 'value']`. That is the point's magnitude, which
+  // `ScatterPoint.z` carries and `zIntensityFor()` makes audible (#826).
+  const sized = data.dimensions.length > 2 ? data.dimensions[2] : undefined;
+
+  const points: ScatterPoint[] = [];
+  for (let index = 0; index < data.count(); index++) {
+    const x = data.get(data.dimensions[0], index);
+    const y = data.get(data.dimensions[1], index);
+    if (typeof x !== 'number' || typeof y !== 'number') {
+      continue;
+    }
+    const size = sized === undefined ? undefined : data.get(sized, index);
+    points.push({
+      x,
+      y,
+      ...(typeof size === 'number' && Number.isFinite(size) ? { z: size } : {}),
+    });
+  }
+
+  const name = authoredName(seriesModel);
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.SCATTER,
+    ...(name ? { name } : {}),
+    ...(selectors ? { selectors } : {}),
+    axes: axisConfig(axes),
+    data: points,
+  };
+}

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -15,6 +15,7 @@ import type {
   EChartsSeriesModel,
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
 import { markPerDatum, markPerSeries } from './selectors';
 
 /**
@@ -25,13 +26,6 @@ export interface EChartsAdapterOptions {
   id?: string;
   /** The figure's title. Defaults to the chart's own `title.text`. */
   title?: string;
-}
-
-let generated = 0;
-
-function nextId(prefix: string): string {
-  generated += 1;
-  return `${prefix}-${generated}`;
 }
 
 /**
@@ -165,14 +159,21 @@ function buildLayers(
   const marked = series.filter(seriesModel => seriesModel.subType !== 'line');
   const perDatum = markPerDatum(
     container,
-    marked.map(seriesModel => drawnCount(seriesModel.getData(), axes.horizontal)),
+    marked.map(seriesModel => drawnCount(seriesModel, axes.horizontal)),
   );
-  const selectorFor = (seriesModel: EChartsSeriesModel): string[] | undefined =>
-    perDatum?.[marked.indexOf(seriesModel)];
+  // A bar names each of its marks; a scatter names its series in one string.
+  // Not a preference: `ScatterTrace` reads `layer.selectors as string` and
+  // `Svg.selectAllElements` guards on `typeof query === 'string'`, so an
+  // array there matches nothing and the layer loses its highlighting without
+  // saying so -- the failure `Svg.isUsableSelector` was written for (#990).
+  const eachMarkOf = (seriesModel: EChartsSeriesModel): string[] | undefined =>
+    perDatum?.points[marked.indexOf(seriesModel)];
+  const wholeSeriesOf = (seriesModel: EChartsSeriesModel): string | undefined =>
+    perDatum?.series[marked.indexOf(seriesModel)];
 
   const layers: MaidrLayer[] = [];
   if (bars.length > 0) {
-    layers.push(barLayer(bars, axes, selectorFor));
+    layers.push(barLayer(bars, axes, eachMarkOf));
   }
 
   const lines = others.filter(seriesModel => seriesModel.subType === 'line');
@@ -181,7 +182,7 @@ function buildLayers(
     layers.push(
       seriesModel.subType === 'line'
         ? lineLayer(seriesModel, axes, polylines?.[lines.indexOf(seriesModel)])
-        : scatterLayer(seriesModel, axes, selectorFor(seriesModel)),
+        : scatterLayer(seriesModel, axes, wholeSeriesOf(seriesModel)),
     );
   }
 
@@ -195,15 +196,62 @@ function buildLayers(
  * one `null` puts **two** rects on the page -- so counting the data list
  * would make every count check fail on a chart with a gap, and drop the
  * highlighting with it (#1002).
+ *
+ * Asked through {@link drewMark} rather than inline, so that the count and
+ * the layer that reads the same series agree on which data drew. They did
+ * not: this counted a scatter datum whose magnitude was a number, while
+ * `scatterLayer` emits a point only when **both** coordinates are, so a
+ * series with one such datum would stamp a mark no point stood for.
  */
-function drawnCount(data: EChartsList, horizontal: boolean): number {
+function drawnCount(seriesModel: EChartsSeriesModel, horizontal: boolean): number {
+  const data = seriesModel.getData();
   let drawn = 0;
   for (let index = 0; index < data.count(); index++) {
-    if (measured(magnitudeOf(data, index, horizontal))) {
+    if (drewMark(seriesModel.subType, data, index, horizontal)) {
       drawn += 1;
     }
   }
   return drawn;
+}
+
+/**
+ * Whether one datum put a mark on the page, asked the way its layer asks it.
+ *
+ * @param subType    - The series type, which decides the question
+ * @param data       - The series' data list
+ * @param index      - Which datum to ask about
+ * @param horizontal - Whether the chart's category axis is `y`
+ * @returns True when the datum drew
+ */
+function drewMark(
+  subType: string,
+  data: EChartsList,
+  index: number,
+  horizontal: boolean,
+): boolean {
+  if (subType === 'scatter') {
+    return placed(data, index) !== undefined;
+  }
+  return measured(magnitudeOf(data, index, horizontal));
+}
+
+/**
+ * A scatter point's coordinates, when it has both.
+ *
+ * @param data  - The series' data list
+ * @param index - Which datum to read
+ * @returns The pair, or `undefined` when either coordinate is not a number
+ */
+function placed(
+  data: EChartsList,
+  index: number,
+): { x: number; y: number } | undefined {
+  const x = data.get(data.dimensions[0], index);
+  const y = data.get(data.dimensions[1], index);
+  if (typeof x !== 'number' || typeof y !== 'number') {
+    return undefined;
+  }
+  return { x, y };
 }
 
 function measured(value: number | null): value is number {
@@ -273,8 +321,8 @@ function barLayer(
 ): MaidrLayer {
   const orientation = axes.horizontal ? Orientation.HORIZONTAL : Orientation.VERTICAL;
   const selectors = bars.map(selectorFor);
-  const highlight = selectors.every((list): list is string[] => list !== undefined)
-    ? selectors.flat()
+  const named = selectors.every((list): list is string[] => list !== undefined)
+    ? selectors
     : undefined;
 
   // One bar series is a plain bar chart; several are segmented, and `stack`
@@ -300,7 +348,9 @@ function barLayer(
       type: TraceType.BAR,
       orientation,
       ...(name ? { name } : {}),
-      ...(highlight ? { selectors: highlight } : {}),
+      // One row, flattened: `AbstractBarPlot`'s array branch takes a list of
+      // marks and declines a nested one outright.
+      ...(named ? { selectors: named[0] } : {}),
       axes: axisConfig(axes),
       data: points,
     };
@@ -330,7 +380,11 @@ function barLayer(
     id: nextId('layer'),
     type: stacked ? TraceType.STACKED : TraceType.DODGED,
     orientation,
-    ...(highlight ? { selectors: highlight } : {}),
+    // A row per series, not one flat list. `SegmentedTrace` routes an array
+    // to `mapGridToSvgElements`, which wants a row per series and declines a
+    // flat one -- for the reason it gives itself, that a flat list says which
+    // bars there are but not which cell each one is in.
+    ...(named ? { selectors: named } : {}),
     axes: axisConfig(axes),
     data,
   };
@@ -390,7 +444,7 @@ function stepDirectionOf(step: string): 'vh' | 'hv' {
 function scatterLayer(
   seriesModel: EChartsSeriesModel,
   axes: Axes,
-  selectors: string[] | undefined,
+  selectors: string | undefined,
 ): MaidrLayer {
   const data = seriesModel.getData();
   // A `symbolSize` reading a third column shows up as an extra dimension,
@@ -400,15 +454,13 @@ function scatterLayer(
 
   const points: ScatterPoint[] = [];
   for (let index = 0; index < data.count(); index++) {
-    const x = data.get(data.dimensions[0], index);
-    const y = data.get(data.dimensions[1], index);
-    if (typeof x !== 'number' || typeof y !== 'number') {
+    const at = placed(data, index);
+    if (!at) {
       continue;
     }
     const size = sized === undefined ? undefined : data.get(sized, index);
     points.push({
-      x,
-      y,
+      ...at,
       ...(typeof size === 'number' && Number.isFinite(size) ? { z: size } : {}),
     });
   }

--- a/src/adapters/echarts/index.ts
+++ b/src/adapters/echarts/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Apache ECharts adapter for MAIDR.
+ *
+ * Converts a rendered ECharts instance into MAIDR's accessible format for
+ * audio sonification, text descriptions, braille output and keyboard
+ * navigation.
+ *
+ * @remarks
+ * The adapter must be called **after** ECharts has drawn, because it locates
+ * marks in the SVG -- register it on the chart's `finished` event, or call it
+ * from a `setTimeout` after `setOption`.
+ *
+ * Use the **SVG renderer**. ECharts defaults to canvas, which draws no
+ * elements to point at, so a canvas chart reads correctly and highlights
+ * nothing.
+ *
+ * The readings target **echarts 6.1.0**, measured in Chromium; the mark
+ * detection in `selectors.ts` depends on how that version paints, so verify it
+ * if you upgrade.
+ *
+ * @example
+ * ```html
+ * <script src="https://cdn.jsdelivr.net/npm/echarts@6/dist/echarts.min.js"></script>
+ * <script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+ * <script src="https://cdn.jsdelivr.net/npm/maidr/dist/echarts.js"></script>
+ * <script>
+ *   const container = document.querySelector('#chart');
+ *   const chart = echarts.init(container, null, { renderer: 'svg' });
+ *   chart.setOption({
+ *     title: { text: 'Daily Visitors' },
+ *     xAxis: { type: 'category', data: ['Mon', 'Tue', 'Wed'], name: 'Day' },
+ *     yAxis: { name: 'Visitors' },
+ *     series: [{ type: 'bar', name: 'Visitors', data: [120, 240, 180] }],
+ *   });
+ *   chart.on('finished', function once() {
+ *     chart.off('finished', once);
+ *     const maidr = maidrECharts.createMaidrFromEChart(chart, container);
+ *     container.setAttribute('maidr', JSON.stringify(maidr));
+ *   });
+ * </script>
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export {
+  createMaidrFromEChart,
+  type EChartsAdapterOptions,
+} from './converters';
+
+export type {
+  EChartsInstance,
+  EChartsList,
+  EChartsSeriesModel,
+  EChartsSeriesType,
+} from './types';

--- a/src/adapters/echarts/selectors.ts
+++ b/src/adapters/echarts/selectors.ts
@@ -38,6 +38,17 @@ const DATUM_ATTRIBUTE = 'data-maidr-echart-mark';
 const SERIES_ATTRIBUTE = 'data-maidr-echart-line';
 
 /**
+ * Which series a per-datum mark belongs to.
+ *
+ * Written alongside {@link DATUM_ATTRIBUTE} in the same pass, because the two
+ * layer kinds want the marks addressed differently and neither shape can be
+ * derived from the other. A bar layer names one mark per bar; a scatter layer
+ * names its whole series at once, since `ScatterTrace` reads `layer.selectors`
+ * as a single string and an array matches nothing at all.
+ */
+const GROUP_ATTRIBUTE = 'data-maidr-echart-group';
+
+/**
  * Paints that are chart furniture rather than data.
  *
  * Black is the border artefact ECharts draws one of per series, and also the
@@ -150,7 +161,22 @@ function unstamp(container: HTMLElement, attribute: string): void {
 }
 
 /**
- * Stamps a chart's per-datum marks and returns one selector per datum.
+ * How a chart's per-datum marks can be addressed once they are stamped.
+ *
+ * Two views of the same marks, because the traces that consume them want
+ * different shapes and getting it wrong costs the layer its highlighting in
+ * silence (#990): `BarTrace` and `SegmentedTrace` resolve a selector per
+ * mark, while `ScatterTrace` resolves one selector for a whole series.
+ */
+export interface DatumMarks {
+  /** One selector per mark, grouped by series. */
+  points: string[][];
+  /** One selector naming a whole series' marks, in series order. */
+  series: string[];
+}
+
+/**
+ * Stamps a chart's per-datum marks and returns the ways they can be addressed.
  *
  * The marks of every series are found together, because they are painted the
  * same way and only their order tells them apart -- so the total is checked
@@ -159,14 +185,15 @@ function unstamp(container: HTMLElement, attribute: string): void {
  *
  * @param container - The element the chart was rendered into
  * @param drawn     - How many marks each series drew, in series order
- * @returns One selector list per series, or `undefined` when the drawing does
- *   not match what the model described
+ * @returns The addresses of the stamped marks, or `undefined` when the drawing
+ *   does not match what the model described
  */
 export function markPerDatum(
   container: HTMLElement,
   drawn: number[],
-): string[][] | undefined {
+): DatumMarks | undefined {
   unstamp(container, DATUM_ATTRIBUTE);
+  unstamp(container, GROUP_ATTRIBUTE);
 
   const expected = drawn.reduce((total, count) => total + count, 0);
   if (expected === 0) {
@@ -182,21 +209,26 @@ export function markPerDatum(
     return undefined;
   }
 
-  marks.forEach((mark, index) => mark.setAttribute(DATUM_ATTRIBUTE, `${index}`));
-
-  const selectors: string[][] = [];
+  const points: string[][] = [];
   let offset = 0;
-  for (const count of drawn) {
-    selectors.push(
-      Array.from(
-        { length: count },
-        (_, index) => selectorFor(container, DATUM_ATTRIBUTE, offset + index),
-      ),
-    );
-    offset += count;
+  for (let series = 0; series < drawn.length; series++) {
+    const row: string[] = [];
+    for (let index = 0; index < drawn[series]; index++) {
+      const mark = marks[offset + index];
+      mark.setAttribute(DATUM_ATTRIBUTE, `${offset + index}`);
+      mark.setAttribute(GROUP_ATTRIBUTE, `${series}`);
+      row.push(selectorFor(container, DATUM_ATTRIBUTE, offset + index));
+    }
+    points.push(row);
+    offset += drawn[series];
   }
 
-  return selectors;
+  return {
+    points,
+    series: drawn.map(
+      (_, series) => selectorFor(container, GROUP_ATTRIBUTE, series),
+    ),
+  };
 }
 
 /**

--- a/src/adapters/echarts/selectors.ts
+++ b/src/adapters/echarts/selectors.ts
@@ -1,0 +1,239 @@
+/**
+ * Locating the marks an ECharts chart drew, so a layer can point at them.
+ *
+ * ECharts gives a reading nothing to address by: the SVG is one flat `<g>`
+ * with no ids, no `data-*` attributes and only generated `zr0-cls-N` classes,
+ * `dataIndex` is not set on the traversed zrender elements in the production
+ * build, and the element-to-DOM-node mapping is not exposed by any public
+ * property. Measured on echarts 6.1.0 in Chromium (#1195).
+ *
+ * What the drawing does give is a clean separation by paint, and marks that
+ * are contiguous in data order:
+ *
+ * | what | fill | stroke |
+ * |---|---|---|
+ * | gridline, axis line | `none` | grey |
+ * | **bar / scatter mark** | the series colour | -- |
+ * | **line** | `none` | the series colour, `stroke-width: 2` |
+ * | area fill | the series colour | none |
+ * | hover symbol | `#fff` | the series colour |
+ * | border artefact | `#000` | none |
+ *
+ * So a mark is found by its paint, checked against what the model says was
+ * drawn, and stamped. **A count that disagrees drops the highlighting for
+ * that series** rather than outlining the wrong datum -- the discipline the
+ * Google Charts Calendar established (#1174), and the only safe answer when
+ * position is the only handle.
+ */
+
+/**
+ * What each mark is stamped with, so a selector names one by position.
+ *
+ * Two attributes rather than one, because a chart holding both a bar and a
+ * line is stamped twice and each pass clears its own marks first: sharing an
+ * attribute made the second pass wipe what the first had just written, and
+ * every bar selector then resolved to nothing while the line's still worked.
+ */
+const DATUM_ATTRIBUTE = 'data-maidr-echart-mark';
+const SERIES_ATTRIBUTE = 'data-maidr-echart-line';
+
+/**
+ * Paints that are chart furniture rather than data.
+ *
+ * Black is the border artefact ECharts draws one of per series, and also the
+ * background it puts behind an axis name; white backs the hover symbols.
+ * None of them is a mark, and all of them would otherwise be counted as one.
+ *
+ * **A series painted pure black loses its highlighting** rather than
+ * mis-outlining: its marks are excluded here, the count check then fails, and
+ * the chart reads without an outline. That is the same conservative failure
+ * the count check exists to produce, and it is the price of a drawing whose
+ * only handle is paint.
+ */
+const FURNITURE_FILLS = new Set(['none', 'transparent', '#000000', '#ffffff']);
+
+/**
+ * One colour, spelled one way.
+ *
+ * The same black arrives as `#000` on the border artefact and as
+ * `rgb(0,0,0)` on an axis name's background -- measured, and the second
+ * spelling slipped past a set that only held the first, so a chart with a
+ * named axis counted one furniture element as a mark and lost its
+ * highlighting to the mismatch.
+ *
+ * @param paint - A `fill` attribute as written in the SVG
+ * @returns A lower-case `#rrggbb`, or the keyword unchanged
+ */
+function normalise(paint: string): string {
+  const trimmed = paint.trim().toLowerCase();
+
+  const rgb = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(trimmed);
+  if (rgb) {
+    return `#${rgb.slice(1, 4).map(part => Number(part).toString(16).padStart(2, '0')).join('')}`;
+  }
+
+  const short = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/.exec(trimmed);
+  if (short) {
+    return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Whether an element is painted as a solid mark -- a bar, a scatter symbol or
+ * an area's fill.
+ *
+ * @param element - A candidate element from the chart's SVG
+ * @returns True when its fill is a series colour
+ */
+function isFilledMark(element: Element): boolean {
+  const fill = element.getAttribute('fill');
+  if (!fill) {
+    return false;
+  }
+
+  return !FURNITURE_FILLS.has(normalise(fill));
+}
+
+/**
+ * Whether an element is a drawn line rather than a gridline.
+ *
+ * Both are unfilled and stroked, and the one thing that separates them is
+ * weight: measured, a series line carries `stroke-width: 2` while gridlines
+ * and the axis line carry none at all. A hover symbol is stroked in the
+ * series colour too, but it is *filled* `#fff`, so it never reaches here.
+ *
+ * @param element - A candidate element from the chart's SVG
+ * @returns True when it is a series' polyline
+ */
+function isStrokedLine(element: Element): boolean {
+  const fill = element.getAttribute('fill');
+  if (fill && !FURNITURE_FILLS.has(normalise(fill))) {
+    return false;
+  }
+  if (!element.getAttribute('stroke')) {
+    return false;
+  }
+
+  return Number.parseFloat(element.getAttribute('stroke-width') || '0') >= 1;
+}
+
+/**
+ * Every element that is a mark of some kind, in the order the chart drew it.
+ *
+ * @param container - The element the chart was rendered into
+ * @param kind      - Whether the series draws one element per datum
+ * @returns The candidates, in DOM order
+ */
+function candidates(container: HTMLElement, kind: 'filled' | 'stroked'): Element[] {
+  const svg = container.querySelector('svg');
+  if (!svg) {
+    return [];
+  }
+
+  const test = kind === 'filled' ? isFilledMark : isStrokedLine;
+
+  return Array.from(svg.querySelectorAll('path,rect,circle')).filter(test);
+}
+
+/**
+ * Clears the marks of one kind that a previous initialisation left behind.
+ *
+ * @param container - The element the chart was rendered into
+ * @param attribute - Which kind of stamp to clear
+ */
+function unstamp(container: HTMLElement, attribute: string): void {
+  container
+    .querySelectorAll(`[${attribute}]`)
+    .forEach(element => element.removeAttribute(attribute));
+}
+
+/**
+ * Stamps a chart's per-datum marks and returns one selector per datum.
+ *
+ * The marks of every series are found together, because they are painted the
+ * same way and only their order tells them apart -- so the total is checked
+ * once, against what every series says it drew, and a mismatch drops the
+ * highlighting for the whole chart.
+ *
+ * @param container - The element the chart was rendered into
+ * @param drawn     - How many marks each series drew, in series order
+ * @returns One selector list per series, or `undefined` when the drawing does
+ *   not match what the model described
+ */
+export function markPerDatum(
+  container: HTMLElement,
+  drawn: number[],
+): string[][] | undefined {
+  unstamp(container, DATUM_ATTRIBUTE);
+
+  const expected = drawn.reduce((total, count) => total + count, 0);
+  if (expected === 0) {
+    return undefined;
+  }
+
+  const marks = candidates(container, 'filled');
+  if (marks.length !== expected) {
+    console.warn(
+      `[MAIDR] ECharts mark count mismatch: expected ${expected}, found ${marks.length}. `
+      + 'Visual highlighting is disabled for this chart.',
+    );
+    return undefined;
+  }
+
+  marks.forEach((mark, index) => mark.setAttribute(DATUM_ATTRIBUTE, `${index}`));
+
+  const selectors: string[][] = [];
+  let offset = 0;
+  for (const count of drawn) {
+    selectors.push(
+      Array.from(
+        { length: count },
+        (_, index) => selectorFor(container, DATUM_ATTRIBUTE, offset + index),
+      ),
+    );
+    offset += count;
+  }
+
+  return selectors;
+}
+
+/**
+ * Stamps a chart's per-series polylines and returns one selector per series.
+ *
+ * @param container - The element the chart was rendered into
+ * @param count     - How many series drew a line
+ * @returns One selector per series, or `undefined` on a mismatch
+ */
+export function markPerSeries(
+  container: HTMLElement,
+  count: number,
+): string[] | undefined {
+  unstamp(container, SERIES_ATTRIBUTE);
+
+  if (count === 0) {
+    return undefined;
+  }
+
+  const lines = candidates(container, 'stroked');
+  if (lines.length !== count) {
+    console.warn(
+      `[MAIDR] ECharts line count mismatch: expected ${count}, found ${lines.length}. `
+      + 'Visual highlighting is disabled for this chart.',
+    );
+    return undefined;
+  }
+
+  lines.forEach((line, index) => line.setAttribute(SERIES_ATTRIBUTE, `${index}`));
+
+  return lines.map((_, index) => selectorFor(container, SERIES_ATTRIBUTE, index));
+}
+
+function selectorFor(
+  container: HTMLElement,
+  attribute: string,
+  index: number,
+): string {
+  return `#${container.id} svg [${attribute}="${index}"]`;
+}

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Minimal type declarations for the Apache ECharts API.
+ *
+ * These cover only the subset the MAIDR ECharts adapter reads. ECharts is
+ * loaded as a peer dependency or a CDN script and is not installed in this
+ * repo, so nothing here is imported from the package -- the shapes were
+ * measured against **echarts 6.1.0** driven in Chromium rather than copied
+ * from its published types, and the fields declared are exactly the ones a
+ * reading was proven to need.
+ *
+ * @see https://echarts.apache.org/
+ */
+
+/**
+ * The series types this adapter reads.
+ *
+ * ECharts draws seventeen; these are the cartesian three, which is the first
+ * tier of xability/maidr#1195. Every other series type is refused by name so
+ * that gaining a reading later is a decision rather than an accident.
+ */
+export type EChartsSeriesType = 'bar' | 'line' | 'scatter';
+
+/**
+ * One column of a series' internal data list.
+ *
+ * Measured: a cartesian series carries `['x', 'y']`, and a scatter whose
+ * `symbolSize` reads a third column carries `['x', 'y', 'value']`.
+ */
+export type EChartsDimension = string;
+
+/**
+ * A series' data list.
+ *
+ * Addressed by index rather than iterated, which is what lets a reading walk
+ * it in the order the chart drew it.
+ */
+export interface EChartsList {
+  /** The column names, in order. */
+  dimensions: EChartsDimension[];
+  /** How many data points the series holds. */
+  count: () => number;
+  /**
+   * The category name at `index`.
+   *
+   * Measured: the category axis' label on a category axis, and the empty
+   * string on a value axis -- so an empty name means "this axis carries
+   * numbers", not "this point is unnamed".
+   */
+  getName: (index: number) => string;
+  /**
+   * The value of one dimension at `index`.
+   *
+   * On a category axis this is the category's **index**, not its name; the
+   * name comes from {@link getName}.
+   */
+  get: (dimension: EChartsDimension, index: number) => number | null | undefined;
+}
+
+/**
+ * One series of a rendered chart.
+ */
+export interface EChartsSeriesModel {
+  /** The declared series type -- `'bar'`, `'line'`, `'scatter'`, … */
+  subType: string;
+  /**
+   * The series' resolved name.
+   *
+   * ECharts invents one (`'series 0'`, with a NUL separator) when the author
+   * supplied none, so a name is only worth emitting when the author wrote it;
+   * see `authoredName` in the converters.
+   */
+  name: string;
+  /** The series' data list. */
+  getData: () => EChartsList;
+  /** Read one of the series' resolved options. */
+  get: (key: string) => unknown;
+}
+
+/**
+ * One axis, legend or title of a rendered chart.
+ */
+export interface EChartsComponentModel {
+  /** Read one of the component's resolved options. */
+  get: (key: string) => unknown;
+}
+
+/**
+ * A rendered chart's resolved model.
+ */
+export interface EChartsModel {
+  /** Visit every series, in declaration order. */
+  eachSeries: (
+    callback: (series: EChartsSeriesModel, index: number) => void,
+  ) => void;
+  /** Visit every component of one main type, in declaration order. */
+  eachComponent: (
+    query: { mainType: string },
+    callback: (component: EChartsComponentModel, index: number) => void,
+  ) => void;
+}
+
+/**
+ * A rendered ECharts instance.
+ *
+ * Only `getModel` is read. `getZr()` and `dispatchAction()` are deliberately
+ * not declared: the first exposes no element-to-DOM-node mapping in the
+ * production build, and the second is ECharts' own highlighting, which
+ * `MaidrLayer.selectors` has no way to call (#1195).
+ */
+export interface EChartsInstance {
+  getModel: () => EChartsModel;
+}

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -2293,6 +2293,27 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
         }
       }
 
+      // ECharts scales its symbols into place rather than moving them:
+      // `matrix(s, 0, 0, s, e, f)`, where the symbol's own path is a unit
+      // shape about the origin, so the mark's centre is `(e, f)` -- the last
+      // two numbers, which is what a matrix translates by whatever the other
+      // four are. Read before the `d` fallback below and not after, because
+      // ECharts writes both: every symbol's `d` begins `M1 0`, so the
+      // fallback would answer the same coordinate for every point on the
+      // chart and group the whole scatter into one column.
+      if (Number.isNaN(x) || Number.isNaN(y)) {
+        const transform = element.getAttribute('transform');
+        if (transform) {
+          const match = transform.match(
+            /matrix\s*\(\s*(?:[\d.eE+-]+[\s,]+){4}([\d.eE+-]+)[\s,]+([\d.eE+-]+)/,
+          );
+          if (match) {
+            x = Number.parseFloat(match[1]);
+            y = Number.parseFloat(match[2]);
+          }
+        }
+      }
+
       // Highcharts (and other path-rendered marker libraries) embed the
       // marker center in the `d` attribute as `M x y …`. Parse the initial
       // moveTo command to recover (x, y) when none of the explicit attribute

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -33,7 +33,7 @@ interface FakeSeries {
   /** The magnitude at each position; `null` is a datum that drew nothing. */
   values: (number | null)[];
   /** The other coordinate, when the chart is not categorical. */
-  positions?: number[];
+  positions?: (number | null)[];
   /** A third column, which is what a sized symbol reads. */
   sizes?: number[];
   name?: string;
@@ -56,7 +56,9 @@ function fakeList(series: FakeSeries, horizontal: boolean): EChartsList {
         return series.values[index];
       }
       if (dimension === position) {
-        return series.positions?.[index] ?? index;
+        // Read verbatim when the case supplies them, so a `null` coordinate
+        // stays a `null` rather than falling back to the index.
+        return series.positions ? series.positions[index] : index;
       }
       return series.sizes?.[index];
     },
@@ -338,6 +340,32 @@ describe('an eCharts scatter chart', () => {
       { x: 2, y: 4 },
       { x: 3, y: 1 },
     ]);
+  });
+
+  it('counts only the points it will emit', () => {
+    // A point needs both coordinates to be drawn, and `scatterLayer` emits
+    // only the ones that have them. The count the marks are checked against
+    // has to ask the same question: counting the datum with no `x` would
+    // expect three marks on a drawing that has two, the check would fail,
+    // and the whole chart would lose its highlighting over a point that was
+    // never on it.
+    const [layer] = layersOf(
+      {
+        series: [{
+          type: 'scatter',
+          values: [2, 4, 1],
+          positions: [1, null, 3],
+        }],
+      },
+      drawnChart(2, 0),
+    );
+
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: 1, y: 2 },
+      { x: 3, y: 1 },
+    ]);
+    expect(layer.selectors).toBeDefined();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('makes a sized symbol audible', () => {

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -1,0 +1,464 @@
+import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters/echarts/types';
+import type { BarPoint, LinePoint, ScatterPoint, SegmentedPoint } from '@type/grammar';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * The first tier of the ECharts adapter (#1195).
+ *
+ * ECharts had none at all -- fourteen libraries did, and the largest one with
+ * no MAIDR support was this. The readings here are the cartesian three, and
+ * the shapes the fakes below stand in for were measured against **echarts
+ * 6.1.0** driven in Chromium, not read from its documentation:
+ *
+ *     dimensions   ['x', 'y'], or ['x', 'y', 'value'] with a sized symbol
+ *     getName(i)   the category on a category axis, '' on a value axis
+ *     get(dim, i)  the value; on a category axis x is the INDEX
+ *     horizontal   y is the category axis, and the values arrive
+ *                  [magnitude, categoryIndex]
+ *
+ * The marks are the harder half, and `selectors.ts` says why: the SVG has no
+ * ids, no `data-*` and only generated classes, so a mark is found by its
+ * paint and checked by its count.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface FakeSeries {
+  type: string;
+  /** Category names, or `undefined` for a value axis. */
+  names?: string[];
+  /** The magnitude at each position; `null` is a datum that drew nothing. */
+  values: (number | null)[];
+  /** The other coordinate, when the chart is not categorical. */
+  positions?: number[];
+  /** A third column, which is what a sized symbol reads. */
+  sizes?: number[];
+  name?: string;
+  stack?: string;
+  step?: string;
+  areaStyle?: object;
+}
+
+function fakeList(series: FakeSeries, horizontal: boolean): EChartsList {
+  const dimensions = series.sizes ? ['x', 'y', 'value'] : ['x', 'y'];
+  const magnitude = horizontal ? 'x' : 'y';
+  const position = horizontal ? 'y' : 'x';
+
+  return {
+    dimensions,
+    count: () => series.values.length,
+    getName: index => series.names?.[index] ?? '',
+    get: (dimension, index) => {
+      if (dimension === magnitude) {
+        return series.values[index];
+      }
+      if (dimension === position) {
+        return series.positions?.[index] ?? index;
+      }
+      return series.sizes?.[index];
+    },
+  };
+}
+
+function fakeSeries(series: FakeSeries, horizontal: boolean): EChartsSeriesModel {
+  const options: Record<string, unknown> = {
+    name: series.name,
+    stack: series.stack,
+    step: series.step,
+    areaStyle: series.areaStyle,
+  };
+
+  return {
+    subType: series.type,
+    // ECharts always resolves one, inventing a name for a series declared
+    // without any -- which is why the reading asks the *option* instead.
+    name: series.name ?? 'series 0',
+    getData: () => fakeList(series, horizontal),
+    get: key => options[key],
+  };
+}
+
+interface FakeChart {
+  series: FakeSeries[];
+  xName?: string;
+  yName?: string;
+  title?: string;
+  horizontal?: boolean;
+}
+
+function fakeInstance(chart: FakeChart): EChartsInstance {
+  const horizontal = Boolean(chart.horizontal);
+  const components: Record<string, Record<string, unknown>[]> = {
+    xAxis: [{ name: chart.xName, type: horizontal ? 'value' : 'category' }],
+    yAxis: [{ name: chart.yName, type: horizontal ? 'category' : 'value' }],
+    title: chart.title === undefined ? [] : [{ text: chart.title }],
+  };
+
+  return {
+    getModel: () => ({
+      eachSeries: (callback) => {
+        chart.series.forEach((series, index) =>
+          callback(fakeSeries(series, horizontal), index));
+      },
+      eachComponent: (query, callback) => {
+        (components[query.mainType] ?? []).forEach((options, index) =>
+          callback({ get: key => options[key] }, index));
+      },
+    }),
+  };
+}
+
+/**
+ * A drawn chart: `marks` solid paths in the series colour, `lines` stroked
+ * ones, and the furniture that must not be counted as either.
+ *
+ * The furniture is not decoration in this fixture -- each piece is one the
+ * detection was measured against, and one of them (the axis name's black
+ * background, written `rgb(0,0,0)`) is what a set holding only `#000` let
+ * through.
+ */
+function drawnChart(marks: number, lines: number): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('chart') as HTMLElement;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+
+  const add = (attributes: Record<string, string>): void => {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    Object.entries(attributes).forEach(([key, value]) => path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  // Gridlines: unfilled, stroked grey, and unweighted.
+  add({ fill: 'none', stroke: '#dbdee4' });
+  add({ fill: 'none', stroke: '#54555a' });
+
+  for (let index = 0; index < marks; index++) {
+    add({ fill: '#5070dd' });
+  }
+  for (let index = 0; index < lines; index++) {
+    add({ 'fill': 'none', 'stroke': '#5070dd', 'stroke-width': '2' });
+  }
+
+  // A hover symbol, and the two blacks: the per-series border artefact and
+  // an axis name's background, each in its own spelling.
+  add({ 'fill': '#fff', 'stroke': '#5070dd', 'stroke-width': '0.7' });
+  add({ fill: '#000' });
+  add({ fill: 'rgb(0,0,0)', stroke: '#3c3c41' });
+
+  container.appendChild(svg);
+  return container;
+}
+
+function layersOf(chart: FakeChart, container: HTMLElement) {
+  return createMaidrFromEChart(fakeInstance(chart), container).subplots[0][0].layers;
+}
+
+const CATEGORIES = ['A', 'B', 'C'];
+
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+afterAll(() => {
+  warnSpy.mockRestore();
+});
+
+describe('an eCharts bar chart', () => {
+  it('is read as the bars it draws, named by their categories', () => {
+    const [layer] = layersOf(
+      { series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }] },
+      drawnChart(3, 0),
+    );
+
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.orientation).toBe(Orientation.VERTICAL);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 },
+      { x: 'C', y: 3 },
+    ]);
+  });
+
+  it('reads a sideways chart from which axis is categorical', () => {
+    // ECharts has no "horizontal" option: a bar is turned on its side by
+    // making y the category axis, and that is the only thing that says so.
+    const [layer] = layersOf(
+      {
+        horizontal: true,
+        series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }],
+      },
+      drawnChart(3, 0),
+    );
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    // The magnitude belongs to x and the category to y -- declaring the
+    // orientation without moving the payload is the defect #480 had.
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 1, y: 'A' },
+      { x: 2, y: 'B' },
+      { x: 3, y: 'C' },
+    ]);
+  });
+
+  it('leaves out a category the chart drew no bar for', () => {
+    const [layer] = layersOf(
+      { series: [{ type: 'bar', names: CATEGORIES, values: [1, null, 3] }] },
+      drawnChart(2, 0),
+    );
+
+    expect(layer.data as BarPoint[]).toEqual([{ x: 'A', y: 1 }, { x: 'C', y: 3 }]);
+    // Two bars were drawn, so two selectors -- counting the data list would
+    // have expected three and dropped the highlighting (#1002).
+    expect(layer.selectors).toHaveLength(2);
+  });
+
+  it('is stacked when the series share a stack, and dodged when they do not', () => {
+    const series = [
+      { type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'One' },
+      { type: 'bar', names: CATEGORIES, values: [3, 1, 2], name: 'Two' },
+    ];
+
+    const [dodged] = layersOf({ series }, drawnChart(6, 0));
+    expect(dodged.type).toBe(TraceType.DODGED);
+
+    const [stacked] = layersOf(
+      { series: series.map(one => ({ ...one, stack: 'total' })) },
+      drawnChart(6, 0),
+    );
+    expect(stacked.type).toBe(TraceType.STACKED);
+    expect((stacked.data as SegmentedPoint[][])[1]).toEqual([
+      { x: 'A', y: 3, z: 'Two' },
+      { x: 'B', y: 1, z: 'Two' },
+      { x: 'C', y: 2, z: 'Two' },
+    ]);
+  });
+});
+
+describe('an eCharts line chart', () => {
+  it('keeps a gap as a position with no reading', () => {
+    // `LinePoint` can say it and `BarPoint` cannot: the samples either side
+    // stay in their places instead of the series closing over the hole, and
+    // it is not a zero (#925).
+    const [layer] = layersOf(
+      { series: [{ type: 'line', names: CATEGORIES, values: [1, null, 3] }] },
+      drawnChart(0, 1),
+    );
+
+    expect(layer.type).toBe(TraceType.LINE);
+    expect((layer.data as LinePoint[][])[0]).toEqual([
+      { x: 'A', y: 1 },
+      { x: 'B', y: null },
+      { x: 'C', y: 3 },
+    ]);
+  });
+
+  it('positions its samples by x when the axis carries numbers', () => {
+    // A line on a `type: 'value'` x axis has no category names, so the
+    // position is the coordinate itself -- and it is the **x** coordinate.
+    // Taking y would announce every sample as sitting at its own magnitude.
+    const [layer] = layersOf(
+      { series: [{ type: 'line', values: [2, 4, 1], positions: [10, 20, 30] }] },
+      drawnChart(0, 1),
+    );
+
+    expect((layer.data as LinePoint[][])[0]).toEqual([
+      { x: 10, y: 2 },
+      { x: 20, y: 4 },
+      { x: 30, y: 1 },
+    ]);
+  });
+
+  it('is an area when the series fills the band under it', () => {
+    // `areaStyle` is what fills it, so it is what makes the chart an area
+    // rather than a line -- read off the resolved option so an author cannot
+    // mislabel one as the other.
+    const [layer] = layersOf(
+      {
+        series: [{
+          type: 'line',
+          names: CATEGORIES,
+          values: [1, 2, 3],
+          areaStyle: {},
+        }],
+      },
+      drawnChart(1, 1),
+    );
+
+    expect(layer.type).toBe(TraceType.AREA);
+  });
+
+  it('carries the staircase direction the series was drawn with', () => {
+    const [held] = layersOf(
+      { series: [{ type: 'line', names: CATEGORIES, values: [1, 2, 3], step: 'end' }] },
+      drawnChart(0, 1),
+    );
+    expect(held.stepDirection).toBe('hv');
+
+    const [jumped] = layersOf(
+      { series: [{ type: 'line', names: CATEGORIES, values: [1, 2, 3], step: 'start' }] },
+      drawnChart(0, 1),
+    );
+    expect(jumped.stepDirection).toBe('vh');
+  });
+
+  it('points at the polyline, which is what the chart drew', () => {
+    const [layer] = layersOf(
+      { series: [{ type: 'line', names: CATEGORIES, values: [1, 2, 3] }] },
+      drawnChart(0, 1),
+    );
+
+    // One path per series rather than one per point, measured -- so the
+    // selector is the whole line, as it is in every other adapter.
+    expect(typeof layer.selectors).toBe('string');
+  });
+});
+
+describe('an eCharts scatter chart', () => {
+  it('reads its coordinates rather than a category index', () => {
+    const [layer] = layersOf(
+      {
+        series: [{
+          type: 'scatter',
+          values: [2, 4, 1],
+          positions: [1, 2, 3],
+        }],
+      },
+      drawnChart(3, 0),
+    );
+
+    expect(layer.type).toBe(TraceType.SCATTER);
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: 1, y: 2 },
+      { x: 2, y: 4 },
+      { x: 3, y: 1 },
+    ]);
+  });
+
+  it('makes a sized symbol audible', () => {
+    // A `symbolSize` reading a third column arrives as an extra dimension.
+    // `ScatterPoint.z` carries it and `zIntensityFor()` sounds it (#826), so
+    // dropping it would silence the thing the chart is drawn to show.
+    const [layer] = layersOf(
+      {
+        series: [{
+          type: 'scatter',
+          values: [2, 4],
+          positions: [1, 2],
+          sizes: [10, 30],
+        }],
+      },
+      drawnChart(2, 0),
+    );
+
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: 1, y: 2, z: 10 },
+      { x: 2, y: 4, z: 30 },
+    ]);
+  });
+});
+
+describe('a chart drawing more than one kind of mark', () => {
+  it('leaves both kinds pointing at what they drew', () => {
+    // The two passes stamp different things -- bars per datum, lines per
+    // series -- and each clears its own marks before writing. Sharing one
+    // attribute made the line pass wipe what the bar pass had just written,
+    // so every bar selector resolved to nothing while the line's still
+    // worked. Found by running the adapter against the real library, and
+    // invisible to any test that draws only one kind.
+    const container = drawnChart(3, 1);
+    const layers = layersOf(
+      {
+        series: [
+          { type: 'bar', names: CATEGORIES, values: [1, 2, 3] },
+          { type: 'line', names: CATEGORIES, values: [3, 2, 1] },
+        ],
+      },
+      container,
+    );
+
+    const [bar, line] = layers;
+    const barSelectors = bar.selectors as string[];
+    expect(barSelectors).toHaveLength(3);
+    barSelectors.forEach(selector =>
+      expect(container.querySelector(selector)).not.toBeNull());
+
+    expect(container.querySelector(line.selectors as string)).not.toBeNull();
+  });
+});
+
+describe('what the adapter will not claim', () => {
+  it('refuses a chart of series it has no reading for', () => {
+    // By name, rather than mapped onto whichever trace is closest. ECharts
+    // draws seventeen series types and most have a trace waiting for them,
+    // but each wants its own measured layout first (#1195).
+    expect(() => layersOf(
+      { series: [{ type: 'pie', values: [1, 2, 3] }] },
+      drawnChart(3, 0),
+    )).toThrow(/Unsupported ECharts series type\(s\): pie/);
+  });
+
+  it('drops the highlighting when the drawing holds a different number of marks', () => {
+    const [layer] = layersOf(
+      { series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }] },
+      drawnChart(2, 0),
+    );
+
+    expect(layer.selectors).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ECharts mark count mismatch'),
+    );
+    // The reading survives; only the outline is gone.
+    expect(layer.data as BarPoint[]).toHaveLength(3);
+  });
+
+  it('names a layer only when the author named the series', () => {
+    // ECharts always resolves a name, inventing one for a series declared
+    // without any, and emitting that would name a layer after a counter.
+    const [named] = layersOf(
+      { series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'Sales' }] },
+      drawnChart(3, 0),
+    );
+    expect(named.name).toBe('Sales');
+
+    const [unnamed] = layersOf(
+      { series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }] },
+      drawnChart(3, 0),
+    );
+    expect(unnamed.name).toBeUndefined();
+  });
+});
+
+describe('what the figure says about itself', () => {
+  it('takes the axis names and the title the author wrote', () => {
+    const figure = createMaidrFromEChart(
+      fakeInstance({
+        title: 'Visitors',
+        xName: 'Day',
+        yName: 'Count',
+        series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }],
+      }),
+      drawnChart(3, 0),
+    );
+
+    expect(figure.title).toBe('Visitors');
+    const [layer] = figure.subplots[0][0].layers;
+    expect(layer.axes?.x?.label).toBe('Day');
+    expect(layer.axes?.y?.label).toBe('Count');
+  });
+
+  it('leaves an unnamed axis unlabelled rather than inventing one', () => {
+    const [layer] = layersOf(
+      { series: [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }] },
+      drawnChart(3, 0),
+    );
+
+    expect(layer.axes?.x?.label).toBeUndefined();
+    expect(layer.axes?.y?.label).toBeUndefined();
+  });
+});

--- a/test/adapters/echarts/highlightBinding.test.ts
+++ b/test/adapters/echarts/highlightBinding.test.ts
@@ -1,0 +1,317 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The ECharts adapter's selectors, resolved by the traces that consume them.
+ *
+ * `cartesian.test.ts` checks that each selector string the adapter emits finds
+ * the element it means to, and that is a weaker claim than it looks: a trace
+ * only ever reaches those strings through `mapToSvgElements`, and each trace
+ * class accepts a different *shape*. A layer whose selectors are individually
+ * correct and collectively the wrong shape resolves nothing at all, silently,
+ * on a chart whose payload is otherwise perfect.
+ *
+ * Two of the four layers this adapter emits were exactly that:
+ *
+ * - **scatter** carried one selector per point. `ScatterTrace` reads
+ *   `layer.selectors as string` and hands it to `Svg.selectAllElements`,
+ *   whose `isUsableSelector` guard requires `typeof query === 'string'`, so
+ *   an array matched nothing and every ECharts scatter highlighted nothing.
+ *   The shape it wants is one selector naming the whole series at once.
+ * - **stacked and dodged** carried every cell's selector flattened into one
+ *   list. `SegmentedTrace.mapToSvgElements` routes an array to
+ *   `mapGridToSvgElements`, which wants a row per series and declines a flat
+ *   list -- for the reason its own comment gives, that a flat list says which
+ *   bars there are but not which cell each one is in.
+ *
+ * Both are the same mistake `Svg.isUsableSelector` was written for (#990) and
+ * both failed the same way: no highlight, no warning, nothing in the payload
+ * to suggest anything was wrong. So these cases stop at the trace rather than
+ * at the selector string, and each asserts that a navigated cell resolves to
+ * the mark the adapter stamped for it.
+ */
+
+import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters/echarts/types';
+import type { MaidrLayer, SegmentedPoint } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { LineTrace } from '@model/line';
+import { ScatterTrace } from '@model/scatter';
+import { SegmentedTrace } from '@model/segmented';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const CATEGORIES = ['A', 'B', 'C'];
+
+interface FakeSeries {
+  type: string;
+  names?: string[];
+  values: (number | null)[];
+  positions?: number[];
+  name?: string;
+  stack?: string;
+}
+
+function fakeList(series: FakeSeries): EChartsList {
+  return {
+    dimensions: ['x', 'y'],
+    count: () => series.values.length,
+    getName: index => series.names?.[index] ?? '',
+    get: (dimension, index) => (dimension === 'y'
+      ? series.values[index]
+      : series.positions?.[index] ?? index),
+  };
+}
+
+function fakeSeriesModel(series: FakeSeries): EChartsSeriesModel {
+  const options: Record<string, unknown> = {
+    name: series.name,
+    stack: series.stack,
+  };
+  return {
+    subType: series.type,
+    name: series.name ?? 'series 0',
+    getData: () => fakeList(series),
+    get: key => options[key],
+  };
+}
+
+function fakeInstance(series: FakeSeries[]): EChartsInstance {
+  return {
+    getModel: () => ({
+      eachSeries: (callback) => {
+        series.forEach((one, index) => callback(fakeSeriesModel(one), index));
+      },
+      eachComponent: (query, callback) => {
+        const components: Record<string, Record<string, unknown>[]> = {
+          xAxis: [{ type: 'category' }],
+          yAxis: [{ type: 'value' }],
+          title: [],
+        };
+        (components[query.mainType] ?? []).forEach((options, index) =>
+          callback({ get: key => options[key] }, index));
+      },
+    }),
+  };
+}
+
+/**
+ * The document ECharts drew.
+ *
+ * This file runs in the jsdom environment rather than the node one its
+ * siblings use, because a trace is not a pure function of its layer: building
+ * a `LineTrace` reaches `Svg.createCircleElement`, which asks
+ * `window.getComputedStyle` for the line's paint. `cartesian.test.ts` never
+ * constructs one and so never needs a window; nothing here can avoid it.
+ *
+ * Every mark is given an id of its own so a resolved element can say which
+ * mark it is -- the ids are the fixture's, not the adapter's, which addresses
+ * marks only by the attribute it stamps.
+ *
+ * @param marks - How many filled marks the chart drew
+ * @param lines - How many stroked polylines it drew
+ * @returns The container the chart was rendered into
+ */
+function drawnChart(marks: number, lines: number): HTMLElement {
+  document.body.innerHTML = '<div id="chart"></div>';
+  // jsdom builds every SVG child as a plain `SVGElement` and defines neither
+  // constructor, so `LineTrace`'s `instanceof SVGPathElement` throws a
+  // ReferenceError unless a test binds them (#1001).
+  const globals = globalThis as unknown as Record<string, unknown>;
+  globals.SVGPathElement = globals.SVGElement;
+  globals.SVGPolylineElement = class NeverAPolyline {};
+
+  const container = document.getElementById('chart') as HTMLElement;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+
+  const add = (id: string, attributes: Record<string, string>): void => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('id', id);
+    Object.entries(attributes).forEach(([key, value]) => path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  add('grid', { fill: 'none', stroke: '#dbdee4' });
+  for (let index = 0; index < marks; index++) {
+    // A symbol as ECharts writes one: a unit shape about the origin, scaled
+    // and moved into place by a matrix, so the mark's centre is the last two
+    // numbers and the `d` says nothing about where it is. Measured on
+    // echarts 6.1.0 -- `matrix(2.937,0,0,2.937,240,235)`, `d="M1 0A1 1 …"`.
+    add(`mark-${index}`, {
+      fill: '#5070dd',
+      d: 'M1 0A1 1 0 1 1 1 -0.0001',
+      transform: `matrix(2.937,0,0,2.937,${100 + index * 50},${200 - index * 10})`,
+    });
+  }
+  for (let index = 0; index < lines; index++) {
+    add(`line-${index}`, {
+      'fill': 'none',
+      'stroke': '#5070dd',
+      'stroke-width': '2',
+      'd': 'M0 100L50 90L100 80',
+    });
+  }
+
+  container.appendChild(svg);
+  return container;
+}
+
+function layerFor(series: FakeSeries[], marks: number, lines: number): MaidrLayer {
+  const container = drawnChart(marks, lines);
+  const layer = createMaidrFromEChart(fakeInstance(series), container)
+    .subplots[0][0]
+    .layers[0];
+  if (!layer) {
+    throw new Error('no layer emitted');
+  }
+  return layer;
+}
+
+/** As much of a trace as navigating one costs. */
+interface Cursor {
+  moveToIndex: (row: number, col: number) => void;
+  state: TraceState;
+}
+
+/**
+ * The ids of the marks a trace resolves at one position.
+ *
+ * @param cursor - The trace to navigate
+ * @param row    - Which row to move to
+ * @param col    - Which column to move to
+ * @returns The resolved elements' ids, empty when nothing resolved
+ */
+function highlighted(
+  cursor: Cursor,
+  row: number,
+  col: number,
+): string[] {
+  cursor.moveToIndex(row, col);
+  const state = cursor.state as Extract<TraceState, { empty: false }>;
+  const highlight = state.highlight as { empty?: boolean; elements?: unknown };
+  if (highlight.empty || !highlight.elements) {
+    return [];
+  }
+  const elements = Array.isArray(highlight.elements)
+    ? highlight.elements
+    : [highlight.elements];
+  return (elements as { id?: string }[]).map(element => element.id ?? '(unnamed)');
+}
+
+afterEach(() => {
+  const globals = globalThis as unknown as Record<string, unknown>;
+  delete globals.SVGPathElement;
+  delete globals.SVGPolylineElement;
+  document.body.innerHTML = '';
+});
+
+describe('an eCharts bar layer', () => {
+  it('outlines the bar the reader is on', () => {
+    const layer = layerFor(
+      [{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }],
+      3,
+      0,
+    );
+    const trace = new BarTrace(layer);
+
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+  });
+});
+
+describe('an eCharts stacked bar layer', () => {
+  it('outlines the segment the reader is on, not nothing at all', () => {
+    // Six marks: three categories in each of two series, series-major, which
+    // is the order ECharts draws them in.
+    const layer = layerFor(
+      [
+        { type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'one', stack: 'total' },
+        { type: 'bar', names: CATEGORIES, values: [4, 5, 6], name: 'two', stack: 'total' },
+      ],
+      6,
+      0,
+    );
+    const trace = new SegmentedTrace(layer);
+    const rows = layer.data as SegmentedPoint[][];
+
+    expect(rows).toHaveLength(2);
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+    expect(highlighted(trace, 1, 0)).toEqual(['mark-3']);
+    expect(highlighted(trace, 1, 2)).toEqual(['mark-5']);
+  });
+});
+
+describe('an eCharts dodged bar layer', () => {
+  it('outlines the bar the reader is on, not nothing at all', () => {
+    const layer = layerFor(
+      [
+        { type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'one' },
+        { type: 'bar', names: CATEGORIES, values: [4, 5, 6], name: 'two' },
+      ],
+      6,
+      0,
+    );
+    const trace = new SegmentedTrace(layer);
+
+    expect(highlighted(trace, 0, 1)).toEqual(['mark-1']);
+    expect(highlighted(trace, 1, 1)).toEqual(['mark-4']);
+  });
+});
+
+describe('an eCharts scatter layer', () => {
+  it('outlines the point the reader is on, not nothing at all', () => {
+    const layer = layerFor(
+      [{ type: 'scatter', values: [1, 2, 3], positions: [10, 20, 30] }],
+      3,
+      0,
+    );
+    const trace = new ScatterTrace(layer);
+
+    // A scatter navigates by x, and each x here holds one point.
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+  });
+});
+
+describe('two eCharts scatter series', () => {
+  it('each outline only their own points', () => {
+    // Every mark on the chart is painted alike and stamped in one pass, so
+    // the stamp has to say which series a mark belongs to as well as which
+    // datum it is. Naming them all alike would put the second series' points
+    // on the first series' outline -- and with one series on the chart, which
+    // is what every other case here has, the two are indistinguishable.
+    const container = drawnChart(5, 0);
+    const layers = createMaidrFromEChart(
+      fakeInstance([
+        { type: 'scatter', values: [1, 2], positions: [10, 20], name: 'one' },
+        { type: 'scatter', values: [3, 4, 5], positions: [30, 40, 50], name: 'two' },
+      ]),
+      container,
+    ).subplots[0][0].layers;
+
+    expect(layers).toHaveLength(2);
+    const first = new ScatterTrace(layers[0]);
+    const second = new ScatterTrace(layers[1]);
+
+    expect(highlighted(first, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(first, 0, 1)).toEqual(['mark-1']);
+    expect(highlighted(second, 0, 0)).toEqual(['mark-2']);
+    expect(highlighted(second, 0, 2)).toEqual(['mark-4']);
+  });
+});
+
+describe('an eCharts line layer', () => {
+  it('outlines the line the reader is on', () => {
+    const layer = layerFor(
+      [{ type: 'line', names: CATEGORIES, values: [1, 2, 3] }],
+      0,
+      1,
+    );
+    const trace = new LineTrace(layer);
+
+    expect(highlighted(trace, 0, 0)).not.toEqual([]);
+  });
+});


### PR DESCRIPTION
Tier 1 of #1195. Also fixes #1197.

## What

ECharts had no adapter while fourteen other chart libraries did, so an ECharts figure was unreachable to MAIDR entirely — not degraded, not partially read, simply absent. This adds `src/adapters/echarts/` covering the cartesian series:

| ECharts | read as |
| --- | --- |
| `bar` (single) | `bar` |
| `bar` with `stack` | `stacked` |
| several `bar` series, no `stack` | `dodged` |
| `bar` on a category `yAxis` | the same, `orientation: 'horz'` |
| `line` | `line` |
| `line` with `areaStyle` | `area` |
| `line` with `step` | `line` carrying the step direction |
| `scatter` | `scatter`, with `symbolSize` read into `z` |

A `pie` chart — anything outside the set — is refused rather than half-read.

## The addressability problem, and how this resolves it

Every other adapter addresses its marks by selector because its library
puts something addressable on them. ECharts' SVG renderer does not: the
tree is flat, and no element carries an id, a class, or a `data-*`
attribute that ties it to a datum.

What the renderer does guarantee is that data marks are separable from
chart furniture by paint — a bar or a symbol is filled, a line is stroked
and unfilled, and the furniture (axis lines, splitlines, the background,
the label backgrounds) is neither, or is painted in the small set of
furniture colours. It also draws marks in data order.

So the adapter counts what it expects to find, compares that against what
the paint filter selected, and stamps its own attributes onto the elements
only when the two agree. On a mismatch it warns and emits the layer with
no selectors, which reads and sonifies but does not highlight. Pointing
at the wrong mark is worse than pointing at none, so a mismatch fails
that way deliberately.

The consequence worth stating plainly: **a series painted pure black is
read but not highlighted**, because pure black is how ECharts paints
several pieces of furniture and the filter cannot tell them apart. That
is the conservative failure, and `docs/echarts.md` says so.

## Each layer gets the selector shape its trace can resolve

A selector that finds the right element is only half of it. Each trace class
accepts a different **shape**, and a layer whose selectors are individually
right and collectively the wrong shape resolves nothing at all — silently, with
no warning and nothing wrong in the payload:

| layer | shape | what reads it |
| --- | --- | --- |
| `bar` | one selector per bar | `AbstractBarPlot`'s array branch |
| `stacked`, `dodged` | a row of selectors per series | `SegmentedTrace.mapGridToSvgElements` |
| `scatter` | **one** selector naming the whole series | `ScatterTrace`, which casts `layer.selectors` to `string` |
| `line`, `area` | one selector per series | `LineTrace.mapToSvgElements` |

So marks are stamped twice in one pass — once per mark, once per series — and
each layer takes the address its own trace can use. Two of the four had this
wrong on the first commit and highlighted nothing; the fix is in `07f7284`,
pinned by tests that build the real trace rather than stopping at the string.

**#1197 is the model half of the scatter case.** ECharts does not *move* its
symbols into place, it *scales* them there: `matrix(s, 0, 0, s, e, f)` over a
unit shape whose `d` always begins `M1 0`. `ScatterTrace.groupSvgElements`
recovers a mark's position from the DOM, and its `d` fallback answered `(1, 0)`
for every point on the chart, grouping the whole scatter into one column. It
reads the matrix now, before that fallback. Nothing about it is
ECharts-specific — it is what any renderer does that draws one symbol path and
scales it per point.

## Two bugs the live run caught

Both were invisible to the unit tests as first written, and both are now
pinned by tests:

1. **The per-datum and per-series stamps shared one attribute.** Stamping
   the line series unstamped every bar, so on a mixed bar + line chart no
   bar could be highlighted while every line could.
2. **An axis name draws an `rgb(0, 0, 0)` background rect.** The paint
   filter recognised `#000000` as furniture but not the `rgb()` spelling
   of it, so it counted the rect as a mark, every count check failed, and
   every chart with an axis name lost its highlighting. Paint is now
   normalised before it is compared.

## Verification

- **Live, against echarts 6.1.0 in Chromium**: twelve figures — `bar`,
  unnamed `bar`, horizontal `bar`, `bar` with gaps, stacked, dodged,
  `line`, area, step, `line` with a gap, `scatter`, sized `scatter` —
  with **zero selector failures**, and `pie` correctly refused. Payloads
  spot-checked against what was drawn, including the horizontal swap
  (`{x: 1, y: 'A'}`) and the gap (`{x: 'B', y: null}`).
- **Mutation sweep: 22/22 caught.**
- Full gate: `eslint`, `tsc --noEmit`, `npm test` (427 suites / 5862
  tests, plus the ESM project's 10 / 138), `npm run build` (15/15
  bundles, up from 14), `npm run docs`.

One note for anyone re-running the tests: the ESM project has to be run
through plain `npm test` rather than `--selectProjects esm`, which fails
with `SyntaxError: Unexpected token 'export'` on the jest-resolve
cross-project memoisation bug tracked in #703. That is unrelated to this
change.

## Not in this change

Tiers 2–4 of #1195: the single-series shapes (`pie`, `gauge`, `funnel`,
`radar`, `boxplot`, `candlestick`, `heatmap`), the hierarchies and graphs
(`tree`, `treemap`, `sunburst`, `sankey`, `graph`), and
`themeRiver` / `pictorialBar`.