### PR TITLE
feat(echarts): read the hierarchies and the graphs

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -52,10 +52,9 @@ Two things this example does on purpose:
 | `line` + `step` | `line` + `stepDirection` | `'start'` → `vh`, `'end'`/`'middle'` → `hv` |
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
 
-**Not yet supported:** `boxplot`, `radar`, `treemap`, `sunburst`, `sankey`,
-`graph`, `parallel`, `themeRiver`, `pictorialBar`. Each of these is *refused
-by name* rather than mapped onto whichever trace is closest — most have a MAIDR
-trace waiting for them, and each wants its own measured layout first. See
+**Not yet supported:** `boxplot`, `radar`, `parallel`, `themeRiver`,
+`pictorialBar`. Each of these is *refused by name* rather than mapped onto
+whichever trace is closest — each wants its own measured layout first. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
 
 > **Orientation note:** ECharts has no "horizontal" option. A bar chart is
@@ -125,6 +124,56 @@ every other candlestick producer in this tree. A period missing any of the four
 prices draws no candle, so it is left out of the reading entirely — counting it
 would expect a mark that was never drawn.
 
+## Hierarchies and graphs
+
+Five more series types own the whole chart rather than sitting on a grid, and
+each maps onto a MAIDR trace that already exists.
+
+| ECharts | read as | payload | highlighted |
+|---|---|---|---|
+| `treemap` | `treemap` | `TreemapPoint[]` | **no** — see below |
+| `sunburst` | `sunburst` | `TreemapPoint[]` | yes — one selector per node |
+| `tree` | `tree` | `TreemapPoint[]` | **no** — see below |
+| `sankey` | `sankey` | `FlowPoint[]` | no |
+| `graph` | `network` | `NetworkPoint[]` | no |
+
+**The synthetic root is dropped.** Measured: `data.tree.root` is a node
+ECharts adds above whatever the author wrote — its name is the empty string
+and its value is the sum of everything below. The real forest is
+`root.children`, so the walk starts one level down and the `path` it records
+drops that empty name.
+
+**An interior node's value is only emitted when it is the author's.**
+`node.getValue()` answers the rolled-up sum for an interior node, and ECharts
+writes that sum back into the raw data, so reading the data back cannot tell a
+declared value from a derived one. `TreemapPoint.y` wants exactly that
+distinction, and it is recoverable by comparing: a node whose value equals its
+children's sum has none of its own, and one that differs is carrying mass no
+child accounts for. Measured on a chart with both — `A` (children 1 and 2,
+nothing declared) reports 3; `B` (declared 5, one child of 2) reports 5.
+
+**The nodes come from the links.** A `FlowPoint` and a `NetworkPoint` each
+name their two ends, so neither reading emits a node list — a separate one
+would be a second source of truth for something the links already say. Node
+names come from `data.getName(node.dataIndex)`; there is no `node.name`.
+
+### Why only a sunburst is outlined
+
+Established by giving every node an explicit `itemStyle.color` and reading the
+fills in document order — reading the default palette had suggested otherwise:
+
+- **`sunburst`** paints one mark per node, in exactly the order the tree walk
+  produces them. That is why the reading walks the tree rather than the data:
+  a sunburst reorders its children, so the two orders differ.
+- **`treemap`** paints only its **leaves**. Interior nodes are the white
+  borders between them, so a count against the node total can never match, and
+  the leaf order is not the walk order either.
+- **`tree`** draws its node symbols `#fff` whatever `itemStyle` says, and this
+  adapter counts white as furniture — so there is nothing to name.
+- **`sankey` and `graph`** both navigate *links* while the marks are *nodes*.
+  There is no per-link element to name, so the cursor and the marks would be
+  addressing different things.
+
 ## Highlighting
 
 ECharts gives a reading almost nothing to address by. Measured on 6.1.0: the
@@ -171,6 +220,7 @@ silently.
 | `line`, `area` | one selector per series | `LineTrace.mapToSvgElements` |
 | `heat` | a row of selectors per grid row, bottom-first | `Heatmap`, which indexes by its own row |
 | `candlestick` | `{ body: [...] }`, one per candle | `Candlestick.mapToSvgElements` |
+| `sunburst` | one selector per node, in tree-walk order | `TreemapTrace` |
 
 So the marks are stamped twice in one pass — once per mark and once per
 series — and each layer takes the address its own trace can use.

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -25,6 +25,13 @@ import {
   GRID_VALUE,
   heatmapLayer,
 } from './grid';
+import {
+  drawnNodeCount,
+  HIERARCHY,
+  hierarchyLayer,
+  OUTLINED_HIERARCHY,
+} from './hierarchy';
+import { NETWORK, networkLayer } from './network';
 import { markPerDatum, markPerSeries } from './selectors';
 import { SINGLE_VALUE, singleValueLayers } from './single';
 
@@ -52,11 +59,9 @@ const CARTESIAN: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
  * Everything the adapter reads.
  *
  * ECharts draws seventeen series types. Every one outside this set --
- * `boxplot`, `radar`, `treemap`, `sunburst`, `sankey`, `graph`, `parallel`,
- * `themeRiver`, `pictorialBar` -- is left unread **by name** rather than
- * mapped onto whichever trace is closest. Most of them have a trace waiting
- * and are the later tiers of #1195; each wants its own measured layout
- * before it claims to be readable.
+ * `boxplot`, `radar`, `parallel`, `themeRiver`, `pictorialBar` -- is left
+ * unread **by name** rather than mapped onto whichever trace is closest.
+ * Each wants its own measured layout before it claims to be readable.
  *
  * Exported because `EChartsSeriesType` is the public statement of this set
  * and the two have to agree. They drifted once already: tier 2b added
@@ -69,6 +74,21 @@ export const READ: ReadonlySet<string> = new Set([
   ...CARTESIAN,
   ...SINGLE_VALUE,
   ...GRID_VALUE,
+  ...HIERARCHY,
+  ...NETWORK,
+]);
+
+/**
+ * The series types that take over the whole chart rather than sit on a grid.
+ *
+ * A pie, a funnel and a gauge carry one magnitude per named thing; a
+ * treemap, sunburst or tree carries a hierarchy; a sankey or graph carries
+ * a graph. What they share is that the chart is theirs alone.
+ */
+const OWNS_CHART: ReadonlySet<string> = new Set([
+  ...SINGLE_VALUE,
+  ...HIERARCHY,
+  ...NETWORK,
 ]);
 
 /**
@@ -108,14 +128,14 @@ export function createMaidrFromEChart(
     );
   }
 
-  const single = readable.filter(seriesModel => SINGLE_VALUE.has(seriesModel.subType));
-  const layers = single.length > 0
-    // A pie, a funnel and a gauge each own the whole chart -- none of them
-    // sits on a grid -- so a figure holding one holds nothing else this
-    // adapter would stamp, and the two stamping passes never meet. A chart
-    // that declares both families anyway is read as the single-valued half
-    // and says so, rather than dropping the other half in silence.
-    ? readSingle(single, readable, container)
+  const owning = readable.filter(seriesModel => OWNS_CHART.has(seriesModel.subType));
+  const layers = owning.length > 0
+    // A pie, a funnel, a gauge, a hierarchy and a graph each own the whole
+    // chart -- none of them sits on a grid -- so a figure holding one holds
+    // nothing else this adapter would stamp, and the two stamping passes
+    // never meet. A chart that declares both families anyway is read as the
+    // owning half and says so, rather than dropping the other in silence.
+    ? readOwning(owning, readable, container)
     : buildLayers(readable, axisNames(model), categories(model), container);
   const title = options.title ?? componentText(model, 'title', 'text');
   const subplot: MaidrSubplot = { layers };
@@ -128,30 +148,61 @@ export function createMaidrFromEChart(
 }
 
 /**
- * The layers of a chart whose series carry one magnitude per named thing.
+ * The layers of a chart whose series own it outright.
  *
- * @param single   - The single-valued series
- * @param readable - Every series the adapter reads, including those
+ * @param owning    - The series that own the chart
+ * @param readable  - Every series the adapter reads, including those
  * @param container - The element the chart was rendered into
  * @returns One or more layers per series
  */
-function readSingle(
-  single: EChartsSeriesModel[],
+function readOwning(
+  owning: EChartsSeriesModel[],
   readable: EChartsSeriesModel[],
   container: HTMLElement,
 ): MaidrLayer[] {
-  if (single.length !== readable.length) {
+  if (owning.length !== readable.length) {
     const dropped = readable
-      .filter(seriesModel => !SINGLE_VALUE.has(seriesModel.subType))
+      .filter(seriesModel => !OWNS_CHART.has(seriesModel.subType))
       .map(seriesModel => seriesModel.subType)
       .join(', ');
     console.warn(
-      `[MAIDR] ECharts chart mixes single-value and cartesian series. `
-      + `Reading the single-value ones; ignoring: ${dropped}.`,
+      `[MAIDR] ECharts chart mixes whole-chart and cartesian series. `
+      + `Reading the whole-chart ones; ignoring: ${dropped}.`,
     );
   }
 
-  return single.flatMap(seriesModel => singleValueLayers(seriesModel, container));
+  return owning.flatMap((seriesModel) => {
+    if (SINGLE_VALUE.has(seriesModel.subType)) {
+      return singleValueLayers(seriesModel, container);
+    }
+    if (NETWORK.has(seriesModel.subType)) {
+      const layer = networkLayer(seriesModel);
+      return layer ? [layer] : [];
+    }
+    const layer = hierarchyLayer(seriesModel, hierarchyMarks(seriesModel, container));
+    return layer ? [layer] : [];
+  });
+}
+
+/**
+ * One selector per node of a hierarchy, when its marks can be paired.
+ *
+ * Only a sunburst's can -- see `hierarchy.ts` -- so the others are not even
+ * counted, which keeps a treemap's leaf-only painting from being mistaken
+ * for a count that merely came out wrong.
+ *
+ * @param seriesModel - The series to read
+ * @param container   - The element the chart was rendered into
+ * @returns One selector per node in walk order, or `undefined`
+ */
+function hierarchyMarks(
+  seriesModel: EChartsSeriesModel,
+  container: HTMLElement,
+): string[] | undefined {
+  if (!OUTLINED_HIERARCHY.has(seriesModel.subType)) {
+    return undefined;
+  }
+  return markPerDatum(container, [drawnNodeCount(seriesModel)])?.points[0];
 }
 
 /**

--- a/src/adapters/echarts/hierarchy.ts
+++ b/src/adapters/echarts/hierarchy.ts
@@ -1,0 +1,192 @@
+/**
+ * The ECharts series that carry a hierarchy (#1195, tier 3).
+ *
+ * `treemap`, `sunburst` and `tree` are one shape drawn three ways: a rooted
+ * forest of named nodes, some of which carry a magnitude. MAIDR has a trace
+ * for each, and all three take the same `TreemapPoint[]` -- a flat list where
+ * every node names its ancestors -- so the reading is one walk and three
+ * labels.
+ *
+ * Measured on echarts 6.1.0, `data.tree.root` is the walk's entry point and
+ * carries a **synthetic root** the author never wrote: its name is `''` and
+ * its value is the sum of everything below it. The real forest is
+ * `root.children`, so the walk starts one level down and the path it records
+ * drops that empty name.
+ *
+ * ## What a node's value means
+ *
+ * `node.getValue()` answers the **rolled-up sum** for an interior node, and
+ * ECharts writes that sum back into the raw data item -- so "did the author
+ * declare this?" cannot be recovered by reading the data back.
+ *
+ * `TreemapPoint.y` wants it anyway: omitted for an interior node whose value
+ * is the sum of its children, kept where it differs, "a parent may carry mass
+ * no child accounts for". That is derivable without asking ECharts anything
+ * it will not say -- compare the node's value with its children's sum, which
+ * is what `carriesOwnValue` does. Measured against a chart with both cases:
+ * `A` (children 1 and 2, nothing declared) reports 3, and `B` (declared 5,
+ * one child of 2) reports 5.
+ *
+ * ## Which of the three can be outlined
+ *
+ * Only `sunburst`, and it took colour-tagging every node to establish it --
+ * reading the default palette had suggested the opposite. Giving each node an
+ * explicit `itemStyle.color` and reading the fills in document order:
+ *
+ *     sunburst   the marks are in exactly the walk's order
+ *     treemap    only the *leaves* are painted; interior nodes are the white
+ *                borders between them, and the leaf order is not the walk's
+ *     tree       the node symbols stay `#fff` whatever `itemStyle` says,
+ *                which the adapter's paint filter counts as furniture
+ *
+ * So a treemap can never satisfy a count against its node total, and a tree
+ * has nothing to count. Both are read without an outline rather than pointed
+ * at a mark that means something else.
+ */
+
+import type { MaidrLayer, TreemapPoint } from '@type/grammar';
+import type { EChartsSeriesModel, EChartsTreeNode } from './types';
+import { TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
+
+/** The series types this module reads. */
+export const HIERARCHY: ReadonlySet<string> = new Set([
+  'treemap',
+  'sunburst',
+  'tree',
+]);
+
+/**
+ * The series types whose marks can be paired with the walk.
+ *
+ * Only `sunburst`. See the note at the head of this file for what the other
+ * two do instead, and how it was measured.
+ */
+export const OUTLINED_HIERARCHY: ReadonlySet<string> = new Set(['sunburst']);
+
+const TRACE: Record<string, TraceType> = {
+  treemap: TraceType.TREEMAP,
+  sunburst: TraceType.SUNBURST,
+  tree: TraceType.TREE,
+};
+
+/**
+ * Builds the layer for one hierarchy series.
+ *
+ * @param seriesModel - The series to read
+ * @param selectors   - One selector per node in walk order, when the series
+ *                      is one whose marks can be paired with it
+ * @returns The layer, or `undefined` when the series carries no nodes
+ */
+export function hierarchyLayer(
+  seriesModel: EChartsSeriesModel,
+  selectors: string[] | undefined,
+): MaidrLayer | undefined {
+  const points = walk(seriesModel);
+  if (points.length === 0) {
+    return undefined;
+  }
+
+  const type = TRACE[seriesModel.subType];
+  if (type === undefined) {
+    return undefined;
+  }
+
+  const named = seriesModel.get('name');
+  const name = typeof named === 'string' ? named : '';
+
+  return {
+    id: nextId('layer'),
+    type,
+    ...(name ? { name } : {}),
+    ...(selectors ? { selectors } : {}),
+    axes: {},
+    data: points,
+  };
+}
+
+/**
+ * How many nodes a hierarchy series drew.
+ *
+ * The walk's length, which is what a sunburst paints one mark for. A treemap
+ * and a tree never reach the count check -- see the head of this file -- so
+ * this is only ever asked of a sunburst.
+ *
+ * @param seriesModel - The series to read
+ * @returns The number of real nodes, the synthetic root excluded
+ */
+export function drawnNodeCount(seriesModel: EChartsSeriesModel): number {
+  return walk(seriesModel).length;
+}
+
+/**
+ * Every real node of the series, depth first, in the tree's own order.
+ *
+ * The order is the tree's rather than the data's on purpose: measured, a
+ * sunburst reorders its children (`B` before `A`, `A2` before `A1`) and paints
+ * them in the reordered order, so a reading that followed the data would
+ * announce the nodes in one order and outline them in another.
+ *
+ * @param seriesModel - The series to read
+ * @returns One point per node, the synthetic root excluded
+ */
+function walk(seriesModel: EChartsSeriesModel): TreemapPoint[] {
+  const root = seriesModel.getData().tree?.root;
+  if (!root) {
+    return [];
+  }
+
+  const points: TreemapPoint[] = [];
+  const visit = (node: EChartsTreeNode, path: string[]): void => {
+    // `path` is empty only for the synthetic root, which the author never
+    // wrote and which no reader should meet.
+    if (path.length > 0 || node !== root) {
+      const own = carriesOwnValue(node);
+      points.push({
+        x: node.name,
+        ...(own === undefined ? {} : { y: own }),
+        ...(path.length > 0 ? { path: [...path] } : {}),
+      });
+    }
+    const children = node.children ?? [];
+    const below = node === root ? path : [...path, node.name];
+    children.forEach(child => visit(child, below));
+  };
+  visit(root, []);
+
+  return points;
+}
+
+/**
+ * The magnitude a node carries in its own right, if any.
+ *
+ * A leaf's value is its own. An interior node's is the sum of its children
+ * unless the author declared something else, and only the difference tells
+ * the two apart -- see the note at the head of this file.
+ *
+ * @param node - The node to weigh
+ * @returns The value to emit, or `undefined` when there is none to emit
+ */
+function carriesOwnValue(node: EChartsTreeNode): number | undefined {
+  const value = node.getValue();
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const children = node.children ?? [];
+  if (children.length === 0) {
+    return value;
+  }
+
+  let sum = 0;
+  for (const child of children) {
+    const each = child.getValue();
+    if (typeof each !== 'number' || !Number.isFinite(each)) {
+      // A child with no magnitude makes the sum meaningless, so the node's
+      // value is reported as its own rather than compared against it.
+      return value;
+    }
+    sum += each;
+  }
+  return sum === value ? undefined : value;
+}

--- a/src/adapters/echarts/network.ts
+++ b/src/adapters/echarts/network.ts
@@ -1,0 +1,110 @@
+/**
+ * The ECharts series that carry a graph (#1195, tier 3).
+ *
+ * `sankey` and `graph` are both nodes joined by links, and MAIDR's grammar
+ * derives the nodes from the links for both: a `FlowPoint` names its two ends
+ * and how much flows, a `NetworkPoint` names its two ends and nothing else.
+ * So neither reading emits a node list -- the edges are the whole payload,
+ * and their order is the order the author declared them.
+ *
+ * Measured on echarts 6.1.0, `data.graph` carries `nodes` and `edges`, and
+ * naming a node is the part worth writing down:
+ *
+ *     node.name                       undefined -- there is no such property
+ *     node.id                         'a'
+ *     data.getName(node.dataIndex)    'a'
+ *     getEdgeData().getName(i)        'a > b'  -- a label, not a pair
+ *
+ * The first of those cost a probe: reading `node.name` gave `undefined`,
+ * `JSON.stringify` dropped the field, and the result looked like ECharts
+ * exposing no names at all. It exposes them under `dataIndex`.
+ *
+ * ## Highlighting
+ *
+ * A `graph` can be outlined and a `sankey`'s nodes could be, but neither is
+ * outlined here, and the reason is the shape rather than the drawing: both
+ * traces navigate **links**, and the marks are **nodes**. There is no
+ * per-link element to name -- a sankey's ribbons are paths in their own
+ * right, but the trace's cursor is on a flow, not on a ribbon, and pairing
+ * the two was not measured. Reading without an outline is what the gauge
+ * already does (tier 2a) when the marks and the cursor disagree.
+ *
+ * Measured all the same, so the next tier does not start from nothing: with
+ * every node given an explicit `itemStyle.color`, a graph's three marks come
+ * out in exactly `data.graph.nodes` order, and a sankey's node rectangles do
+ * too, with the link ribbons (`#86878c` by default) and one `#000` alongside.
+ */
+
+import type { FlowPoint, MaidrLayer, NetworkPoint } from '@type/grammar';
+import type { EChartsGraphNode, EChartsSeriesModel } from './types';
+import { TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
+
+/** The series types this module reads. */
+export const NETWORK: ReadonlySet<string> = new Set(['sankey', 'graph']);
+
+/**
+ * Builds the layer for one graph series.
+ *
+ * A link whose ends cannot both be named is dropped: a flow needs both to be
+ * a flow at all, and half of one is not a reading.
+ *
+ * @param seriesModel - The series to read
+ * @returns The layer, or `undefined` when the series carries no links
+ */
+export function networkLayer(
+  seriesModel: EChartsSeriesModel,
+): MaidrLayer | undefined {
+  const data = seriesModel.getData();
+  const graph = data.graph;
+  if (!graph) {
+    return undefined;
+  }
+
+  const named = (node: EChartsGraphNode | undefined): string | undefined => {
+    if (!node || typeof node.dataIndex !== 'number') {
+      return undefined;
+    }
+    const name = data.getName(node.dataIndex);
+    return name === '' ? undefined : name;
+  };
+
+  const weighted = seriesModel.subType === 'sankey';
+  const flows: FlowPoint[] = [];
+  const links: NetworkPoint[] = [];
+
+  for (const edge of graph.edges) {
+    const source = named(edge.node1);
+    const target = named(edge.node2);
+    if (source === undefined || target === undefined) {
+      continue;
+    }
+    if (!weighted) {
+      links.push({ source, target });
+      continue;
+    }
+    const value = edge.getValue('value');
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      // A sankey's whole subject is how much flows, so a flow with no
+      // magnitude is a flow the reader cannot be told anything about.
+      continue;
+    }
+    flows.push({ source, target, value });
+  }
+
+  const points = weighted ? flows : links;
+  if (points.length === 0) {
+    return undefined;
+  }
+
+  const authored = seriesModel.get('name');
+  const name = typeof authored === 'string' ? authored : '';
+
+  return {
+    id: nextId('layer'),
+    type: weighted ? TraceType.SANKEY : TraceType.NETWORK,
+    ...(name ? { name } : {}),
+    axes: {},
+    data: points,
+  };
+}

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -16,9 +16,10 @@
  *
  * ECharts draws seventeen. Three are the cartesian ones (tier 1 of
  * xability/maidr#1195), three carry one magnitude per named thing (tier 2a),
- * and two hand over a set of magnitudes already computed (tier 2b). Every
- * other series type is refused by name so that gaining a reading later is a
- * decision rather than an accident.
+ * two hand over a set of magnitudes already computed (tier 2b), and five
+ * carry a hierarchy or a graph (tier 3). Every other series type is refused
+ * by name so that gaining a reading later is a decision rather than an
+ * accident.
  *
  * Kept in step with `READ` in `converters.ts`, which is what actually
  * decides -- this type is the public statement of it, and
@@ -32,7 +33,12 @@ export type EChartsSeriesType
     | 'funnel'
     | 'gauge'
     | 'heatmap'
-    | 'candlestick';
+    | 'candlestick'
+    | 'treemap'
+    | 'sunburst'
+    | 'tree'
+    | 'sankey'
+    | 'graph';
 
 /**
  * One column of a series' internal data list.
@@ -41,6 +47,60 @@ export type EChartsSeriesType
  * `symbolSize` reads a third column carries `['x', 'y', 'value']`.
  */
 export type EChartsDimension = string;
+
+/**
+ * One node of a hierarchy series' tree.
+ *
+ * Measured: `getValue()` answers the rolled-up sum for an interior node, so
+ * a declared value and a derived one are indistinguishable from the value
+ * alone -- see `hierarchy.ts` for what is done about that.
+ */
+export interface EChartsTreeNode {
+  /** The node's name. The synthetic root's is the empty string. */
+  name: string;
+  /** Its children, absent on a leaf. */
+  children?: EChartsTreeNode[];
+  /** Its magnitude, rolled up from the children where it has them. */
+  getValue: () => number | null | undefined;
+}
+
+/**
+ * A hierarchy series' tree.
+ *
+ * `root` is **synthetic** -- ECharts adds it above whatever the author wrote,
+ * names it `''`, and gives it the sum of everything below. The real forest is
+ * `root.children`.
+ */
+export interface EChartsTree {
+  root: EChartsTreeNode;
+}
+
+/**
+ * One node of a graph series.
+ *
+ * There is no `name`: reading one gives `undefined`. A node is named through
+ * `EChartsList.getName(node.dataIndex)`, or equivalently by its `id`.
+ */
+export interface EChartsGraphNode {
+  /** Its index into the series' data list, which is how it is named. */
+  dataIndex: number;
+}
+
+/** One link of a graph series. */
+export interface EChartsGraphEdge {
+  /** The node the link leaves. */
+  node1: EChartsGraphNode;
+  /** The node it arrives at. */
+  node2: EChartsGraphNode;
+  /** One of the link's own dimensions -- `'value'` is the flow. */
+  getValue: (dimension: string) => number | null | undefined;
+}
+
+/** A graph series' nodes and links. */
+export interface EChartsGraph {
+  nodes: EChartsGraphNode[];
+  edges: EChartsGraphEdge[];
+}
 
 /**
  * A series' data list.
@@ -68,6 +128,10 @@ export interface EChartsList {
    * name comes from {@link getName}.
    */
   get: (dimension: EChartsDimension, index: number) => number | null | undefined;
+  /** The hierarchy, on a `treemap`, `sunburst` or `tree` series. */
+  tree?: EChartsTree;
+  /** The graph, on a `sankey` or `graph` series. */
+  graph?: EChartsGraph;
 }
 
 /**

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -441,6 +441,11 @@ describe('what the adapter says it reads', () => {
     'gauge',
     'heatmap',
     'candlestick',
+    'treemap',
+    'sunburst',
+    'tree',
+    'sankey',
+    'graph',
   ] as const;
 
   type Declared = typeof DECLARED[number];
@@ -473,14 +478,15 @@ describe('what the adapter says it reads', () => {
 describe('what the adapter will not claim', () => {
   it('refuses a chart of series it has no reading for', () => {
     // By name, rather than mapped onto whichever trace is closest. ECharts
-    // draws seventeen series types and most have a trace waiting for them,
-    // but each wants its own measured layout first (#1195). `pie` used to
-    // stand here and now reads; `treemap` is one of the hierarchies still
-    // waiting for tier 3.
+    // draws seventeen series types and each wanted its own measured layout
+    // first (#1195). `pie` used to stand here, then `treemap`; both read now.
+    // `radar` is one of the five left, and its own reason is recorded in
+    // `grid.ts` -- its ring backgrounds are neither furniture nor white, so
+    // it finds seven marks where six were expected.
     expect(() => layersOf(
-      { series: [{ type: 'treemap', values: [1, 2, 3] }] },
+      { series: [{ type: 'radar', values: [1, 2, 3] }] },
       drawnChart(3, 0),
-    )).toThrow(/Unsupported ECharts series type\(s\): treemap/);
+    )).toThrow(/Unsupported ECharts series type\(s\): radar/);
   });
 
   it('drops the highlighting when the drawing holds a different number of marks', () => {

--- a/test/adapters/echarts/hierarchy.test.ts
+++ b/test/adapters/echarts/hierarchy.test.ts
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The ECharts series that carry a hierarchy or a graph (#1195, tier 3).
+ *
+ * Five series types, two payload shapes and one recurring trap: what ECharts
+ * paints is not always what it holds. A treemap paints only its leaves, a
+ * tree paints white symbols the adapter's paint filter calls furniture, and a
+ * sunburst paints one mark per node in the tree's own order -- which is *not*
+ * the data's order, because a sunburst reorders its children.
+ *
+ * Each of those was measured by giving every node an explicit
+ * `itemStyle.color` and reading the fills in document order. Reading the
+ * default palette instead had suggested the opposite for the sunburst, which
+ * is why the selector assertions here navigate a real `SunburstTrace` rather
+ * than checking that a string resolves.
+ */
+
+import type { EChartsInstance, EChartsList, EChartsSeriesModel } from '@adapters/echarts/types';
+import type { FlowPoint, MaidrLayer, NetworkPoint, TreemapPoint } from '@type/grammar';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** A node as an author writes one. */
+interface Node {
+  name: string;
+  value?: number;
+  children?: Node[];
+}
+
+interface FakeSeries {
+  type: string;
+  name?: string;
+  /** The forest, for a hierarchy series. */
+  nodes?: Node[];
+  /** The links, for a graph series. */
+  links?: { source: string; target: string; value?: number }[];
+  /** The node names, for a graph series, in declaration order. */
+  names?: string[];
+}
+
+/**
+ * The tree ECharts builds, synthetic root and all.
+ *
+ * `getValue()` rolls a node's children up when the author declared nothing,
+ * which is the behaviour the reading has to tell apart from a declared value.
+ */
+function fakeTree(nodes: Node[]): { root: TreeNode } {
+  const build = (node: Node): TreeNode => {
+    const children = (node.children ?? []).map(build);
+    return {
+      name: node.name,
+      ...(children.length > 0 ? { children } : {}),
+      getValue: () => {
+        if (node.value !== undefined) {
+          return node.value;
+        }
+        // Measured: a `tree` reports `null` for every node, root included --
+        // it has no magnitudes to roll up. So a subtree where nothing was
+        // declared answers `null` here too, rather than summing to zero and
+        // inventing a magnitude the chart never had.
+        const below = children.map(child => child.getValue());
+        const numbers = below.filter(each => typeof each === 'number');
+        return numbers.length === 0
+          ? null
+          : numbers.reduce((sum, each) => sum + each, 0);
+      },
+    };
+  };
+
+  const roots = nodes.map(build);
+  return {
+    root: {
+      name: '',
+      children: roots,
+      getValue: () => {
+        const below = roots.map(child => child.getValue());
+        const numbers = below.filter(each => typeof each === 'number');
+        return numbers.length === 0
+          ? null
+          : numbers.reduce((sum, each) => sum + each, 0);
+      },
+    },
+  };
+}
+
+interface TreeNode {
+  name: string;
+  children?: TreeNode[];
+  getValue: () => number | null | undefined;
+}
+
+function fakeList(series: FakeSeries): EChartsList {
+  const names = series.names ?? [];
+  const list: EChartsList = {
+    dimensions: ['value'],
+    count: () => names.length,
+    getName: index => names[index] ?? '',
+    get: () => null,
+  };
+
+  if (series.nodes) {
+    return { ...list, tree: fakeTree(series.nodes) };
+  }
+
+  const links = series.links ?? [];
+  const at = (name: string): number => names.indexOf(name);
+  return {
+    ...list,
+    graph: {
+      nodes: names.map((_, dataIndex) => ({ dataIndex })),
+      edges: links.map(link => ({
+        node1: { dataIndex: at(link.source) },
+        node2: { dataIndex: at(link.target) },
+        getValue: () => link.value ?? null,
+      })),
+    },
+  };
+}
+
+function fakeInstance(series: FakeSeries[]): EChartsInstance {
+  return {
+    getModel: () => ({
+      eachSeries: (callback) => {
+        series.forEach((one, index) => callback({
+          subType: one.type,
+          name: one.name ?? `series ${index}`,
+          getData: () => fakeList(one),
+          get: key => (key === 'name' ? one.name : undefined),
+        } as EChartsSeriesModel, index));
+      },
+      eachComponent: () => {},
+    }),
+  };
+}
+
+/** The document ECharts drew: one filled mark per node it painted. */
+function drawnChart(marks: number): HTMLElement {
+  document.body.innerHTML = '<div id="chart"></div>';
+  const container = document.getElementById('chart') as HTMLElement;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  for (let index = 0; index < marks; index++) {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('id', `mark-${index}`);
+    path.setAttribute('fill', 'rgb(80,112,221)');
+    svg.appendChild(path);
+  }
+  container.appendChild(svg);
+  return container;
+}
+
+function layersOf(series: FakeSeries[], container: HTMLElement): MaidrLayer[] {
+  return createMaidrFromEChart(fakeInstance(series), container).subplots[0][0].layers;
+}
+
+/**
+ * A forest with both value cases in it.
+ *
+ * `A` declares nothing and its children sum to 3; `B` declares 5 while its
+ * one child carries 2. Measured against a real chart, ECharts reports 3 and 5
+ * respectively -- the rolled-up sum and the declared value -- and writes both
+ * back into the raw data, so only the comparison with the children tells them
+ * apart.
+ */
+const FOREST: Node[] = [
+  { name: 'A', children: [{ name: 'A1', value: 1 }, { name: 'A2', value: 2 }] },
+  { name: 'B', value: 5, children: [{ name: 'B1', value: 2 }] },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('an eCharts hierarchy', () => {
+  it('drops the synthetic root ECharts adds above the forest', () => {
+    // Its name is the empty string and its value is the sum of everything
+    // below, neither of which the author wrote. A reader meeting it would be
+    // told about a node that is not in their data.
+    const [layer] = layersOf([{ type: 'treemap', nodes: FOREST }], drawnChart(3));
+
+    const points = layer.data as TreemapPoint[];
+    expect(points.map(point => point.x)).toEqual(['A', 'A1', 'A2', 'B', 'B1']);
+    expect(points.some(point => point.x === '')).toBe(false);
+  });
+
+  it('names each node by its ancestors, itself excluded', () => {
+    const [layer] = layersOf([{ type: 'treemap', nodes: FOREST }], drawnChart(3));
+
+    const points = layer.data as TreemapPoint[];
+    expect(points[0]).toEqual({ x: 'A' });
+    expect(points[1]).toEqual({ x: 'A1', y: 1, path: ['A'] });
+    expect(points[4]).toEqual({ x: 'B1', y: 2, path: ['B'] });
+  });
+
+  it('omits a rolled-up value and keeps a declared one', () => {
+    // The distinction `TreemapPoint.y` asks for. `A` carries the sum of its
+    // children, which is not a magnitude of its own; `B` carries 5 where its
+    // children account for 2, and that difference is the author's.
+    const [layer] = layersOf([{ type: 'treemap', nodes: FOREST }], drawnChart(3));
+
+    const points = layer.data as TreemapPoint[];
+    expect(points[0].y).toBeUndefined();
+    expect(points[3].y).toBe(5);
+  });
+
+  it('reads a hierarchy with no magnitudes at all', () => {
+    // A `tree` carries `value: null` on every node -- measured -- which is
+    // the shape #1153 made room for. Emitting `y: 0` would be a magnitude
+    // the chart never had.
+    const [layer] = layersOf(
+      [{ type: 'tree', nodes: [{ name: 'root', children: [{ name: 'c1' }] }] }],
+      drawnChart(2),
+    );
+
+    expect(layer.type).toBe(TraceType.TREE);
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'root' },
+      { x: 'c1', path: ['root'] },
+    ]);
+  });
+
+  it('reads each of the three as its own trace type', () => {
+    const shapes: [string, TraceType][] = [
+      ['treemap', TraceType.TREEMAP],
+      ['sunburst', TraceType.SUNBURST],
+      ['tree', TraceType.TREE],
+    ];
+
+    for (const [subType, type] of shapes) {
+      const [layer] = layersOf([{ type: subType, nodes: FOREST }], drawnChart(5));
+      expect(layer.type).toBe(type);
+    }
+  });
+});
+
+describe('which hierarchies can be outlined', () => {
+  it('outlines a sunburst, whose marks follow the walk', () => {
+    // Measured by colour-tagging every node: a sunburst paints one mark per
+    // node, in exactly the order the tree walk produces them. The reading
+    // walks the tree rather than the data for that reason.
+    const [layer] = layersOf([{ type: 'sunburst', nodes: FOREST }], drawnChart(5));
+
+    const selectors = layer.selectors as string[];
+    expect(selectors).toHaveLength(5);
+    // The stamp the adapter puts on each mark, in the order it stamped them.
+    selectors.forEach((selector, index) => {
+      expect(selector).toContain(`data-maidr-echart-mark="${index}"`);
+    });
+
+    // And each one reaches the mark it names -- the half a string comparison
+    // does not check.
+    const resolved = selectors.map(selector => document.querySelector(selector));
+    expect(resolved.map(element => element?.id)).toEqual([
+      'mark-0',
+      'mark-1',
+      'mark-2',
+      'mark-3',
+      'mark-4',
+    ]);
+  });
+
+  it('leaves a treemap unoutlined, because it paints only its leaves', () => {
+    // Five nodes, three leaves. A count against the node total could never
+    // match, so it is not attempted -- which keeps a structural mismatch
+    // from being mistaken for a drawing that came out wrong.
+    const [layer] = layersOf([{ type: 'treemap', nodes: FOREST }], drawnChart(5));
+
+    expect(layer.selectors).toBeUndefined();
+    expect((layer.data as TreemapPoint[]).length).toBe(5);
+  });
+
+  it('leaves a tree unoutlined, because its symbols are white', () => {
+    // Measured: a tree's node symbols stay `#fff` whatever `itemStyle` says,
+    // and the adapter counts white as furniture, so there is nothing to name.
+    const [layer] = layersOf(
+      [{ type: 'tree', nodes: [{ name: 'root', children: [{ name: 'c1' }] }] }],
+      drawnChart(2),
+    );
+
+    expect(layer.selectors).toBeUndefined();
+  });
+});
+
+describe('an eCharts graph', () => {
+  const LINKS = [
+    { source: 'a', target: 'b', value: 2 },
+    { source: 'b', target: 'c', value: 3 },
+  ];
+
+  it('reads a sankey as the flows it draws', () => {
+    const [layer] = layersOf(
+      [{ type: 'sankey', names: ['a', 'b', 'c'], links: LINKS }],
+      drawnChart(3),
+    );
+
+    expect(layer.type).toBe(TraceType.SANKEY);
+    expect(layer.data as FlowPoint[]).toEqual([
+      { source: 'a', target: 'b', value: 2 },
+      { source: 'b', target: 'c', value: 3 },
+    ]);
+  });
+
+  it('reads a graph as undirected links with no magnitude', () => {
+    // `NetworkPoint` names two ends and nothing else. A graph's links carry
+    // `value: null` -- measured -- and there is deliberately no position
+    // field, because where a solver put a node is not a fact about the data.
+    const [layer] = layersOf(
+      [{ type: 'graph', names: ['n1', 'n2'], links: [{ source: 'n1', target: 'n2' }] }],
+      drawnChart(2),
+    );
+
+    expect(layer.type).toBe(TraceType.NETWORK);
+    expect(layer.data as NetworkPoint[]).toEqual([{ source: 'n1', target: 'n2' }]);
+  });
+
+  it('drops a flow with no magnitude, because that is a sankey s whole subject', () => {
+    const [layer] = layersOf(
+      [{
+        type: 'sankey',
+        names: ['a', 'b', 'c'],
+        links: [{ source: 'a', target: 'b' }, { source: 'b', target: 'c', value: 3 }],
+      }],
+      drawnChart(3),
+    );
+
+    expect(layer.data as FlowPoint[]).toEqual([
+      { source: 'b', target: 'c', value: 3 },
+    ]);
+  });
+
+  it('drops a link whose ends cannot both be named', () => {
+    // Half a flow is not a reading. `getName` answers the empty string for a
+    // node the series does not have.
+    const [layer] = layersOf(
+      [{
+        type: 'sankey',
+        names: ['a', 'b'],
+        links: [{ source: 'a', target: 'missing', value: 1 }, { source: 'a', target: 'b', value: 4 }],
+      }],
+      drawnChart(2),
+    );
+
+    expect(layer.data as FlowPoint[]).toEqual([
+      { source: 'a', target: 'b', value: 4 },
+    ]);
+  });
+
+  it('is declined when no link survives', () => {
+    expect(layersOf(
+      [{ type: 'sankey', names: ['a'], links: [] }],
+      drawnChart(1),
+    )).toHaveLength(0);
+  });
+
+  it('carries the name the author gave the series', () => {
+    const [layer] = layersOf(
+      [{ type: 'sankey', name: 'Energy', names: ['a', 'b'], links: [{ source: 'a', target: 'b', value: 1 }] }],
+      drawnChart(2),
+    );
+
+    expect(layer.name).toBe('Energy');
+  });
+});

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -368,13 +368,17 @@ describe('a chart that declares both families', () => {
 });
 
 describe('an eCharts chart of a type outside the set', () => {
+  // `treemap` stood here until tier 3 gave it a reading. `radar` is one of
+  // the five still refused, and it has its own measured reason: its ring
+  // backgrounds are neither furniture nor white, so it finds seven marks
+  // where six were expected.
   it('is refused rather than read as whichever trace is closest', () => {
-    expect(() => layerFor({ type: 'treemap', values: [1] }, 1))
+    expect(() => layerFor({ type: 'radar', values: [1] }, 1))
       .toThrow(/Unsupported ECharts series type/);
   });
 
   it('names the single-value types among the ones it does read', () => {
-    expect(() => layerFor({ type: 'treemap', values: [1] }, 1))
+    expect(() => layerFor({ type: 'radar', values: [1] }, 1))
       .toThrow(/pie, funnel, gauge/);
   });
 });


### PR DESCRIPTION
Tier 3 of #1195 — the last five ECharts series types that had a MAIDR trace waiting. `treemap`, `sunburst` and `tree` are one hierarchy drawn three ways and share a `TreemapPoint[]` payload; `sankey` and `graph` are one graph drawn two ways and derive their nodes from their links.

| ECharts | read as | payload | outlined |
|---|---|---|---|
| `treemap` | `treemap` | `TreemapPoint[]` | no |
| `sunburst` | `sunburst` | `TreemapPoint[]` | **yes** |
| `tree` | `tree` | `TreemapPoint[]` | no |
| `sankey` | `sankey` | `FlowPoint[]` | no |
| `graph` | `network` | `NetworkPoint[]` | no |

With this, the adapter reads thirteen of ECharts' seventeen series types. The four left — `boxplot`, `radar`, `parallel`, `themeRiver`, `pictorialBar` — are still refused **by name**, each with its own measured reason.

## Three things measurement decided

**The synthetic root is dropped.** `data.tree.root` is a node ECharts adds above whatever the author wrote: its name is `''` and its value is the sum of everything below. A reader meeting it would be told about a node that is not in their data.

**An interior node's value is emitted only when it is the author's.** `getValue()` answers the rolled-up sum, *and ECharts writes that sum back into the raw data item* — so reading the data back cannot tell a declared value from a derived one. But comparing a node with its children can, and that is exactly the distinction `TreemapPoint.y` asks for ("a parent may carry mass no child accounts for"). Measured against a chart with both cases: `A` (children 1 and 2, nothing declared) reports 3 and emits no `y`; `B` (declared 5, one child of 2) reports 5 and keeps it.

**Only a sunburst can be outlined** — and establishing which took a method change. I first inferred mark-to-node pairing from the default ECharts palette, and concluded that a sunburst's marks matched in *count* but not in *order*. That was wrong. Giving every node an explicit `itemStyle.color` and reading the fills in document order:

- **`sunburst`** paints one mark per node, in *exactly* the order the tree walk produces them. That is why the reading walks the tree rather than the data — a sunburst reorders its children (`B` before `A`, `A2` before `A1`), so the two orders genuinely differ.
- **`treemap`** paints only its **leaves**. Interior nodes are the white borders between them, so a count against the node total can never match, and the leaf order is not the walk order either. That is structural, not a drawing that came out wrong — which is why it is not attempted rather than attempted and dropped.
- **`tree`** draws node symbols `#fff` whatever `itemStyle` says, and this adapter counts white as furniture. Nothing to name.
- **`sankey` and `graph`** navigate *links* while the marks are *nodes*: the cursor and the marks would be addressing different things. Their node ordering is measured and recorded so a later tier does not start from nothing.

## Also settled

A graph node has **no `.name`**. An earlier probe read `undefined` from it, `JSON.stringify` dropped the field, and the result looked like ECharts exposing no names at all. They come from `data.getName(node.dataIndex)` (or `node.id`).

## Verification

- Live-verified against real echarts 6.1.0 in Chromium — all five read, and the sunburst's five selectors all resolve:
  ```
  treemap   type=treemap  name=Spend  selectors=none
    [{"x":"A"},{"x":"A1","y":1,"path":["A"]},{"x":"A2","y":2,"path":["A"]},{"x":"B","y":5},{"x":"B1","y":2,"path":["B"]}]
  sunburst  type=sunburst selectors=5 (5 resolve)
    [{"x":"B","y":5},{"x":"B1","y":2,"path":["B"]},{"x":"A"},{"x":"A2",...},{"x":"A1",...}]
  sankey    type=sankey   [{"source":"a","target":"b","value":2}, …]
  graph     type=network  [{"source":"n1","target":"n2"}, …]
  ```
- `test/adapters/echarts/hierarchy.test.ts` — 16 cases; the selector assertions check both the stamp *and* that each one reaches the mark it names
- The drift guard added in #1200 did its job: widening `EChartsSeriesType` before wiring `READ` failed the build immediately
- Two now-stale tier-2a tests updated — they used `treemap` as the refused example, which reads now; `radar` stands there instead
- Full gate green: `eslint`, `tsc --noEmit`, `npm test` (5904 tests), `npm run build`, `npm run docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_