### PR TITLE
feat(echarts): read a heat grid and a price chart

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -52,11 +52,10 @@ Two things this example does on purpose:
 | `line` + `step` | `line` + `stepDirection` | `'start'` → `vh`, `'end'`/`'middle'` → `hv` |
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
 
-**Not yet supported:** `boxplot`, `candlestick`, `heatmap`, `radar`,
-`treemap`, `sunburst`, `sankey`, `graph`, `parallel`, `themeRiver`,
-`pictorialBar`. Each of these is *refused by name* rather than
-mapped onto whichever trace is closest — most have a MAIDR trace waiting for
-them, and each wants its own measured layout first. See
+**Not yet supported:** `boxplot`, `radar`, `treemap`, `sunburst`, `sankey`,
+`graph`, `parallel`, `themeRiver`, `pictorialBar`. Each of these is *refused
+by name* rather than mapped onto whichever trace is closest — most have a MAIDR
+trace waiting for them, and each wants its own measured layout first. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
 
 > **Orientation note:** ECharts has no "horizontal" option. A bar chart is
@@ -92,6 +91,39 @@ gauge is read without an outline.
 `min` and `max` come off the series rather than being defaulted here.
 `getModel()` resolves ECharts' own `0` and `100` when the author wrote
 neither, so the dial the reader is told about is the dial that was drawn.
+
+## Grid-value charts
+
+A heat grid and a price chart sit on the same cartesian axes the bar family
+uses, and differ from it in the same way: a datum is not one magnitude but a
+set of them, and ECharts has already worked them out. Measured on 6.1.0 the
+model reports them under named dimensions, so nothing is recovered from the
+drawing:
+
+| ECharts | `data.dimensions` | read as | highlighted |
+|---|---|---|---|
+| `heatmap` | `['x', 'y', 'value']` | `heat` | yes — a selector per cell |
+| `candlestick` | `['base', 'open', 'close', 'lowest', 'highest']` | `candlestick` | yes — a selector per candle |
+
+Both draw exactly one filled mark per datum — a cell, a candle body with its
+wick — which is the same shape the bar reading already counts and stamps.
+
+**A heatmap numbers a cell by axis index, not by name,** and a category y axis
+runs bottom-up: a 2×2 grid reports its cells as `[0,0]`, `[0,1]`, `[1,0]`,
+`[1,1]` with `y = 0` along the bottom. `HeatmapData` is top-first, so the rows
+are turned over on the way out — and the selector grid is built by the same
+walk that places the values, so a cell's outline and its reading cannot
+disagree.
+
+**A cell the chart drew nothing at stays empty rather than becoming a zero.** A
+grid is a rectangle and the data need not fill it, so a missing cell reads as
+missing ([#1191](https://github.com/xability/maidr/issues/1191)) and carries no
+selector.
+
+**A candlestick's `volatility` is the day's range** (`high - low`), matching
+every other candlestick producer in this tree. A period missing any of the four
+prices draws no candle, so it is left out of the reading entirely — counting it
+would expect a mark that was never drawn.
 
 ## Highlighting
 
@@ -137,6 +169,8 @@ silently.
 | `stacked`, `dodged` | a row of selectors per series | `SegmentedTrace.mapGridToSvgElements` |
 | `scatter` | **one** selector naming the whole series | `ScatterTrace`, which casts `layer.selectors` to `string` |
 | `line`, `area` | one selector per series | `LineTrace.mapToSvgElements` |
+| `heat` | a row of selectors per grid row, bottom-first | `Heatmap`, which indexes by its own row |
+| `candlestick` | `{ body: [...] }`, one per candle | `Candlestick.mapToSvgElements` |
 
 So the marks are stamped twice in one pass — once per mark and once per
 series — and each layer takes the address its own trace can use.

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -7,6 +7,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
+import type { AxisCategories } from './grid';
 import type {
   EChartsComponentModel,
   EChartsInstance,
@@ -16,6 +17,14 @@ import type {
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
+import {
+  candlestickLayer,
+  categoriesOf,
+  drawnCandleCount,
+  drawnGridCount,
+  GRID_VALUE,
+  heatmapLayer,
+} from './grid';
 import { markPerDatum, markPerSeries } from './selectors';
 import { SINGLE_VALUE, singleValueLayers } from './single';
 
@@ -49,7 +58,7 @@ const CARTESIAN: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
  * Most of them have a trace waiting and are the later tiers of #1195; each
  * wants its own measured layout before it claims to be readable.
  */
-const READ: ReadonlySet<string> = new Set([...CARTESIAN, ...SINGLE_VALUE]);
+const READ: ReadonlySet<string> = new Set([...CARTESIAN, ...SINGLE_VALUE, ...GRID_VALUE]);
 
 /**
  * Converts a rendered ECharts instance into a MAIDR figure.
@@ -96,7 +105,7 @@ export function createMaidrFromEChart(
     // that declares both families anyway is read as the single-valued half
     // and says so, rather than dropping the other half in silence.
     ? readSingle(single, readable, container)
-    : buildLayers(readable, axisNames(model), container);
+    : buildLayers(readable, axisNames(model), categories(model), container);
   const title = options.title ?? componentText(model, 'title', 'text');
   const subplot: MaidrSubplot = { layers };
 
@@ -193,6 +202,7 @@ function text(value: unknown): string {
 function buildLayers(
   series: EChartsSeriesModel[],
   axes: Axes,
+  grid: AxisCategories,
   container: HTMLElement,
 ): MaidrLayer[] {
   const bars = series.filter(seriesModel => seriesModel.subType === 'bar');
@@ -200,11 +210,13 @@ function buildLayers(
 
   // Every per-datum mark of the chart is painted alike and only its position
   // tells it apart, so they are located once for all of them, in the order
-  // the series were declared.
+  // the series were declared. A heat cell and a candle body join that pool:
+  // both are one filled mark per datum, which is the only thing the count
+  // check asks of a series.
   const marked = series.filter(seriesModel => seriesModel.subType !== 'line');
   const perDatum = markPerDatum(
     container,
-    marked.map(seriesModel => drawnCount(seriesModel, axes.horizontal)),
+    marked.map(seriesModel => drawnMarks(seriesModel, axes, grid)),
   );
   // A bar names each of its marks; a scatter names its series in one string.
   // Not a preference: `ScatterTrace` reads `layer.selectors as string` and
@@ -224,14 +236,87 @@ function buildLayers(
   const lines = others.filter(seriesModel => seriesModel.subType === 'line');
   const polylines = markPerSeries(container, lines.length);
   for (const seriesModel of others) {
-    layers.push(
-      seriesModel.subType === 'line'
-        ? lineLayer(seriesModel, axes, polylines?.[lines.indexOf(seriesModel)])
-        : scatterLayer(seriesModel, axes, wholeSeriesOf(seriesModel)),
+    const layer = otherLayer(
+      seriesModel,
+      axes,
+      grid,
+      polylines?.[lines.indexOf(seriesModel)],
+      eachMarkOf(seriesModel),
+      wholeSeriesOf(seriesModel),
     );
+    if (layer) {
+      layers.push(layer);
+    }
   }
 
   return layers;
+}
+
+/**
+ * The layer for one non-bar series.
+ *
+ * @param seriesModel  - The series to read
+ * @param axes         - The chart's orientation and axis names
+ * @param grid         - The category names of both axes
+ * @param polyline     - Its stroked line, when it drew one
+ * @param eachMark     - One selector per mark, when they were found
+ * @param wholeSeries  - One selector naming the whole series
+ * @returns The layer, or `undefined` when the series has no reading
+ */
+function otherLayer(
+  seriesModel: EChartsSeriesModel,
+  axes: Axes,
+  grid: AxisCategories,
+  polyline: string | undefined,
+  eachMark: string[] | undefined,
+  wholeSeries: string | undefined,
+): MaidrLayer | undefined {
+  switch (seriesModel.subType) {
+    case 'line':
+      return lineLayer(seriesModel, axes, polyline);
+    case 'heatmap':
+      return heatmapLayer(seriesModel, grid, axes, eachMark);
+    case 'candlestick':
+      return candlestickLayer(seriesModel, axes, eachMark);
+    default:
+      return scatterLayer(seriesModel, axes, wholeSeries);
+  }
+}
+
+/**
+ * The category names both axes were drawn with.
+ *
+ * @param model - The chart's model
+ * @returns The labels of each axis, empty where the axis carries numbers
+ */
+function categories(model: EChartsModel): AxisCategories {
+  return {
+    x: categoriesOf(firstComponent(model, 'xAxis')),
+    y: categoriesOf(firstComponent(model, 'yAxis')),
+  };
+}
+
+/**
+ * How many marks a series drew, asked the way its own layer asks it.
+ *
+ * @param seriesModel - The series to read
+ * @param axes        - The chart's orientation
+ * @param grid        - The category names of both axes
+ * @returns The number of marks the drawing should hold for this series
+ */
+function drawnMarks(
+  seriesModel: EChartsSeriesModel,
+  axes: Axes,
+  grid: AxisCategories,
+): number {
+  switch (seriesModel.subType) {
+    case 'heatmap':
+      return drawnGridCount(seriesModel, grid);
+    case 'candlestick':
+      return drawnCandleCount(seriesModel);
+    default:
+      return drawnCount(seriesModel, axes.horizontal);
+  }
 }
 
 /**

--- a/src/adapters/echarts/grid.ts
+++ b/src/adapters/echarts/grid.ts
@@ -86,36 +86,22 @@ export function heatmapLayer(
     return undefined;
   }
 
-  const data = seriesModel.getData();
   const rows = axes.y.length;
   const columns = axes.x.length;
   const points: (number | null)[][] = Array.from(
     { length: rows },
     () => Array.from({ length: columns }, () => null),
   );
-  // The same walk `drawnGridCount` makes, so a cell's selector and its value
-  // are placed by one rule rather than two that could disagree.
   const grid: (string | null)[][] = Array.from(
     { length: rows },
     () => Array.from({ length: columns }, () => null),
   );
 
-  let drawn = 0;
-  for (let index = 0; index < data.count(); index++) {
-    const column = whole(data.get('x', index));
-    const row = whole(data.get('y', index));
-    const value = data.get('value', index);
-    if (column === null || row === null || !measured(value)) {
-      continue;
-    }
-    if (row >= rows || column >= columns) {
-      continue;
-    }
-    // `points` is top-first and `row` counts up from the bottom.
-    points[rows - 1 - row][column] = value;
-    grid[row][column] = selectorFor?.[drawn] ?? null;
-    drawn += 1;
-  }
+  placedCells(seriesModel, axes).forEach((cell, drawn) => {
+    // `points` is top-first and `cell.row` counts up from the bottom.
+    points[rows - 1 - cell.row][cell.column] = cell.value;
+    grid[cell.row][cell.column] = selectorFor?.[drawn] ?? null;
+  });
 
   const named = seriesModel.get('name');
   const name = typeof named === 'string' ? named : '';
@@ -145,19 +131,53 @@ export function drawnGridCount(
   seriesModel: EChartsSeriesModel,
   axes: AxisCategories,
 ): number {
+  return placedCells(seriesModel, axes).length;
+}
+
+/** One cell that was drawn, at the axis indices ECharts placed it by. */
+interface PlacedCell {
+  row: number;
+  column: number;
+  value: number;
+}
+
+/**
+ * The cells a heatmap series drew, in data order.
+ *
+ * The count check and the layer ask the same question -- which cells reached
+ * the page -- so they ask it in one place. Two copies of this predicate would
+ * agree until one of them was edited, and the disagreement would show up as a
+ * selector list one longer than the marks it addresses: every cell after the
+ * first divergence outlined one place off, silently.
+ *
+ * A cell is drawn when it has whole, non-negative coordinates, a finite
+ * value, and a place inside the axes. Each of those was measured against a
+ * real chart: `[0.5, 0.5]` and `[5, 5]` on a 2x2 grid are both kept in the
+ * model, and a `null` or `'-'` value is kept as `null`.
+ *
+ * @param seriesModel - The series to read
+ * @param axes        - The category names of both axes
+ * @returns One entry per drawn cell, in the order the data declared them
+ */
+function placedCells(
+  seriesModel: EChartsSeriesModel,
+  axes: AxisCategories,
+): PlacedCell[] {
   const data = seriesModel.getData();
-  let drawn = 0;
+  const cells: PlacedCell[] = [];
   for (let index = 0; index < data.count(); index++) {
     const column = whole(data.get('x', index));
     const row = whole(data.get('y', index));
-    if (column === null || row === null || !measured(data.get('value', index))) {
+    const value = data.get('value', index);
+    if (column === null || row === null || !measured(value)) {
       continue;
     }
-    if (row < axes.y.length && column < axes.x.length) {
-      drawn += 1;
+    if (row >= axes.y.length || column >= axes.x.length) {
+      continue;
     }
+    cells.push({ row, column, value });
   }
-  return drawn;
+  return cells;
 }
 
 /**

--- a/src/adapters/echarts/grid.ts
+++ b/src/adapters/echarts/grid.ts
@@ -1,0 +1,306 @@
+/**
+ * The ECharts series that hand over a summary already computed.
+ *
+ * A heat grid and a price chart both sit on the cartesian axes the bar family
+ * uses, and both differ from it in the same way: a datum is not one magnitude
+ * but a set of them, and ECharts has already worked them out. Measured on
+ * echarts 6.1.0, the model reports them under named dimensions:
+ *
+ *     heatmap      ['x', 'y', 'value']
+ *     candlestick  ['base', 'open', 'close', 'lowest', 'highest']
+ *
+ * so neither needs anything recovered from the drawing. Both draw exactly one
+ * filled mark per datum -- a cell, a candle body with its wick -- which is the
+ * same shape `markPerDatum` already counts and stamps for a bar.
+ *
+ * Tier 2b of #1195. `boxplot` and `radar` are measured and deliberately left
+ * for later: see the note at the foot of this file.
+ */
+
+import type {
+  CandlestickPoint,
+  HeatmapData,
+  MaidrLayer,
+} from '@type/grammar';
+import type { EChartsComponentModel, EChartsSeriesModel } from './types';
+import { TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
+
+/** The series types this module reads. */
+export const GRID_VALUE: ReadonlySet<string> = new Set([
+  'heatmap',
+  'candlestick',
+]);
+
+/** The category names an axis was drawn with, in axis order. */
+export interface AxisCategories {
+  x: string[];
+  y: string[];
+}
+
+/** The titles the chart wrote beside each axis. */
+export interface AxisNames {
+  x: string;
+  y: string;
+}
+
+/**
+ * Reads a category axis' own labels.
+ *
+ * @param axis - The axis component, when the chart declared one
+ * @returns The labels in axis order, empty when the axis carries numbers
+ */
+export function categoriesOf(axis: EChartsComponentModel | undefined): string[] {
+  const data = axis?.get('data');
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  return data.map(entry => (typeof entry === 'string' ? entry : String(entry)));
+}
+
+/**
+ * Builds the layer for one heatmap series.
+ *
+ * ECharts numbers a cell by **axis index**, not by name, and a category y
+ * axis runs bottom-up -- measured, a 2x2 grid reports its four cells as
+ * `[0,0]`, `[0,1]`, `[1,0]`, `[1,1]` with `y = 0` at the bottom.
+ * `HeatmapData.y` and `points` are top-first, so the rows are turned over on
+ * the way out.
+ *
+ * A cell the chart drew nothing at stays `null` rather than becoming a zero:
+ * a grid is a rectangle and the data need not fill it (#1191).
+ *
+ * @param seriesModel - The series to read
+ * @param axes        - The category names of both axes
+ * @param names       - The axis titles
+ * @param selectorFor - One selector per drawn cell, in data order
+ * @returns The layer, or `undefined` when the grid has no named axes to sit on
+ */
+export function heatmapLayer(
+  seriesModel: EChartsSeriesModel,
+  axes: AxisCategories,
+  names: AxisNames,
+  selectorFor: string[] | undefined,
+): MaidrLayer | undefined {
+  if (axes.x.length === 0 || axes.y.length === 0) {
+    return undefined;
+  }
+
+  const data = seriesModel.getData();
+  const rows = axes.y.length;
+  const columns = axes.x.length;
+  const points: (number | null)[][] = Array.from(
+    { length: rows },
+    () => Array.from({ length: columns }, () => null),
+  );
+  // The same walk `drawnGridCount` makes, so a cell's selector and its value
+  // are placed by one rule rather than two that could disagree.
+  const grid: (string | null)[][] = Array.from(
+    { length: rows },
+    () => Array.from({ length: columns }, () => null),
+  );
+
+  let drawn = 0;
+  for (let index = 0; index < data.count(); index++) {
+    const column = whole(data.get('x', index));
+    const row = whole(data.get('y', index));
+    const value = data.get('value', index);
+    if (column === null || row === null || !measured(value)) {
+      continue;
+    }
+    if (row >= rows || column >= columns) {
+      continue;
+    }
+    // `points` is top-first and `row` counts up from the bottom.
+    points[rows - 1 - row][column] = value;
+    grid[row][column] = selectorFor?.[drawn] ?? null;
+    drawn += 1;
+  }
+
+  const named = seriesModel.get('name');
+  const name = typeof named === 'string' ? named : '';
+  const payload: HeatmapData = { x: axes.x, y: [...axes.y].reverse(), points };
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.HEATMAP,
+    ...(name ? { name } : {}),
+    ...(selectorFor ? { selectors: grid } : {}),
+    axes: {
+      x: { label: names.x || undefined },
+      y: { label: names.y || undefined },
+    },
+    data: payload,
+  };
+}
+
+/**
+ * How many cells a heatmap series actually drew.
+ *
+ * @param seriesModel - The series to read
+ * @param axes        - The category names of both axes
+ * @returns The number of cells that carry a value inside the grid
+ */
+export function drawnGridCount(
+  seriesModel: EChartsSeriesModel,
+  axes: AxisCategories,
+): number {
+  const data = seriesModel.getData();
+  let drawn = 0;
+  for (let index = 0; index < data.count(); index++) {
+    const column = whole(data.get('x', index));
+    const row = whole(data.get('y', index));
+    if (column === null || row === null || !measured(data.get('value', index))) {
+      continue;
+    }
+    if (row < axes.y.length && column < axes.x.length) {
+      drawn += 1;
+    }
+  }
+  return drawn;
+}
+
+/**
+ * Builds the layer for one candlestick series.
+ *
+ * ECharts hands over the four prices already named -- `open`, `close`,
+ * `lowest`, `highest` -- so nothing is recovered from the drawing. The
+ * period's label comes from the category axis through `getName`, the way
+ * every other categorical reading here takes it.
+ *
+ * `volatility` is the day's range, which is the convention every other
+ * candlestick producer in this tree uses.
+ *
+ * The selectors go in `CandlestickSelector.body` and not in a bare list.
+ * `Candlestick.mapToSvgElements` reads an array as the *legacy* shape -- one
+ * selector for the whole chart -- and takes `selectors[0]` for every candle,
+ * so a per-candle list would outline the first candle wherever the reader
+ * stood. Only `body` is filled: ECharts draws a candle as one path holding
+ * the body and its wick together, so there is no separate element to name a
+ * wick with, and the trace derives what it can from the body.
+ *
+ * @param seriesModel - The series to read
+ * @param names       - The axis titles
+ * @param selectors   - One selector per drawn candle, in data order
+ * @returns The layer
+ */
+export function candlestickLayer(
+  seriesModel: EChartsSeriesModel,
+  names: AxisNames,
+  selectors: string[] | undefined,
+): MaidrLayer {
+  const data = seriesModel.getData();
+  const points: CandlestickPoint[] = [];
+
+  for (let index = 0; index < data.count(); index++) {
+    const candle = pricesOf(seriesModel, index);
+    if (!candle) {
+      continue;
+    }
+    points.push({
+      value: data.getName(index) || `${index + 1}`,
+      open: candle.open,
+      high: candle.high,
+      low: candle.low,
+      close: candle.close,
+      volatility: candle.high - candle.low,
+    });
+  }
+
+  const named = seriesModel.get('name');
+  const name = typeof named === 'string' ? named : '';
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.CANDLESTICK,
+    ...(name ? { name } : {}),
+    ...(selectors ? { selectors: { body: selectors } } : {}),
+    axes: {
+      x: { label: names.x || undefined },
+      y: { label: names.y || undefined },
+    },
+    data: points,
+  };
+}
+
+/**
+ * How many candles a series actually drew.
+ *
+ * @param seriesModel - The series to read
+ * @returns The number of periods that carry all four prices
+ */
+export function drawnCandleCount(seriesModel: EChartsSeriesModel): number {
+  const data = seriesModel.getData();
+  let drawn = 0;
+  for (let index = 0; index < data.count(); index++) {
+    if (pricesOf(seriesModel, index)) {
+      drawn += 1;
+    }
+  }
+  return drawn;
+}
+
+/**
+ * One period's four prices, when it carries all of them.
+ *
+ * A candle needs every one to be drawn at all, so a period missing any is a
+ * period the chart put nothing on the page for.
+ *
+ * @param seriesModel - The series to read
+ * @param index       - Which period to read
+ * @returns The four prices, or `undefined` when one is missing
+ */
+function pricesOf(
+  seriesModel: EChartsSeriesModel,
+  index: number,
+): { open: number; close: number; low: number; high: number } | undefined {
+  const data = seriesModel.getData();
+  const open = data.get('open', index);
+  const close = data.get('close', index);
+  const low = data.get('lowest', index);
+  const high = data.get('highest', index);
+
+  if (!measured(open) || !measured(close) || !measured(low) || !measured(high)) {
+    return undefined;
+  }
+  return { open, close, low, high };
+}
+
+function measured(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * An axis index, which is what a heatmap datum carries in place of a name.
+ *
+ * @param value - The coordinate as the model reports it
+ * @returns The index, or `null` when it is not a whole number
+ */
+function whole(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+/*
+ * `boxplot` and `radar` are measured and left for a later tier, both because
+ * of how they are drawn rather than what they carry.
+ *
+ * A **box plot** hands over its five-number summary outright --
+ * `['base', 'min', 'Q1', 'median', 'Q3', 'max']` -- so the reading is easy and
+ * the highlighting is not: `BoxSelector` wants a selector per part (the
+ * whiskers, the box, the median, each outlier), and ECharts draws the whole
+ * box and both whiskers as **one path**. There is nothing to name the parts
+ * with. It is also painted `#fff`, which this adapter's paint filter counts as
+ * furniture, so it would fail the mark check even if the shape fitted.
+ *
+ * A **radar** reports one dimension per indicator -- `['indicator_0', …]` --
+ * and `RadarTrace` takes one selector per series, which would fit. What does
+ * not is the count: measured, a two-series radar draws six vertex symbols and
+ * also fills its alternating ring backgrounds, one of which (`rgb(234,237,245)`)
+ * is neither furniture nor white, so seven marks are found where six are
+ * expected and the check declines. Reading it without an outline is possible
+ * and is what a later tier should do deliberately, rather than arriving there
+ * by a count that happens to fail.
+ */

--- a/src/adapters/echarts/selectors.ts
+++ b/src/adapters/echarts/selectors.ts
@@ -104,7 +104,17 @@ function isFilledMark(element: Element): boolean {
     return false;
   }
 
-  return !FURNITURE_FILLS.has(normalise(fill));
+  // A `url(#…)` fill is a gradient, and ECharts paints exactly one thing with
+  // one: the `visualMap` legend beside a heat grid. Measured -- a 2x2 heatmap
+  // draws its four cells in flat `rgb(…)` and its legend in two
+  // `url(#zr6-g0)` bands -- so counting the legend would put six marks where
+  // the model says four and cost the grid its highlighting.
+  const paint = normalise(fill);
+  if (paint.startsWith('url(')) {
+    return false;
+  }
+
+  return !FURNITURE_FILLS.has(paint);
 }
 
 /**

--- a/test/adapters/echarts/gridValue.test.ts
+++ b/test/adapters/echarts/gridValue.test.ts
@@ -1,0 +1,413 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The ECharts series that hand over a summary already computed (#1195, tier 2b).
+ *
+ * A heat grid and a price chart sit on the same cartesian axes the bar family
+ * uses and differ from it the same way: a datum is a set of magnitudes rather
+ * than one, and ECharts has already worked them out. Measured on echarts
+ * 6.1.0 the model names them outright -- `['x', 'y', 'value']` and
+ * `['base', 'open', 'close', 'lowest', 'highest']` -- so nothing here is
+ * recovered from the drawing.
+ *
+ * The selectors are checked by building the trace that consumes them, not by
+ * resolving the strings. Tier 1 shipped two layers whose selectors were
+ * individually right and collectively the wrong shape, and they resolved
+ * nothing at all in silence (#1196); a heat grid is the shape most likely to
+ * repeat it, because its rows are turned over between the payload and the
+ * model.
+ */
+
+import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters/echarts/types';
+import type { CandlestickPoint, HeatmapData, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { afterAll, afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { Heatmap } from '@model/heatmap';
+import { TraceType } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface FakeSeries {
+  type: string;
+  /** `[x, y, value]` for a heat grid. */
+  cells?: [number, number, number | null][];
+  /** `[open, close, lowest, highest]` for a price chart, `null` for a gap. */
+  candles?: ([number, number, number, number] | null)[];
+  /** The period names a candlestick's category axis carries. */
+  periods?: string[];
+  name?: string;
+}
+
+function fakeList(series: FakeSeries): EChartsList {
+  if (series.cells) {
+    const cells = series.cells;
+    return {
+      dimensions: ['x', 'y', 'value'],
+      count: () => cells.length,
+      getName: index => String(cells[index][0]),
+      get: (dimension, index) => {
+        const cell = cells[index];
+        if (dimension === 'x') {
+          return cell[0];
+        }
+        return dimension === 'y' ? cell[1] : cell[2];
+      },
+    };
+  }
+
+  const candles = series.candles ?? [];
+  const order = ['base', 'open', 'close', 'lowest', 'highest'];
+  return {
+    dimensions: order,
+    count: () => candles.length,
+    getName: index => series.periods?.[index] ?? '',
+    get: (dimension, index) => {
+      const candle = candles[index];
+      if (dimension === 'base') {
+        return index;
+      }
+      if (!candle) {
+        return null;
+      }
+      return candle[order.indexOf(dimension) - 1];
+    },
+  };
+}
+
+function fakeSeriesModel(series: FakeSeries): EChartsSeriesModel {
+  const options: Record<string, unknown> = { name: series.name };
+  return {
+    subType: series.type,
+    name: series.name ?? 'series 0',
+    getData: () => fakeList(series),
+    get: key => options[key],
+  };
+}
+
+interface FakeChart {
+  series: FakeSeries[];
+  xData?: string[];
+  yData?: string[];
+  xName?: string;
+  yName?: string;
+}
+
+function fakeInstance(chart: FakeChart): EChartsInstance {
+  const components: Record<string, Record<string, unknown>[]> = {
+    xAxis: [{
+      name: chart.xName,
+      type: chart.xData ? 'category' : 'value',
+      data: chart.xData,
+    }],
+    yAxis: [{
+      name: chart.yName,
+      type: chart.yData ? 'category' : 'value',
+      data: chart.yData,
+    }],
+    title: [],
+  };
+
+  return {
+    getModel: () => ({
+      eachSeries: (callback) => {
+        chart.series.forEach((one, index) => callback(fakeSeriesModel(one), index));
+      },
+      eachComponent: (query, callback) => {
+        (components[query.mainType] ?? []).forEach((options, index) =>
+          callback({ get: key => options[key] }, index));
+      },
+    }),
+  };
+}
+
+/**
+ * The document ECharts drew: one filled mark per datum, plus the gradient
+ * bands a `visualMap` legend paints beside a heat grid.
+ *
+ * @param marks    - How many data marks the chart drew
+ * @param gradient - Whether to draw the legend's two `url(#…)` bands
+ * @returns The container the chart was rendered into
+ */
+function drawnChart(marks: number, gradient = false): HTMLElement {
+  document.body.innerHTML = '<div id="chart"></div>';
+  // jsdom implements no layout, so `getBBox` is missing and `Candlestick`
+  // reaches it while deriving an open and a close from a body it was given no
+  // separate element for. A unit box is enough: nothing here asserts on
+  // geometry, only on which element came back.
+  (SVGElement.prototype as unknown as { getBBox: () => DOMRect }).getBBox
+    = () => ({ x: 0, y: 0, width: 1, height: 1 } as DOMRect);
+  const container = document.getElementById('chart') as HTMLElement;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+
+  const add = (id: string, attributes: Record<string, string>): void => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('id', id);
+    Object.entries(attributes).forEach(([key, value]) => path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  for (let index = 0; index < marks; index++) {
+    add(`mark-${index}`, { fill: 'rgb(80,112,221)' });
+  }
+  if (gradient) {
+    // The `visualMap` legend, measured beside a real heat grid: two bands
+    // filled with a gradient reference, which is neither `none` nor a
+    // furniture colour and would otherwise be counted as a cell.
+    add('legend-0', { fill: 'url(#zr6-g0)' });
+    add('legend-1', { fill: 'url(#zr6-g1)' });
+  }
+
+  container.appendChild(svg);
+  return container;
+}
+
+function layersOf(chart: FakeChart, container: HTMLElement): MaidrLayer[] {
+  return createMaidrFromEChart(fakeInstance(chart), container).subplots[0][0].layers;
+}
+
+/** As much of a trace as navigating one costs. */
+interface Cursor {
+  moveToIndex: (row: number, col: number) => void;
+  state: TraceState;
+}
+
+/**
+ * The ids of the marks a trace resolves at one position.
+ *
+ * @param cursor - The trace to navigate
+ * @param row    - Which row to move to
+ * @param col    - Which column to move to
+ * @returns The resolved elements' ids, empty when nothing resolved
+ */
+function highlighted(cursor: Cursor, row: number, col: number): string[] {
+  cursor.moveToIndex(row, col);
+  const state = cursor.state as Extract<TraceState, { empty: false }>;
+  const highlight = state.highlight as { empty?: boolean; elements?: unknown };
+  if (highlight.empty || !highlight.elements) {
+    return [];
+  }
+  const elements = Array.isArray(highlight.elements)
+    ? highlight.elements
+    : [highlight.elements];
+  return (elements as { id?: string }[]).map(element => element.id ?? '(unnamed)');
+}
+
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterAll(() => {
+  warnSpy.mockRestore();
+});
+
+describe('an eCharts heat grid', () => {
+  const GRID: FakeChart = {
+    xData: ['c0', 'c1', 'c2'],
+    yData: ['r0', 'r1'],
+    xName: 'Col',
+    yName: 'Row',
+    series: [{
+      type: 'heatmap',
+      // value = 10 * row + column, so a cell names its own place.
+      cells: [[0, 0, 0], [1, 0, 1], [2, 0, 2], [0, 1, 10], [1, 1, 11], [2, 1, 12]],
+    }],
+  };
+
+  it('turns the rows over, because a category y axis runs bottom-up', () => {
+    // ECharts numbers a cell by axis index and `y = 0` is the bottom row --
+    // measured. `HeatmapData.y` and `points` are top-first, so `r1` leads and
+    // the row of tens is the first one a reader meets.
+    const [layer] = layersOf(GRID, drawnChart(6, true));
+
+    expect(layer.type).toBe(TraceType.HEATMAP);
+    expect(layer.data as HeatmapData).toEqual({
+      x: ['c0', 'c1', 'c2'],
+      y: ['r1', 'r0'],
+      points: [[10, 11, 12], [0, 1, 2]],
+    });
+  });
+
+  it('names both axes after the titles the chart carries', () => {
+    const [layer] = layersOf(GRID, drawnChart(6, true));
+
+    expect(layer.axes?.x?.label).toBe('Col');
+    expect(layer.axes?.y?.label).toBe('Row');
+  });
+
+  it('outlines the cell the reader is on, rows and all', () => {
+    // The one thing the payload cannot show: `Heatmap` reverses the rows
+    // again on construction, so a selector grid is indexed by the model's own
+    // bottom-first row -- the reverse of `points`. Getting it backwards would
+    // outline the top row while announcing the bottom one.
+    const [layer] = layersOf(GRID, drawnChart(6, true));
+    const trace = new Heatmap(layer);
+
+    // Row 0 of the model is the bottom of the grid, which is `r0` --
+    // the cells drawn first, `mark-0` through `mark-2`.
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+    expect(highlighted(trace, 1, 0)).toEqual(['mark-3']);
+    expect(highlighted(trace, 1, 2)).toEqual(['mark-5']);
+  });
+
+  const GAPPY: FakeChart = {
+    xData: ['c0', 'c1'],
+    yData: ['r0', 'r1'],
+    // Measured: ECharts keeps an empty cell in its data and reports the
+    // value as `null`, whether the author wrote `null` or the `'-'` its
+    // options accept. So the count is four and the drawing holds two.
+    series: [{
+      type: 'heatmap',
+      cells: [[0, 0, 1], [0, 1, null], [1, 0, null], [1, 1, 4]],
+    }],
+  };
+
+  it('leaves a cell the chart drew nothing at empty, not zero', () => {
+    // A grid is a rectangle and the data need not fill it. Announcing `0`
+    // there would be a value the chart never drew (#1191).
+    const [layer] = layersOf(GAPPY, drawnChart(2, true));
+
+    expect((layer.data as HeatmapData).points).toEqual([[null, 4], [1, null]]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('counts the cells that were drawn, not the cells that were named', () => {
+    // The count check is what earns the highlighting, so it has to ask the
+    // same question the drawing answers. Counting all four would expect four
+    // marks where two were drawn, and the whole grid would lose its outline.
+    const [layer] = layersOf(GAPPY, drawnChart(2, true));
+    const trace = new Heatmap(layer);
+
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 1, 1)).toEqual(['mark-1']);
+    // The two cells nothing was drawn at name nothing either.
+    expect(highlighted(trace, 0, 1)).toEqual([]);
+    expect(highlighted(trace, 1, 0)).toEqual([]);
+  });
+
+  it('drops a cell placed outside the axes it was drawn against', () => {
+    // Measured: ECharts keeps a datum whose coordinates fall off the grid --
+    // `[5, 5, 9]` on a 2x2 -- and draws nothing for it. Writing it in would
+    // index a row that does not exist and take the whole chart down with a
+    // `TypeError`, so it is dropped from the reading and from the count.
+    const [layer] = layersOf(
+      {
+        xData: ['c0', 'c1'],
+        yData: ['r0', 'r1'],
+        series: [{ type: 'heatmap', cells: [[0, 0, 1], [5, 5, 9], [1, 1, 4]] }],
+      },
+      drawnChart(2, true),
+    );
+
+    expect((layer.data as HeatmapData).points).toEqual([[null, 4], [1, null]]);
+    expect(layer.selectors).toBeDefined();
+  });
+
+  it('reads a cell placed between two rows without outlining anything', () => {
+    // Measured: a datum at `[0.5, 0.5]` is drawn -- three marks for three
+    // data -- but it sits on no row and no column, so there is nowhere in a
+    // `HeatmapData` grid to put it. It is left out, and the count then
+    // disagrees with the drawing, which costs the chart its highlighting.
+    // That is the conservative failure: no outline rather than a wrong one.
+    const [layer] = layersOf(
+      {
+        xData: ['c0', 'c1'],
+        yData: ['r0', 'r1'],
+        series: [{ type: 'heatmap', cells: [[0, 0, 1], [0.5, 0.5, 7], [1, 1, 4]] }],
+      },
+      drawnChart(3, true),
+    );
+
+    expect((layer.data as HeatmapData).points).toEqual([[null, 4], [1, null]]);
+    expect(layer.selectors).toBeUndefined();
+  });
+
+  it('does not count the visualMap legend as a cell', () => {
+    // The legend's bands are filled with a `url(#…)` gradient, which is
+    // neither `none` nor a furniture colour. Counted, they would put eight
+    // marks where the model says six and cost the grid its highlighting.
+    const [layer] = layersOf(GRID, drawnChart(6, true));
+
+    expect(layer.selectors).toBeDefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('is declined when the grid has no named axes to sit on', () => {
+    // Without category names there is nothing to announce a row or a column
+    // as, and `HeatmapData` has no shape for a nameless one.
+    expect(layersOf(
+      { series: [{ type: 'heatmap', cells: [[0, 0, 1]] }] },
+      drawnChart(1),
+    )).toHaveLength(0);
+  });
+});
+
+describe('an eCharts price chart', () => {
+  const PRICES: FakeChart = {
+    xData: ['d1', 'd2', 'd3'],
+    yName: 'Price',
+    series: [{
+      type: 'candlestick',
+      name: 'ACME',
+      periods: ['d1', 'd2', 'd3'],
+      candles: [[10, 12, 9, 13], [12, 11, 10, 14], [11, 15, 11, 16]],
+    }],
+  };
+
+  it('reads the four prices ECharts already named', () => {
+    const [layer] = layersOf(PRICES, drawnChart(3));
+
+    expect(layer.type).toBe(TraceType.CANDLESTICK);
+    expect(layer.name).toBe('ACME');
+    expect(layer.data as CandlestickPoint[]).toEqual([
+      { value: 'd1', open: 10, close: 12, low: 9, high: 13, volatility: 4 },
+      { value: 'd2', open: 12, close: 11, low: 10, high: 14, volatility: 4 },
+      { value: 'd3', open: 11, close: 15, low: 11, high: 16, volatility: 5 },
+    ]);
+  });
+
+  it('outlines the candle the reader is on', () => {
+    const [layer] = layersOf(PRICES, drawnChart(3));
+    const trace = new Candlestick(layer);
+
+    // A candlestick walks its periods along the column and reads one of the
+    // four prices down the row, so the *column* picks the candle. Measured:
+    // moving three rows down at column 0 stays on the first candle, and
+    // moving to column 2 reaches the third.
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 2, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-2']);
+  });
+
+  it('skips a period the chart drew no candle for', () => {
+    // A candle needs all four prices to be drawn at all, so a period missing
+    // one is a period with nothing on the page -- and counting it would
+    // expect three marks where two were drawn.
+    const [layer] = layersOf(
+      {
+        xData: ['d1', 'd2', 'd3'],
+        series: [{
+          type: 'candlestick',
+          periods: ['d1', 'd2', 'd3'],
+          candles: [[10, 12, 9, 13], null, [11, 15, 11, 16]],
+        }],
+      },
+      drawnChart(2),
+    );
+
+    expect((layer.data as CandlestickPoint[]).map(point => point.value))
+      .toEqual(['d1', 'd3']);
+    expect((layer.selectors as { body: string[] }).body).toHaveLength(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Tier 2b of #1195. The two ECharts series that hand over a summary already computed.

A heat grid and a price chart sit on the same cartesian axes the bar family uses and differ from it the same way: a datum is a set of magnitudes rather than one, and ECharts has already worked them out. Measured on **echarts 6.1.0** the model names them outright:

| ECharts | `data.dimensions` | read as | highlighted |
|---|---|---|---|
| `heatmap` | `['x', 'y', 'value']` | `heat` | yes — a selector per cell |
| `candlestick` | `['base', 'open', 'close', 'lowest', 'highest']` | `candlestick` | yes — a selector per candle |

so nothing is recovered from the drawing. Both draw exactly one filled mark per datum — a cell, a candle body with its wick — which is the shape `markPerDatum` already counts and stamps for a bar, so each gets a per-mark outline through the same pass.

## Three things measurement decided

**A heatmap numbers a cell by axis index, and a category y axis runs bottom-up.** A 2×2 grid reports its cells as `[0,0]`, `[0,1]`, `[1,0]`, `[1,1]` with `y = 0` along the bottom. `HeatmapData` is top-first, so the rows are turned over on the way out — and the selector grid is built by *the same walk* that places the values, because `Heatmap` reverses again on construction and indexes selectors by its own bottom-first row. Getting that backwards outlines the top row while announcing the bottom one, which is why the test navigates a real `Heatmap` rather than resolving the strings.

**A `visualMap` legend paints its bands with a `url(#…)` gradient**, which is neither `none` nor a furniture colour. Measured beside a real heat grid: four cells in flat `rgb(…)` and two `url(#zr6-g0)` bands. Counted, the legend would put eight marks where the model says six and cost the grid its highlighting, so `isFilledMark` now declines a gradient fill.

**`Candlestick.mapToSvgElements` reads a bare array as the *legacy* shape** — one selector for the whole chart — and takes `selectors[0]` for every candle. A per-candle list would have outlined the first candle wherever the reader stood. The selectors go in `CandlestickSelector.body`; only `body` is filled, because ECharts draws a candle as one path holding the body and its wick together.

This is the tier-1 lesson (#1196) applied before it could bite: a selector that resolves the right element is only half of it, and each trace class accepts a different *shape*. Every selector assertion here is made by constructing the real trace and navigating it.

## Edge cases, all reachable and all measured

- **A cell with no value stays empty, not zero.** ECharts keeps an empty cell in its data and reports `null`, whether the author wrote `null` or `'-'` — so the count is four and the drawing holds two. The reading counts what was drawn (#1191).
- **A cell placed off the axes is dropped.** A datum at `[5, 5]` on a 2×2 grid is kept in the data and drawn nowhere. Writing it in would index a row that does not exist and take the whole chart down with a `TypeError`.
- **A cell placed between two rows reads without an outline.** A datum at `[0.5, 0.5]` *is* drawn, but it sits on no row and no column, so there is nowhere in a `HeatmapData` grid to put it. It is left out, the count then disagrees with the drawing, and the chart loses its highlighting — the conservative failure rather than a wrong outline.
- **A period missing any of its four prices draws no candle**, so it is left out of the reading and of the count.

## Deferred, with the reason recorded

`boxplot` and `radar` are measured and left for a later tier, both for how they are drawn rather than what they carry. A box plot hands over its five-number summary outright, but `BoxSelector` wants a selector per part and ECharts draws the box and both whiskers as **one path** painted `#fff`. A radar's count does not fit: a two-series radar draws six vertex symbols and also fills its alternating ring backgrounds, one of which (`rgb(234,237,245)`) is neither furniture nor white, so seven marks are found where six are expected. Both notes are in `grid.ts`'s footer.

## Verification

- `test/adapters/echarts/gridValue.test.ts` — 12 cases, jsdom, every selector checked by navigating the real trace
- Live-verified against real echarts 6.1.0 in Chromium via Playwright:
  ```
  heat:    shape=grid sel=6 res=6 nulls=0 match=6 axes=['Col','Row']
           data={"x":["c0","c1","c2"],"y":["r1","r0"],"points":[[10,11,12],[0,1,2]]}
  heatGap: shape=grid sel=4 res=2 nulls=2 match=2
  candle:  sel=3 res=3 match=3 name=ACME  axes=[None,'Price']
  ```
- **Mutation sweep: 46/46 caught**, including all sixteen written for this tier
- Full gate green: `eslint`, `tsc --noEmit`, `npm test` (all projects), `npm run build`, `npm run docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_