### PR TITLE
feat(echarts): read a pie, a funnel and a gauge

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -71,6 +71,28 @@ them, and each wants its own measured layout first. See
 > samples either side stay in their places rather than the series closing over
 > the hole.
 
+## Single-value charts
+
+A pie, a funnel and a gauge sit on no grid and own the whole chart, and all
+three report `data.dimensions` as `['value']` with the label on `getName(i)` —
+so the reading is that pair.
+
+| ECharts | read as | highlighted |
+|---|---|---|
+| `pie` | `pie` | yes — one selector naming every slice |
+| `funnel` | `funnel` | yes — one selector per stage |
+| `gauge` | `gauge` | **no** — see below |
+
+A gauge draws **two** filled marks for its one datum: the track and the
+progress arc, measured as `#e8ebf0` and the series colour. The count check
+every other reading here relies on has nothing to check, and naming either
+mark would be a guess about which one the reader should be shown, so the
+gauge is read without an outline.
+
+`min` and `max` come off the series rather than being defaulted here.
+`getModel()` resolves ECharts' own `0` and `100` when the author wrote
+neither, so the dial the reader is told about is the dial that was drawn.
+
 ## Highlighting
 
 ECharts gives a reading almost nothing to address by. Measured on 6.1.0: the

--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -52,9 +52,9 @@ Two things this example does on purpose:
 | `line` + `step` | `line` + `stepDirection` | `'start'` → `vh`, `'end'`/`'middle'` → `hv` |
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
 
-**Not yet supported:** `pie`, `boxplot`, `candlestick`, `heatmap`, `radar`,
-`funnel`, `gauge`, `treemap`, `sunburst`, `sankey`, `graph`, `parallel`,
-`themeRiver`, `pictorialBar`. Each of these is *refused by name* rather than
+**Not yet supported:** `boxplot`, `candlestick`, `heatmap`, `radar`,
+`treemap`, `sunburst`, `sankey`, `graph`, `parallel`, `themeRiver`,
+`pictorialBar`. Each of these is *refused by name* rather than
 mapped onto whichever trace is closest — most have a MAIDR trace waiting for
 them, and each wants its own measured layout first. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -17,6 +17,7 @@ import type {
 import { Orientation, TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
 import { markPerDatum, markPerSeries } from './selectors';
+import { SINGLE_VALUE, singleValueLayer } from './single';
 
 /**
  * Options accepted by {@link createMaidrFromEChart}.
@@ -38,7 +39,16 @@ export interface EChartsAdapterOptions {
  * Most of them have a trace waiting and are the later tiers of #1195; each
  * wants its own measured layout before it claims to be readable.
  */
-const READ: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
+const CARTESIAN: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
+
+/**
+ * Everything the adapter reads, cartesian and single-valued together.
+ *
+ * The two families are read by different code because they are different
+ * shapes -- one has axes and positions, the other has names and magnitudes --
+ * and a chart cannot hold both: a pie has no grid to share with a bar.
+ */
+const READ: ReadonlySet<string> = new Set([...CARTESIAN, ...SINGLE_VALUE]);
 
 /**
  * Converts a rendered ECharts instance into a MAIDR figure.
@@ -77,8 +87,15 @@ export function createMaidrFromEChart(
     );
   }
 
-  const axes = axisNames(model);
-  const layers = buildLayers(readable, axes, container);
+  const single = readable.filter(seriesModel => SINGLE_VALUE.has(seriesModel.subType));
+  const layers = single.length > 0
+    // A pie, a funnel and a gauge each own the whole chart -- none of them
+    // sits on a grid -- so a figure holding one holds nothing else this
+    // adapter would stamp, and the two stamping passes never meet.
+    ? single
+        .map(seriesModel => singleValueLayer(seriesModel, container))
+        .filter((layer): layer is MaidrLayer => layer !== undefined)
+    : buildLayers(readable, axisNames(model), container);
   const title = options.title ?? componentText(model, 'title', 'text');
   const subplot: MaidrSubplot = { layers };
 

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -17,7 +17,7 @@ import type {
 import { Orientation, TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
 import { markPerDatum, markPerSeries } from './selectors';
-import { SINGLE_VALUE, singleValueLayer } from './single';
+import { SINGLE_VALUE, singleValueLayers } from './single';
 
 /**
  * Options accepted by {@link createMaidrFromEChart}.
@@ -30,23 +30,24 @@ export interface EChartsAdapterOptions {
 }
 
 /**
- * The series types this tier reads.
+ * The series types that live on a grid.
  *
- * ECharts draws seventeen. Every other one -- `pie`, `boxplot`,
- * `candlestick`, `heatmap`, `radar`, `funnel`, `gauge`, `treemap`,
- * `sunburst`, `sankey`, `graph`, `parallel`, `themeRiver`, `pictorialBar` --
- * is left unread by name rather than mapped onto whichever trace is closest.
- * Most of them have a trace waiting and are the later tiers of #1195; each
- * wants its own measured layout before it claims to be readable.
+ * Not the whole of what the adapter reads -- see `READ` below, which is this
+ * set together with the single-valued ones. The two are kept apart because
+ * they are read by different code: one has axes and positions, the other
+ * names and magnitudes.
  */
 const CARTESIAN: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
 
 /**
- * Everything the adapter reads, cartesian and single-valued together.
+ * Everything the adapter reads.
  *
- * The two families are read by different code because they are different
- * shapes -- one has axes and positions, the other has names and magnitudes --
- * and a chart cannot hold both: a pie has no grid to share with a bar.
+ * ECharts draws seventeen series types. Every one outside this set --
+ * `boxplot`, `candlestick`, `heatmap`, `radar`, `treemap`, `sunburst`,
+ * `sankey`, `graph`, `parallel`, `themeRiver`, `pictorialBar` -- is left
+ * unread **by name** rather than mapped onto whichever trace is closest.
+ * Most of them have a trace waiting and are the later tiers of #1195; each
+ * wants its own measured layout before it claims to be readable.
  */
 const READ: ReadonlySet<string> = new Set([...CARTESIAN, ...SINGLE_VALUE]);
 
@@ -91,10 +92,10 @@ export function createMaidrFromEChart(
   const layers = single.length > 0
     // A pie, a funnel and a gauge each own the whole chart -- none of them
     // sits on a grid -- so a figure holding one holds nothing else this
-    // adapter would stamp, and the two stamping passes never meet.
-    ? single
-        .map(seriesModel => singleValueLayer(seriesModel, container))
-        .filter((layer): layer is MaidrLayer => layer !== undefined)
+    // adapter would stamp, and the two stamping passes never meet. A chart
+    // that declares both families anyway is read as the single-valued half
+    // and says so, rather than dropping the other half in silence.
+    ? readSingle(single, readable, container)
     : buildLayers(readable, axisNames(model), container);
   const title = options.title ?? componentText(model, 'title', 'text');
   const subplot: MaidrSubplot = { layers };
@@ -104,6 +105,33 @@ export function createMaidrFromEChart(
     ...(title ? { title } : {}),
     subplots: [[subplot]],
   };
+}
+
+/**
+ * The layers of a chart whose series carry one magnitude per named thing.
+ *
+ * @param single   - The single-valued series
+ * @param readable - Every series the adapter reads, including those
+ * @param container - The element the chart was rendered into
+ * @returns One or more layers per series
+ */
+function readSingle(
+  single: EChartsSeriesModel[],
+  readable: EChartsSeriesModel[],
+  container: HTMLElement,
+): MaidrLayer[] {
+  if (single.length !== readable.length) {
+    const dropped = readable
+      .filter(seriesModel => !SINGLE_VALUE.has(seriesModel.subType))
+      .map(seriesModel => seriesModel.subType)
+      .join(', ');
+    console.warn(
+      `[MAIDR] ECharts chart mixes single-value and cartesian series. `
+      + `Reading the single-value ones; ignoring: ${dropped}.`,
+    );
+  }
+
+  return single.flatMap(seriesModel => singleValueLayers(seriesModel, container));
 }
 
 /**

--- a/src/adapters/echarts/single.ts
+++ b/src/adapters/echarts/single.ts
@@ -1,0 +1,207 @@
+/**
+ * The ECharts series that carry one magnitude per named thing.
+ *
+ * A pie, a funnel and a gauge share a shape the cartesian series do not: no
+ * axes, one series to a chart, and a datum that is a name and a number rather
+ * than a position and a magnitude. `data.dimensions` is `['value']` for all
+ * three -- measured on echarts 6.1.0 -- and `getName(i)` carries the label,
+ * so the whole reading is that pair.
+ *
+ * Tier 2a of #1195. The statistical and grid shapes -- `boxplot`,
+ * `candlestick`, `heatmap`, `radar` -- are the same measurement exercise with
+ * a different summary at the end of it, and each wants its selector shape
+ * established against the trace that reads it before it claims to be
+ * highlightable, which is what tier 1 learned the hard way (#1196).
+ */
+
+import type { BarPoint, GaugePoint, MaidrLayer, PiePoint } from '@type/grammar';
+import type { EChartsSeriesModel } from './types';
+import { TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
+import { markPerDatum } from './selectors';
+
+/** One datum: what it is called, and what it measures. */
+interface Reading {
+  name: string;
+  value: number;
+}
+
+/** The series types this module reads. */
+export const SINGLE_VALUE: ReadonlySet<string> = new Set([
+  'pie',
+  'funnel',
+  'gauge',
+]);
+
+/**
+ * What the label and value of one datum are.
+ *
+ * @param seriesModel - The series to read
+ * @returns One `{ name, value }` per datum that carries a number
+ */
+function readValues(seriesModel: EChartsSeriesModel): Reading[] {
+  const data = seriesModel.getData();
+  const dimension = data.dimensions[0] ?? 'value';
+  const read: Reading[] = [];
+
+  for (let index = 0; index < data.count(); index++) {
+    const value = data.get(dimension, index);
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      continue;
+    }
+    read.push({ name: data.getName(index), value });
+  }
+  return read;
+}
+
+/**
+ * Builds the layer for one pie, funnel or gauge series.
+ *
+ * @param seriesModel - The series to read
+ * @param container   - The element the chart was rendered into
+ * @returns The layer, or `undefined` when the series drew no reading
+ */
+export function singleValueLayer(
+  seriesModel: EChartsSeriesModel,
+  container: HTMLElement,
+): MaidrLayer | undefined {
+  const read = readValues(seriesModel);
+  if (read.length === 0) {
+    return undefined;
+  }
+
+  if (seriesModel.subType === 'gauge') {
+    return gaugeLayer(seriesModel, read[0]);
+  }
+
+  // A pie and a funnel each draw exactly one filled mark per datum --
+  // measured: three slices are three filled paths, and the three unfilled
+  // ones beside them are the label guides, which the paint filter already
+  // declines.
+  const marks = markPerDatum(container, [read.length]);
+
+  return seriesModel.subType === 'pie'
+    ? pieLayer(seriesModel, read, marks?.series[0])
+    : funnelLayer(seriesModel, read, marks?.points[0]);
+}
+
+/**
+ * A pie, whose slices are named and measured.
+ *
+ * `PieTrace` reads `layer.selectors` as a single string, so the slices are
+ * named together rather than one at a time -- the shape a scatter needs for
+ * the same reason (#1196).
+ *
+ * @param seriesModel - The series to read
+ * @param read        - Its labelled values
+ * @param selectors   - One selector naming every slice, when they were found
+ * @returns The layer
+ */
+function pieLayer(
+  seriesModel: EChartsSeriesModel,
+  read: Reading[],
+  selectors: string | undefined,
+): MaidrLayer {
+  const data: PiePoint[] = read.map(({ name, value }, index) => ({
+    x: name || `Slice ${index + 1}`,
+    y: value,
+  }));
+  const name = authored(seriesModel);
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.PIE,
+    ...(name ? { name } : {}),
+    ...(selectors ? { selectors } : {}),
+    data,
+  };
+}
+
+/**
+ * A funnel, whose stages stay in the order the chart drew them.
+ *
+ * The order is the reading: MAIDR pitches each stage against the one before
+ * it, so retention is what a listener hears. `FunnelTrace` extends
+ * `BarTrace`, which takes one selector per mark.
+ *
+ * @param seriesModel - The series to read
+ * @param read        - Its labelled values
+ * @param selectors   - One selector per stage, when the marks were found
+ * @returns The layer
+ */
+function funnelLayer(
+  seriesModel: EChartsSeriesModel,
+  read: Reading[],
+  selectors: string[] | undefined,
+): MaidrLayer {
+  const data: BarPoint[] = read.map(({ name, value }, index) => ({
+    x: name || `Stage ${index + 1}`,
+    y: value,
+  }));
+  const name = authored(seriesModel);
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.FUNNEL,
+    ...(name ? { name } : {}),
+    ...(selectors ? { selectors } : {}),
+    data,
+  };
+}
+
+/**
+ * A gauge, which is one reading against the dial it sits on.
+ *
+ * `min` and `max` are asked of the series rather than defaulted here:
+ * `getModel()` resolves ECharts' own `0` and `100` when the author wrote
+ * neither, measured, so the dial the reader is told about is the dial that
+ * was drawn.
+ *
+ * **No selectors.** A gauge draws two filled marks for its one datum -- the
+ * track and the progress arc, measured as `#e8ebf0` and the series colour --
+ * so the count check that every other reading here relies on has nothing to
+ * check: there is no arrangement in which one datum and two marks agree.
+ * Naming either one would be a guess about which the reader should be shown.
+ *
+ * @param seriesModel - The series to read
+ * @param read        - Its one labelled value
+ * @returns The layer
+ */
+function gaugeLayer(
+  seriesModel: EChartsSeriesModel,
+  read: Reading,
+): MaidrLayer {
+  const point: GaugePoint = {
+    value: read.value,
+    min: numeric(seriesModel.get('min'), 0),
+    max: numeric(seriesModel.get('max'), 100),
+    ...(read.name ? { label: read.name } : {}),
+  };
+  const name = authored(seriesModel);
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.GAUGE,
+    ...(name ? { name } : {}),
+    data: point,
+  };
+}
+
+/**
+ * The series' name, when the author wrote one.
+ *
+ * The option rather than `seriesModel.name`, which ECharts always resolves --
+ * it invents one for a series declared without a name, so emitting it would
+ * name a layer after an internal counter (#1195).
+ *
+ * @param seriesModel - The series to read
+ * @returns The authored name, or the empty string
+ */
+function authored(seriesModel: EChartsSeriesModel): string {
+  const name = seriesModel.get('name');
+  return typeof name === 'string' ? name : '';
+}
+
+function numeric(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}

--- a/src/adapters/echarts/single.ts
+++ b/src/adapters/echarts/single.ts
@@ -55,23 +55,31 @@ function readValues(seriesModel: EChartsSeriesModel): Reading[] {
 }
 
 /**
- * Builds the layer for one pie, funnel or gauge series.
+ * Builds the layers for one pie, funnel or gauge series.
+ *
+ * A pie and a funnel are one layer each; a gauge is one **per pointer**.
+ * ECharts draws a pointer for every entry in a gauge's `data` -- measured, a
+ * two-entry gauge reports `count() === 2` and puts two needles on one dial --
+ * and `GaugePoint` is a single reading, so two of them are two layers rather
+ * than one reading and one silently dropped. What that loses is that they
+ * share a dial; nothing in the grammar carries it, and both min and max come
+ * out the same on each, which is as close as it gets.
  *
  * @param seriesModel - The series to read
  * @param container   - The element the chart was rendered into
- * @returns The layer, or `undefined` when the series drew no reading
+ * @returns The layers, empty when the series drew no reading
  */
-export function singleValueLayer(
+export function singleValueLayers(
   seriesModel: EChartsSeriesModel,
   container: HTMLElement,
-): MaidrLayer | undefined {
+): MaidrLayer[] {
   const read = readValues(seriesModel);
   if (read.length === 0) {
-    return undefined;
+    return [];
   }
 
   if (seriesModel.subType === 'gauge') {
-    return gaugeLayer(seriesModel, read[0]);
+    return read.map(one => gaugeLayer(seriesModel, one));
   }
 
   // A pie and a funnel each draw exactly one filled mark per datum --
@@ -80,9 +88,11 @@ export function singleValueLayer(
   // declines.
   const marks = markPerDatum(container, [read.length]);
 
-  return seriesModel.subType === 'pie'
-    ? pieLayer(seriesModel, read, marks?.series[0])
-    : funnelLayer(seriesModel, read, marks?.points[0]);
+  return [
+    seriesModel.subType === 'pie'
+      ? pieLayer(seriesModel, read, marks?.series[0])
+      : funnelLayer(seriesModel, read, marks?.points[0]),
+  ];
 }
 
 /**

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -14,11 +14,21 @@
 /**
  * The series types this adapter reads.
  *
- * ECharts draws seventeen; these are the cartesian three, which is the first
- * tier of xability/maidr#1195. Every other series type is refused by name so
- * that gaining a reading later is a decision rather than an accident.
+ * ECharts draws seventeen. Three are the cartesian ones (tier 1 of
+ * xability/maidr#1195) and three carry one magnitude per named thing (tier
+ * 2a). Every other series type is refused by name so that gaining a reading
+ * later is a decision rather than an accident.
+ *
+ * Kept in step with `READ` in `converters.ts`, which is what actually decides
+ * -- this type is the public statement of it.
  */
-export type EChartsSeriesType = 'bar' | 'line' | 'scatter';
+export type EChartsSeriesType
+  = | 'bar'
+    | 'line'
+    | 'scatter'
+    | 'pie'
+    | 'funnel'
+    | 'gauge';
 
 /**
  * One column of a series' internal data list.

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -424,11 +424,13 @@ describe('what the adapter will not claim', () => {
   it('refuses a chart of series it has no reading for', () => {
     // By name, rather than mapped onto whichever trace is closest. ECharts
     // draws seventeen series types and most have a trace waiting for them,
-    // but each wants its own measured layout first (#1195).
+    // but each wants its own measured layout first (#1195). `pie` used to
+    // stand here and now reads; `treemap` is one of the hierarchies still
+    // waiting for tier 3.
     expect(() => layersOf(
-      { series: [{ type: 'pie', values: [1, 2, 3] }] },
+      { series: [{ type: 'treemap', values: [1, 2, 3] }] },
       drawnChart(3, 0),
-    )).toThrow(/Unsupported ECharts series type\(s\): pie/);
+    )).toThrow(/Unsupported ECharts series type\(s\): treemap/);
   });
 
   it('drops the highlighting when the drawing holds a different number of marks', () => {

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -1,0 +1,314 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The ECharts series that carry one magnitude per named thing (#1195, tier 2a).
+ *
+ * A pie, a funnel and a gauge sit on no grid, own the whole chart, and report
+ * `data.dimensions` as `['value']` with the label on `getName(i)` -- measured
+ * on echarts 6.1.0, not read from the documentation. So the reading is that
+ * pair, and what these cases are about is where each of the three puts it.
+ *
+ * The selectors are checked through the traces that consume them rather than
+ * by resolving the strings, which is the lesson tier 1 paid for (#1196): each
+ * trace class accepts a different shape, and a layer whose selectors are
+ * individually right and collectively the wrong shape resolves nothing at
+ * all, silently.
+ */
+
+import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters/echarts/types';
+import type { BarPoint, GaugePoint, MaidrLayer, PiePoint } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { FunnelTrace } from '@model/funnel';
+import { PieTrace } from '@model/pie';
+import { TraceType } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface FakeSeries {
+  type: string;
+  names?: (string | undefined)[];
+  values: (number | null)[];
+  name?: string;
+  min?: number;
+  max?: number;
+}
+
+function fakeSeriesModel(series: FakeSeries): EChartsSeriesModel {
+  const options: Record<string, unknown> = {
+    name: series.name,
+    min: series.min,
+    max: series.max,
+  };
+  const list: EChartsList = {
+    dimensions: ['value'],
+    count: () => series.values.length,
+    getName: index => series.names?.[index] ?? '',
+    get: (_dimension, index) => series.values[index],
+  };
+
+  return {
+    subType: series.type,
+    name: series.name ?? 'series 0',
+    getData: () => list,
+    get: key => options[key],
+  };
+}
+
+function fakeInstance(series: FakeSeries[]): EChartsInstance {
+  return {
+    getModel: () => ({
+      eachSeries: (callback) => {
+        series.forEach((one, index) => callback(fakeSeriesModel(one), index));
+      },
+      // A pie, a funnel and a gauge declare no axes at all, which is part of
+      // what makes them a family of their own.
+      eachComponent: () => {},
+    }),
+  };
+}
+
+/**
+ * The document ECharts drew: one filled path per slice or stage, and the
+ * unfilled label guides beside them that the paint filter must decline.
+ *
+ * @param marks - How many data marks the chart drew
+ * @returns The container the chart was rendered into
+ */
+function drawnChart(marks: number): HTMLElement {
+  document.body.innerHTML = '<div id="chart"></div>';
+  const container = document.getElementById('chart') as HTMLElement;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+
+  const add = (id: string, attributes: Record<string, string>): void => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('id', id);
+    Object.entries(attributes).forEach(([key, value]) => path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  for (let index = 0; index < marks; index++) {
+    add(`mark-${index}`, { fill: '#5070dd' });
+    // The guide line a pie draws out to each label: stroked, unfilled, and
+    // exactly as numerous as the slices, so a filter that counted it would
+    // find twice what it expected.
+    add(`guide-${index}`, { fill: 'none', stroke: '#5070dd' });
+  }
+
+  container.appendChild(svg);
+  return container;
+}
+
+function layerFor(series: FakeSeries, marks: number): MaidrLayer {
+  const container = drawnChart(marks);
+  const layer = createMaidrFromEChart(fakeInstance([series]), container)
+    .subplots[0][0]
+    .layers[0];
+  if (!layer) {
+    throw new Error('no layer emitted');
+  }
+  return layer;
+}
+
+/** As much of a trace as navigating one costs. */
+interface Cursor {
+  moveToIndex: (row: number, col: number) => void;
+  state: TraceState;
+}
+
+/**
+ * The ids of the marks a trace resolves at one position.
+ *
+ * @param cursor - The trace to navigate
+ * @param row    - Which row to move to
+ * @param col    - Which column to move to
+ * @returns The resolved elements' ids, empty when nothing resolved
+ */
+function highlighted(
+  cursor: Cursor,
+  row: number,
+  col: number,
+): string[] {
+  cursor.moveToIndex(row, col);
+  const state = cursor.state as Extract<TraceState, { empty: false }>;
+  const highlight = state.highlight as { empty?: boolean; elements?: unknown };
+  if (highlight.empty || !highlight.elements) {
+    return [];
+  }
+  const elements = Array.isArray(highlight.elements)
+    ? highlight.elements
+    : [highlight.elements];
+  return (elements as { id?: string }[]).map(element => element.id ?? '(unnamed)');
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('an eCharts pie chart', () => {
+  it('is read as the slices it draws, named and measured', () => {
+    const layer = layerFor(
+      { type: 'pie', names: ['A', 'B', 'C'], values: [1, 2, 3], name: 'Share' },
+      3,
+    );
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.name).toBe('Share');
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 },
+      { x: 'C', y: 3 },
+    ]);
+  });
+
+  it('names every slice at once, which is the shape PieTrace reads', () => {
+    // `PieTrace` casts `layer.selectors` to `string`, and
+    // `Svg.selectAllElements` declines anything that is not one, so a list
+    // here would resolve nothing and lose the highlighting in silence.
+    const layer = layerFor(
+      { type: 'pie', names: ['A', 'B', 'C'], values: [1, 2, 3] },
+      3,
+    );
+
+    expect(typeof layer.selectors).toBe('string');
+    const trace = new PieTrace(layer);
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+  });
+
+  it('names a slice the author left unnamed', () => {
+    // A slice with no name is still a slice, and `PiePoint.x` is what a
+    // reader is told they are on.
+    const layer = layerFor(
+      { type: 'pie', names: ['A', undefined, 'C'], values: [1, 2, 3] },
+      3,
+    );
+
+    expect((layer.data as PiePoint[])[1].x).toBe('Slice 2');
+  });
+});
+
+describe('a single-value datum with no number', () => {
+  it('is left out rather than announced as a slice of nothing', () => {
+    // ECharts draws nothing for it, so reading it would put a slice on the
+    // chart that is not there -- and the mark count would then expect three
+    // where two were drawn, costing the other two their outline as well.
+    const layer = layerFor(
+      { type: 'pie', names: ['A', 'B', 'C'], values: [1, null, 3] },
+      2,
+    );
+
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'A', y: 1 },
+      { x: 'C', y: 3 },
+    ]);
+    expect(layer.selectors).toBeDefined();
+  });
+
+  it('leaves a chart with nothing to read out of the figure', () => {
+    // Not an empty layer: a layer a reader can land on and hear nothing from
+    // is worse than one that is not there (#421 makes the same call in
+    // py-maidr).
+    const container = drawnChart(0);
+    expect(() => createMaidrFromEChart(
+      fakeInstance([{ type: 'pie', names: ['A'], values: [null] }]),
+      container,
+    )).not.toThrow();
+    expect(
+      createMaidrFromEChart(
+        fakeInstance([{ type: 'pie', names: ['A'], values: [null] }]),
+        container,
+      ).subplots[0][0].layers,
+    ).toHaveLength(0);
+  });
+});
+
+describe('an eCharts funnel chart', () => {
+  it('keeps its stages in the order they were drawn', () => {
+    // The order is the reading: MAIDR pitches each stage against the one
+    // before it, so a sorted funnel would announce a retention the chart
+    // never showed.
+    const layer = layerFor(
+      {
+        type: 'funnel',
+        names: ['Visit', 'Cart', 'Buy'],
+        values: [100, 60, 30],
+      },
+      3,
+    );
+
+    expect(layer.type).toBe(TraceType.FUNNEL);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'Visit', y: 100 },
+      { x: 'Cart', y: 60 },
+      { x: 'Buy', y: 30 },
+    ]);
+  });
+
+  it('names each stage separately, which is the shape FunnelTrace reads', () => {
+    // `FunnelTrace` extends `BarTrace`, whose array branch takes one selector
+    // per mark and declines a nested list.
+    const layer = layerFor(
+      {
+        type: 'funnel',
+        names: ['Visit', 'Cart', 'Buy'],
+        values: [100, 60, 30],
+      },
+      3,
+    );
+
+    expect(layer.selectors).toHaveLength(3);
+    const trace = new FunnelTrace(layer);
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+  });
+});
+
+describe('an eCharts gauge', () => {
+  it('is read against the dial it was drawn on', () => {
+    const layer = layerFor(
+      { type: 'gauge', names: ['Speed'], values: [70], min: 10, max: 200 },
+      2,
+    );
+
+    expect(layer.type).toBe(TraceType.GAUGE);
+    expect(layer.data as GaugePoint).toEqual({
+      value: 70,
+      min: 10,
+      max: 200,
+      label: 'Speed',
+    });
+  });
+
+  it('takes ECharts\' own dial when the author wrote none', () => {
+    // `getModel()` resolves the defaults, so 0 and 100 are the numbers the
+    // chart was actually drawn with rather than a guess made here.
+    const layer = layerFor({ type: 'gauge', values: [70] }, 2);
+
+    expect(layer.data as GaugePoint).toEqual({ value: 70, min: 0, max: 100 });
+  });
+
+  it('is read without an outline rather than outlined wrongly', () => {
+    // A gauge draws two filled marks for its one datum -- the track and the
+    // progress arc -- so the count check has nothing to check, and naming
+    // either one would be a guess about which the reader should be shown.
+    const layer = layerFor({ type: 'gauge', values: [70] }, 2);
+
+    expect(layer.selectors).toBeUndefined();
+  });
+});
+
+describe('an eCharts chart of a type outside the set', () => {
+  it('is refused rather than read as whichever trace is closest', () => {
+    expect(() => layerFor({ type: 'treemap', values: [1] }, 1))
+      .toThrow(/Unsupported ECharts series type/);
+  });
+
+  it('names the single-value types among the ones it does read', () => {
+    expect(() => layerFor({ type: 'treemap', values: [1] }, 1))
+      .toThrow(/pie, funnel, gauge/);
+  });
+});

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -21,7 +21,7 @@ import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters
 import type { BarPoint, GaugePoint, MaidrLayer, PiePoint } from '@type/grammar';
 import type { TraceState } from '@type/state';
 import { createMaidrFromEChart } from '@adapters/echarts/converters';
-import { afterEach, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { FunnelTrace } from '@model/funnel';
 import { PieTrace } from '@model/pie';
 import { TraceType } from '@type/grammar';
@@ -144,8 +144,18 @@ function highlighted(
   return (elements as { id?: string }[]).map(element => element.id ?? '(unnamed)');
 }
 
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
 afterEach(() => {
   document.body.innerHTML = '';
+});
+
+afterAll(() => {
+  warnSpy.mockRestore();
 });
 
 describe('an eCharts pie chart', () => {
@@ -298,6 +308,62 @@ describe('an eCharts gauge', () => {
     const layer = layerFor({ type: 'gauge', values: [70] }, 2);
 
     expect(layer.selectors).toBeUndefined();
+  });
+});
+
+describe('a gauge with more than one pointer', () => {
+  it('reads every needle rather than the first', () => {
+    // Measured: a two-entry gauge reports `count() === 2` and draws two
+    // needles on one dial. `GaugePoint` is a single reading, so the two come
+    // out as two layers -- what that loses is that they share a dial, and
+    // nothing in the grammar carries it.
+    const container = drawnChart(2);
+    const layers = createMaidrFromEChart(
+      fakeInstance([{
+        type: 'gauge',
+        names: ['A', 'B'],
+        values: [30, 70],
+        min: 0,
+        max: 100,
+      }]),
+      container,
+    ).subplots[0][0].layers;
+
+    expect(layers).toHaveLength(2);
+    expect(layers[0].data as GaugePoint).toEqual({
+      value: 30,
+      min: 0,
+      max: 100,
+      label: 'A',
+    });
+    expect(layers[1].data as GaugePoint).toEqual({
+      value: 70,
+      min: 0,
+      max: 100,
+      label: 'B',
+    });
+  });
+});
+
+describe('a chart that declares both families', () => {
+  it('reads the single-value half and says what it left out', () => {
+    // A pie has no grid to share with a bar, so this is not a chart ECharts
+    // is drawn to make -- but it is not invalid either, and dropping half of
+    // it in silence is the failure mode this adapter exists to avoid.
+    const container = drawnChart(3);
+    const layers = createMaidrFromEChart(
+      fakeInstance([
+        { type: 'pie', names: ['A', 'B', 'C'], values: [1, 2, 3] },
+        { type: 'bar', names: ['A'], values: [1] },
+      ]),
+      container,
+    ).subplots[0][0].layers;
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.PIE);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ignoring: bar'),
+    );
   });
 });
 


### PR DESCRIPTION
Tier 2a of #1195, on top of the adapter merged in #1196.

## What

Three series types the adapter refused by name now read.

| ECharts | read as | highlighted |
| --- | --- | --- |
| `pie` | `pie` | yes — one selector naming every slice |
| `funnel` | `funnel` | yes — one selector per stage |
| `gauge` | `gauge` | **no**, deliberately — see below |

They share a shape the cartesian series do not: no axes, one series to a
chart, and a datum that is a name and a number rather than a position and a
magnitude. Measured on echarts 6.1.0, all three report `data.dimensions` as
`['value']` with the label on `getName(i)`, so the whole reading is that
pair — which is why they are one module rather than three.

## Each layer gets the selector shape its trace can resolve

Checked by building the real trace and navigating it, not by resolving the
string. That is the lesson tier 1 paid for: two of its four layers carried
selectors that were individually correct and collectively the wrong shape,
and resolved nothing at all with no warning.

- **pie** — `PieTrace` reads `layer.selectors as string`, so the slices are
  named together in one selector. A list there would match nothing.
- **funnel** — `FunnelTrace` extends `BarTrace` and takes its array branch,
  so each stage is named separately.
- **gauge** — none.

## Why a gauge is read without an outline

It draws **two** filled marks for its one datum: the track (`#e8ebf0`) and
the progress arc (the series colour). The count check every other reading in
this adapter relies on has nothing to check — there is no arrangement in
which one datum and two marks agree — and naming either mark would be a
guess about which one the reader should be shown. So the gauge reads and
sonifies, and does not highlight. `docs/echarts.md` says so.

## Measured, not assumed

- `min` and `max` come off the series rather than being defaulted here.
  `getModel()` resolves ECharts' own `0` and `100` when the author wrote
  neither — confirmed live — so the dial the reader is told about is the
  dial that was drawn, and a caller who wrote `min: 10, max: 200` gets
  theirs.
- A pie draws one filled path per slice **and** one unfilled stroked guide
  line out to each label. The paint filter already declines the guides; the
  fixture draws both so a filter that stopped doing so would fail here.
- A datum with no number is left out rather than read as a slice of nothing.
  ECharts draws nothing for it, and counting it would make the mark check
  expect three where two were drawn — costing the two real slices their
  outline as well. A chart with nothing left to read emits no layer rather
  than an empty one a reader could land on and hear nothing from.

## Verification

- **Live, echarts 6.1.0 in Chromium**: pie (one string matching all three
  slices), funnel (three selectors, all resolving), gauge with a written
  dial and gauge with the default one. The tier-1 cases re-run unchanged,
  and `treemap` is still correctly refused.
- **Mutation sweep: 28/28** (was 22/22 before the six new mutants).
- Full gate: eslint, `tsc --noEmit`, 428 suites / 5874 tests plus the ESM
  project's 10 / 138, 15/15 bundles, docs.

## Not in this change

The rest of tier 2 — `boxplot`, `candlestick`, `heatmap`, `radar` — plus the
hierarchies and graphs of tier 3 and `themeRiver` / `pictorialBar` in tier 4.
Every one of them has a trace waiting and a model that carries what it needs
(the survey is in #1195); what each still wants is its own selector shape
established against the trace that reads it, which is the part this PR and
#1196 show is not safe to assume.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_