### PR TITLE
fix(echarts): publish the two series types the adapter gained

### DIFF
--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -52,13 +52,24 @@ const CARTESIAN: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
  * Everything the adapter reads.
  *
  * ECharts draws seventeen series types. Every one outside this set --
- * `boxplot`, `candlestick`, `heatmap`, `radar`, `treemap`, `sunburst`,
- * `sankey`, `graph`, `parallel`, `themeRiver`, `pictorialBar` -- is left
- * unread **by name** rather than mapped onto whichever trace is closest.
- * Most of them have a trace waiting and are the later tiers of #1195; each
- * wants its own measured layout before it claims to be readable.
+ * `boxplot`, `radar`, `treemap`, `sunburst`, `sankey`, `graph`, `parallel`,
+ * `themeRiver`, `pictorialBar` -- is left unread **by name** rather than
+ * mapped onto whichever trace is closest. Most of them have a trace waiting
+ * and are the later tiers of #1195; each wants its own measured layout
+ * before it claims to be readable.
+ *
+ * Exported because `EChartsSeriesType` is the public statement of this set
+ * and the two have to agree. They drifted once already: tier 2b added
+ * `heatmap` and `candlestick` here and left the union naming six types, so
+ * the published type refused a series the adapter reads.
+ * `test/adapters/echarts/cartesian.test.ts` now fails if they disagree in
+ * either direction.
  */
-const READ: ReadonlySet<string> = new Set([...CARTESIAN, ...SINGLE_VALUE, ...GRID_VALUE]);
+export const READ: ReadonlySet<string> = new Set([
+  ...CARTESIAN,
+  ...SINGLE_VALUE,
+  ...GRID_VALUE,
+]);
 
 /**
  * Converts a rendered ECharts instance into a MAIDR figure.

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -15,12 +15,14 @@
  * The series types this adapter reads.
  *
  * ECharts draws seventeen. Three are the cartesian ones (tier 1 of
- * xability/maidr#1195) and three carry one magnitude per named thing (tier
- * 2a). Every other series type is refused by name so that gaining a reading
- * later is a decision rather than an accident.
+ * xability/maidr#1195), three carry one magnitude per named thing (tier 2a),
+ * and two hand over a set of magnitudes already computed (tier 2b). Every
+ * other series type is refused by name so that gaining a reading later is a
+ * decision rather than an accident.
  *
- * Kept in step with `READ` in `converters.ts`, which is what actually decides
- * -- this type is the public statement of it.
+ * Kept in step with `READ` in `converters.ts`, which is what actually
+ * decides -- this type is the public statement of it, and
+ * `test/adapters/echarts/cartesian.test.ts` fails if the two stop agreeing.
  */
 export type EChartsSeriesType
   = | 'bar'
@@ -28,7 +30,9 @@ export type EChartsSeriesType
     | 'scatter'
     | 'pie'
     | 'funnel'
-    | 'gauge';
+    | 'gauge'
+    | 'heatmap'
+    | 'candlestick';
 
 /**
  * One column of a series' internal data list.

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -1,6 +1,6 @@
-import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters/echarts/types';
+import type { EChartsInstance, EChartsList, EChartsSeriesModel, EChartsSeriesType } from '@adapters/echarts/types';
 import type { BarPoint, LinePoint, ScatterPoint, SegmentedPoint } from '@type/grammar';
-import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { createMaidrFromEChart, READ } from '@adapters/echarts/converters';
 import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Orientation, TraceType } from '@type/grammar';
 import { JSDOM } from 'jsdom';
@@ -417,6 +417,56 @@ describe('a chart drawing more than one kind of mark', () => {
       expect(container.querySelector(selector)).not.toBeNull());
 
     expect(container.querySelector(line.selectors as string)).not.toBeNull();
+  });
+});
+
+describe('what the adapter says it reads', () => {
+  // `EChartsSeriesType` is exported from the package, so it is a promise to
+  // consumers about which series this adapter accepts -- and `READ` is what
+  // actually decides. They drifted once: tier 2b taught the adapter to read
+  // `heatmap` and `candlestick` and left the union naming six types, so the
+  // published type refused two series that work.
+  //
+  // Listing the union's members by hand is the only way to compare a type
+  // with a value, so the list is checked against the union in both
+  // directions at compile time, and against `READ` at run time. A type
+  // added to one and not the others now fails here rather than in a
+  // consumer's editor.
+  const DECLARED = [
+    'bar',
+    'line',
+    'scatter',
+    'pie',
+    'funnel',
+    'gauge',
+    'heatmap',
+    'candlestick',
+  ] as const;
+
+  type Declared = typeof DECLARED[number];
+  type Unlisted = Exclude<EChartsSeriesType, Declared>;
+  type Invented = Exclude<Declared, EChartsSeriesType>;
+
+  // The annotation is `true` only while the exclusion is `never`, so a type
+  // in one and not the other makes the annotation `false` and the assignment
+  // a compile error. `[T] extends [never]` rather than `T extends never`,
+  // because the bare form distributes over a union and answers `never` for
+  // every member rather than `false` once.
+  //
+  // Note what does *not* work here: annotating an empty array as
+  // `Unlisted[]`. An empty array satisfies any element type, so it compiles
+  // whatever the exclusion says -- a guard that cannot fail. This was
+  // written that way first and proved vacuous when tested.
+  const EVERY_TYPE_LISTED: [Unlisted] extends [never] ? true : false = true;
+  const NO_TYPE_INVENTED: [Invented] extends [never] ? true : false = true;
+
+  it('lists every member of the published union and no others', () => {
+    expect(EVERY_TYPE_LISTED).toBe(true);
+    expect(NO_TYPE_INVENTED).toBe(true);
+  });
+
+  it('reads exactly the series types it publishes', () => {
+    expect(new Set<string>(DECLARED)).toEqual(READ);
   });
 });
 


### PR DESCRIPTION
A defect I shipped in #1199, found while starting tier 3.

`EChartsSeriesType` is exported from the package (`src/adapters/echarts/index.ts`), so it is a promise to consumers about which series this adapter accepts. Tier 2b taught the adapter to read `heatmap` and `candlestick` and left the union naming six types — so a consumer writing

```ts
const type: EChartsSeriesType = 'heatmap';
```

got a type error for something that works. Its own doc comment claimed it was "kept in step with `READ` in `converters.ts`", which was exactly what had stopped being true. `READ`'s comment had drifted the other way, still listing `candlestick` and `heatmap` among the series left unread.

Both corrected. More to the point, **the agreement is now checked rather than asserted in prose**: `READ` is exported, the union's members are listed once in the test, and the list is compared with the union at compile time in both directions and with `READ` at run time.

## The guard was vacuous on the first attempt

Worth recording, because it is the same failure the fix is about. The compile-time half started as:

```ts
type Unlisted = Exclude<EChartsSeriesType, Declared>;
const unlisted: Unlisted[] = [];   // ← compiles no matter what
```

An empty array satisfies any element type, so this passed with `heatmap` removed from the union. I only found that by deliberately introducing the drift and watching nothing fail. It is a conditional-type annotation now:

```ts
const EVERY_TYPE_LISTED: [Unlisted] extends [never] ? true : false = true;
```

which is `true` only while the exclusion is `never`, so a mismatch makes the annotation `false` and the assignment a compile error. (`[T] extends [never]` rather than the bare form, which distributes over a union and answers `never` per member rather than `false` once.)

## Verified by causing each drift

| drift | result |
|---|---|
| `heatmap` dropped from the union | `error TS2322: Type 'true' is not assignable to type 'false'` |
| `treemap` added to the union | same, on the other assertion |
| `GRID_VALUE` dropped from `READ` | 13 tests fail |

Full gate green: `eslint`, `tsc --noEmit`, `npm test` (all projects), `npm run build`, `npm run docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_