### PR TITLE
feat(echarts): read a pictorial bar as the bar it is

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -51,9 +51,10 @@ Two things this example does on purpose:
 | `line` + `areaStyle` | `area` | The fill is what makes it an area |
 | `line` + `step` | `line` + `stepDirection` | `'start'` → `vh`, `'end'`/`'middle'` → `hv` |
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
+| `pictorialBar` | `bar` | A bar drawn with a symbol instead of a rectangle; read as the bar it is |
 
-**Not yet supported:** `boxplot`, `radar`, `parallel`, `themeRiver`,
-`pictorialBar`. Each of these is *refused by name* rather than mapped onto
+**Not yet supported:** `boxplot`, `radar`, `parallel`, `themeRiver`.
+Each of these is *refused by name* rather than mapped onto
 whichever trace is closest — each wants its own measured layout first. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
 

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -53,7 +53,25 @@ export interface EChartsAdapterOptions {
  * they are read by different code: one has axes and positions, the other
  * names and magnitudes.
  */
-const CARTESIAN: ReadonlySet<string> = new Set(['bar', 'line', 'scatter']);
+const CARTESIAN: ReadonlySet<string> = new Set([
+  'bar',
+  'line',
+  'scatter',
+  'pictorialBar',
+]);
+
+/**
+ * The series types read as a bar.
+ *
+ * `pictorialBar` swaps the rectangle for a repeated symbol and changes
+ * nothing else. Measured on echarts 6.1.0, its model reports the same
+ * `['x', 'y']` a plain bar does, `getName(i)` gives the same category, and it
+ * paints one filled mark per datum in data order -- confirmed by giving each
+ * datum its own `itemStyle.color` and reading the fills in document order.
+ * So it takes the bar reading whole, highlighting included, and the only
+ * thing this set exists for is to say so once rather than in two filters.
+ */
+const BAR: ReadonlySet<string> = new Set(['bar', 'pictorialBar']);
 
 /**
  * Everything the adapter reads.
@@ -267,8 +285,8 @@ function buildLayers(
   grid: AxisCategories,
   container: HTMLElement,
 ): MaidrLayer[] {
-  const bars = series.filter(seriesModel => seriesModel.subType === 'bar');
-  const others = series.filter(seriesModel => seriesModel.subType !== 'bar');
+  const bars = series.filter(seriesModel => BAR.has(seriesModel.subType));
+  const others = series.filter(seriesModel => !BAR.has(seriesModel.subType));
 
   // Every per-datum mark of the chart is painted alike and only its position
   // tells it apart, so they are located once for all of them, in the order

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -16,10 +16,10 @@
  *
  * ECharts draws seventeen. Three are the cartesian ones (tier 1 of
  * xability/maidr#1195), three carry one magnitude per named thing (tier 2a),
- * two hand over a set of magnitudes already computed (tier 2b), and five
- * carry a hierarchy or a graph (tier 3). Every other series type is refused
- * by name so that gaining a reading later is a decision rather than an
- * accident.
+ * two hand over a set of magnitudes already computed (tier 2b), five carry a
+ * hierarchy or a graph (tier 3), and `pictorialBar` is a bar wearing a
+ * symbol. Every other series type is refused by name so that gaining a
+ * reading later is a decision rather than an accident.
  *
  * Kept in step with `READ` in `converters.ts`, which is what actually
  * decides -- this type is the public statement of it, and
@@ -38,7 +38,8 @@ export type EChartsSeriesType
     | 'sunburst'
     | 'tree'
     | 'sankey'
-    | 'graph';
+    | 'graph'
+    | 'pictorialBar';
 
 /**
  * One column of a series' internal data list.

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -446,6 +446,7 @@ describe('what the adapter says it reads', () => {
     'tree',
     'sankey',
     'graph',
+    'pictorialBar',
   ] as const;
 
   type Declared = typeof DECLARED[number];
@@ -472,6 +473,46 @@ describe('what the adapter says it reads', () => {
 
   it('reads exactly the series types it publishes', () => {
     expect(new Set<string>(DECLARED)).toEqual(READ);
+  });
+});
+
+describe('an eCharts pictorial bar', () => {
+  // `pictorialBar` swaps the rectangle for a repeated symbol and changes
+  // nothing else. Measured on echarts 6.1.0: the model reports the same
+  // `['x', 'y']` a plain bar does, `getName(i)` gives the same category, and
+  // giving each datum its own `itemStyle.color` shows one filled mark per
+  // datum in data order. So it takes the bar reading whole rather than
+  // getting one of its own.
+  it('is read as the bar it is, marks and all', () => {
+    const [layer] = layersOf(
+      { series: [{ type: 'pictorialBar', names: CATEGORIES, values: [3, 5, 2] }] },
+      drawnChart(3, 0),
+    );
+
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'A', y: 3 },
+      { x: 'B', y: 5 },
+      { x: 'C', y: 2 },
+    ]);
+    expect(layer.selectors).toHaveLength(3);
+  });
+
+  it('shares one bar layer with a plain bar beside it', () => {
+    // The two are the same shape, so a chart declaring both is one bar
+    // reading rather than two that would each claim the whole category axis.
+    const layers = layersOf(
+      {
+        series: [
+          { type: 'bar', names: CATEGORIES, values: [1, 2, 3] },
+          { type: 'pictorialBar', names: CATEGORIES, values: [4, 5, 6] },
+        ],
+      },
+      drawnChart(6, 0),
+    );
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.DODGED);
   });
 });
 


### PR DESCRIPTION
## What

`pictorialBar` was refused by name, so a pictorial bar chart fell through to
the "not yet supported" path and lost its reading entirely. It is now read as
the bar it draws.

## Why this is the right reading

A `pictorialBar` is a bar with a symbol in place of the rectangle. Measured
against echarts 6.1.0 in Chromium, its series model is a bar's:

```
=== pictorial  subType=pictorialBar count=3 dims=["x","y"] name=P
   rows : [{"name":"A","x":0,"y":3},{"name":"B","x":1,"y":5},{"name":"C","x":2,"y":2}]
   marks: ["path:#111199","path:#229922","path:#993333"]      <- data order
```

Same dimensions, same rows, and one filled mark per datum in data order —
which is exactly what `bar`'s selector shape wants. The marks were paired to
their data by giving every datum an explicit `itemStyle.color` and reading
fills in document order, rather than inferring the pairing from the default
palette.

Live against real echarts, the emitted layer is:

```json
{"type":"bar","name":"P","data":[{"x":"A","y":3},{"x":"B","y":5},{"x":"C","y":2}],
 "axes":{"x":{"label":"Cat"},"y":{"label":"Val"}},"selectors":3,"resolved":3}
```

All three selectors resolve.

## Changes

- `converters.ts` — `pictorialBar` joins `CARTESIAN`. A new `BAR` set replaces
  the two `subType === 'bar'` filters in `buildLayers()`, so a pictorial bar
  shares one bar layer with a plain bar beside it rather than being read as a
  separate chart: two of them without a `stack` come out `dodged_bar`, which
  is what the page draws.
- `types.ts` — the `EChartsSeriesType` union gains `'pictorialBar'`.
- `cartesian.test.ts` — `DECLARED` gains the type (the two-way drift guard
  fails otherwise), plus two cases: read as a bar with its marks, and shared
  with a plain bar as a `dodged_bar`.
- `docs/echarts.md` — moved out of "Not yet supported" into the supported
  table.

## Verification

Full gate green: `eslint src test scripts`, `tsc --noEmit`, `npm test`
(5906 unit + 138 esm + component, all passing), `npm run build`,
`npm run docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_