### PR TITLE
feat(echarts): read the theme rivers and the parallel coordinates

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -53,9 +53,10 @@ Two things this example does on purpose:
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
 | `pictorialBar` | `bar` | A bar drawn with a symbol instead of a rectangle; read as the bar it is |
 
-**Not yet supported:** `boxplot`, `radar`, `parallel`, `themeRiver`.
-Each of these is *refused by name* rather than mapped onto
-whichever trace is closest — each wants its own measured layout first. See
+**Not yet supported:** `boxplot` and `radar`. Both are *refused by name*
+rather than mapped onto whichever trace is closest — each wants its own
+measured layout first, and the footer of `src/adapters/echarts/grid.ts`
+records what stands in the way of each. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
 
 > **Orientation note:** ECharts has no "horizontal" option. A bar chart is
@@ -174,6 +175,49 @@ fills in document order — reading the default palette had suggested otherwise:
 - **`sankey` and `graph`** both navigate *links* while the marks are *nodes*.
   There is no per-link element to name, so the cursor and the marks would be
   addressing different things.
+
+## Theme rivers and parallel coordinates
+
+Two more series types own the chart without sitting on the x/y grid, and
+neither carries a hierarchy or a graph.
+
+| ECharts | read as | payload | highlighted |
+|---|---|---|---|
+| `themeRiver` | `stacked_area` | `SegmentedPoint[][]` | **no** — see below |
+| `parallel` | `parallel_coordinates` | `LinePoint[][]` | **no** — see below |
+
+**A theme river's rows are flat.** Measured, the series carries
+`['time', 'value', 'name']` with one row *per band per instant* — six rows
+for three instants of two bands — and `getName(i)` answers the band's name
+rather than a category label. Grouping those rows is the only way the bands
+come apart, and they are emitted in first-appearance order, which is the
+order the chart stacks them in.
+
+**Its `time` is epoch milliseconds.** Announced raw it would read as
+"1577836800000", so an instant is turned back into the date it is:
+`2020-01-01` when it lands exactly on a UTC midnight, and the full timestamp
+otherwise, so a chart drawn at finer than daily resolution is not rounded.
+
+**A parallel plot's axis names live off the series.** The series carries one
+row per observation and columns named `dim0`, `dim1`, … ; the names those
+columns are drawn under are on the `parallelAxis` components. Each is placed
+by its own `dim` rather than by the order it was declared in — an author may
+write them in any order, and taking them as written would label every value
+with its neighbour's variable. Every point names its own axis in `x`, which
+is what `ParallelTrace` needs: it keys each axis's extent by name rather than
+by column position, so a value is pitched against its own variable's range
+even when an observation is short a reading
+([#1182](https://github.com/xability/maidr/issues/1182)).
+
+**Neither is highlighted, and for different reasons.** A parallel plot's
+polylines are *stroked*, so the mark finder — which pairs filled marks with
+data — finds none at all: measured, zero marks for a two-observation chart.
+A theme river does paint filled marks, but one per **band**, not one per
+datum; `stacked_area` is a segmented trace, whose selectors are a row per
+series *aligned to that series' points*, and that pairing is not on offer.
+Repeating the band's one mark across its instants would resolve and would
+light the whole band on every move within it, which is not where the cursor
+is.
 
 ## Highlighting
 

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -31,6 +31,12 @@ import {
   hierarchyLayer,
   OUTLINED_HIERARCHY,
 } from './hierarchy';
+import {
+  PARALLEL,
+  parallelLayer,
+  THEME_RIVER,
+  themeRiverLayer,
+} from './multiAxis';
 import { NETWORK, networkLayer } from './network';
 import { markPerDatum, markPerSeries } from './selectors';
 import { SINGLE_VALUE, singleValueLayers } from './single';
@@ -76,10 +82,11 @@ const BAR: ReadonlySet<string> = new Set(['bar', 'pictorialBar']);
 /**
  * Everything the adapter reads.
  *
- * ECharts draws seventeen series types. Every one outside this set --
- * `boxplot`, `radar`, `parallel`, `themeRiver`, `pictorialBar` -- is left
- * unread **by name** rather than mapped onto whichever trace is closest.
- * Each wants its own measured layout before it claims to be readable.
+ * ECharts draws seventeen series types. The two still outside this set --
+ * `boxplot` and `radar` -- are left unread **by name** rather than mapped
+ * onto whichever trace is closest. Each wants its own measured layout
+ * before it claims to be readable; `grid.ts`'s footer records what stands
+ * in the way of each.
  *
  * Exported because `EChartsSeriesType` is the public statement of this set
  * and the two have to agree. They drifted once already: tier 2b added
@@ -94,6 +101,8 @@ export const READ: ReadonlySet<string> = new Set([
   ...GRID_VALUE,
   ...HIERARCHY,
   ...NETWORK,
+  ...THEME_RIVER,
+  ...PARALLEL,
 ]);
 
 /**
@@ -101,12 +110,16 @@ export const READ: ReadonlySet<string> = new Set([
  *
  * A pie, a funnel and a gauge carry one magnitude per named thing; a
  * treemap, sunburst or tree carries a hierarchy; a sankey or graph carries
- * a graph. What they share is that the chart is theirs alone.
+ * a graph; a themeRiver sits on a `singleAxis` and a parallel on one
+ * `parallelAxis` per variable. What they share is that the chart is theirs
+ * alone -- none of them sits on the x/y grid.
  */
 const OWNS_CHART: ReadonlySet<string> = new Set([
   ...SINGLE_VALUE,
   ...HIERARCHY,
   ...NETWORK,
+  ...THEME_RIVER,
+  ...PARALLEL,
 ]);
 
 /**
@@ -153,7 +166,7 @@ export function createMaidrFromEChart(
     // nothing else this adapter would stamp, and the two stamping passes
     // never meet. A chart that declares both families anyway is read as the
     // owning half and says so, rather than dropping the other in silence.
-    ? readOwning(owning, readable, container)
+    ? readOwning(owning, readable, container, model)
     : buildLayers(readable, axisNames(model), categories(model), container);
   const title = options.title ?? componentText(model, 'title', 'text');
   const subplot: MaidrSubplot = { layers };
@@ -171,12 +184,15 @@ export function createMaidrFromEChart(
  * @param owning    - The series that own the chart
  * @param readable  - Every series the adapter reads, including those
  * @param container - The element the chart was rendered into
+ * @param model     - The chart's model, for the axes a themeRiver or a
+ *                    parallel is drawn against
  * @returns One or more layers per series
  */
 function readOwning(
   owning: EChartsSeriesModel[],
   readable: EChartsSeriesModel[],
   container: HTMLElement,
+  model: EChartsModel,
 ): MaidrLayer[] {
   if (owning.length !== readable.length) {
     const dropped = readable
@@ -184,7 +200,7 @@ function readOwning(
       .map(seriesModel => seriesModel.subType)
       .join(', ');
     console.warn(
-      `[MAIDR] ECharts chart mixes whole-chart and cartesian series. `
+      `[MAIDR] ECharts chart mixes whole-chart and gridded series. `
       + `Reading the whole-chart ones; ignoring: ${dropped}.`,
     );
   }
@@ -195,6 +211,14 @@ function readOwning(
     }
     if (NETWORK.has(seriesModel.subType)) {
       const layer = networkLayer(seriesModel);
+      return layer ? [layer] : [];
+    }
+    if (THEME_RIVER.has(seriesModel.subType)) {
+      const layer = themeRiverLayer(seriesModel, model);
+      return layer ? [layer] : [];
+    }
+    if (PARALLEL.has(seriesModel.subType)) {
+      const layer = parallelLayer(seriesModel, model);
       return layer ? [layer] : [];
     }
     const layer = hierarchyLayer(seriesModel, hierarchyMarks(seriesModel, container));

--- a/src/adapters/echarts/multiAxis.ts
+++ b/src/adapters/echarts/multiAxis.ts
@@ -1,0 +1,258 @@
+/**
+ * The two ECharts series types that own the chart but are read as a *set of
+ * series* rather than as one thing per datum.
+ *
+ * A `themeRiver` is a stacked area whose bands sit on a `singleAxis` instead
+ * of a cartesian grid; a `parallel` is one polyline per observation across a
+ * `parallelAxis` per variable. Neither sits on the x/y grid the cartesian
+ * readings use, so neither can go through `buildLayers()` -- but neither
+ * carries a hierarchy or a graph either, which is why they are here rather
+ * than in `hierarchy.ts` or `network.ts`.
+ *
+ * Everything below was measured against **echarts 6.1.0** driven in
+ * Chromium, not read off the documentation.
+ */
+
+import type { LinePoint, MaidrLayer, SegmentedPoint } from '@type/grammar';
+import type {
+  EChartsComponentModel,
+  EChartsModel,
+  EChartsSeriesModel,
+} from './types';
+import { TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
+
+/** The stacked-area series that sits on a `singleAxis`. */
+export const THEME_RIVER: ReadonlySet<string> = new Set(['themeRiver']);
+
+/** The one-polyline-per-observation series that sits on `parallelAxis`. */
+export const PARALLEL: ReadonlySet<string> = new Set(['parallel']);
+
+/**
+ * Reads a `themeRiver` as the stacked area it draws.
+ *
+ * Measured, the series carries `['time', 'value', 'name']` with **one row
+ * per band per instant** -- a flat list, not a row per band:
+ *
+ *     count=6  A@2020-01-01=10  A@2020-01-02=15  A@2020-01-03=12
+ *              B@2020-01-01=5   B@2020-01-02=8   B@2020-01-03=20
+ *
+ * `getName(i)` answers the band's name rather than a category label, so the
+ * grouping this reading does is the only way the bands come apart. They are
+ * emitted in first-appearance order, which is the order the chart stacks
+ * them in.
+ *
+ * **`time` is epoch milliseconds.** Announced raw it would read as
+ * "1577836800000", so it is turned back into the date it is -- see
+ * {@link instant}.
+ *
+ * **It is read without an outline.** Measured by colour, the drawing paints
+ * one filled path per *band*, not one per datum: three instants of two bands
+ * gave two marks. `TraceType.STACKED_AREA` is a segmented trace, and a
+ * segmented trace's selectors are a row per series *aligned to that series'
+ * points* -- which is a pairing the drawing does not offer. Repeating the
+ * band's one mark across its instants would resolve, and would light the
+ * whole band on every move within it, which is not what the cursor is on.
+ * So the outline is left to a follow-up that can verify a shape against a
+ * constructed trace rather than against a resolving string.
+ *
+ * @param seriesModel - The series to read
+ * @param model       - The chart's model, for the axis name
+ * @returns The layer, or `undefined` when nothing measurable was drawn
+ */
+export function themeRiverLayer(
+  seriesModel: EChartsSeriesModel,
+  model: EChartsModel,
+): MaidrLayer | undefined {
+  const data = seriesModel.getData();
+  const dated = axisType(model, 'singleAxis') === 'time';
+
+  // First-appearance order, which is the order the bands are stacked in.
+  const order: string[] = [];
+  const bands = new Map<string, SegmentedPoint[]>();
+
+  for (let index = 0; index < data.count(); index++) {
+    const value = data.get('value', index);
+    if (!measured(value)) {
+      continue;
+    }
+    const band = data.getName(index) || `Band ${order.length + 1}`;
+    let points = bands.get(band);
+    if (!points) {
+      points = [];
+      bands.set(band, points);
+      order.push(band);
+    }
+    points.push({ x: instant(data.get('time', index), dated), y: value, z: band });
+  }
+
+  if (order.length === 0) {
+    return undefined;
+  }
+
+  const name = text(seriesModel.get('name'));
+  const when = axisName(model, 'singleAxis');
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.STACKED_AREA,
+    ...(name ? { name } : {}),
+    axes: {
+      x: { label: when || undefined },
+      // The bands are a magnitude with no axis of its own: a themeRiver
+      // draws no value axis, so naming one would be a claim the chart does
+      // not make.
+      y: {},
+    },
+    // A row per band. `SegmentedTrace` declines a flat list, and a flat one
+    // is what the series hands over.
+    data: order.map(band => bands.get(band) ?? []),
+  };
+}
+
+/**
+ * Reads a `parallel` as the parallel-coordinates plot it draws.
+ *
+ * Measured, the series carries one row per **observation** and one dimension
+ * per **variable** -- `['dim0', 'dim1', 'dim2']` for a three-axis chart --
+ * and the names those columns are drawn under live on the `parallelAxis`
+ * components rather than on the series:
+ *
+ *     parallelAxis: [{dim:0,name:'p'}, {dim:1,name:'q'}, {dim:2,name:'r'}]
+ *
+ * so the axis names are read from there, in `dim` order, and fall back to
+ * the dimension's own name when the author wrote none (measured: `name`
+ * comes back as the empty string, not `undefined`).
+ *
+ * Every point names its own axis in `x`, which is what `ParallelTrace`
+ * requires: it keys each axis's extent by name rather than by column
+ * position, so a value is pitched against its own variable's range even when
+ * an observation is short a reading (#1182).
+ *
+ * **It is read without an outline, and that is measured rather than
+ * conceded.** The polylines are *stroked*, not filled, so the mark finder --
+ * which pairs filled marks with data -- finds none at all: zero marks for a
+ * two-observation chart. Reading without one is what `gauge`, `sankey` and
+ * `graph` already do here.
+ *
+ * @param seriesModel - The series to read
+ * @param model       - The chart's model, for the axis names
+ * @returns The layer, or `undefined` when nothing measurable was drawn
+ */
+export function parallelLayer(
+  seriesModel: EChartsSeriesModel,
+  model: EChartsModel,
+): MaidrLayer | undefined {
+  const data = seriesModel.getData();
+  const names = parallelAxisNames(model);
+
+  const observations: LinePoint[][] = [];
+  for (let index = 0; index < data.count(); index++) {
+    const row: LinePoint[] = [];
+    data.dimensions.forEach((dimension, column) => {
+      const value = data.get(dimension, index);
+      if (!measured(value)) {
+        return;
+      }
+      row.push({ x: names[column] || dimension, y: value });
+    });
+    if (row.length > 0) {
+      observations.push(row);
+    }
+  }
+
+  if (observations.length === 0) {
+    return undefined;
+  }
+
+  const name = text(seriesModel.get('name'));
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.PARALLEL,
+    ...(name ? { name } : {}),
+    // No x or y of the chart's own: every axis is a column, and each point
+    // names the one it belongs to.
+    data: observations,
+  };
+}
+
+/**
+ * The `parallelAxis` names, in the order the chart draws them.
+ *
+ * Placed by each component's own `dim` rather than by the order they were
+ * declared in: `dim` is what ties an axis to a column of the series, and an
+ * author may write them in any order.
+ *
+ * @param model - The chart's model
+ * @returns One name per column, empty where the author wrote none
+ */
+function parallelAxisNames(model: EChartsModel): string[] {
+  const names: string[] = [];
+  model.eachComponent({ mainType: 'parallelAxis' }, (component, index) => {
+    const dim = component.get('dim');
+    const at = typeof dim === 'number' && Number.isInteger(dim) && dim >= 0
+      ? dim
+      : index;
+    names[at] = text(component.get('name'));
+  });
+  return names;
+}
+
+/**
+ * One instant of a themeRiver's axis, in terms a reader can hear.
+ *
+ * ECharts hands over epoch milliseconds. A date is announced as the day it
+ * is when the instant lands exactly on a UTC midnight -- which is what daily
+ * data does -- and as the full timestamp otherwise, so nothing is rounded
+ * away from a chart that carries a time of day.
+ *
+ * A non-time axis is left as the number it is.
+ *
+ * @param value - The raw value of the `time` column
+ * @param dated - Whether the axis was declared `type: 'time'`
+ * @returns The value to announce
+ */
+function instant(value: number | null | undefined, dated: boolean): string | number {
+  if (!measured(value)) {
+    return 0;
+  }
+  if (!dated) {
+    return value;
+  }
+  const when = new Date(value);
+  if (Number.isNaN(when.getTime())) {
+    return value;
+  }
+  const iso = when.toISOString();
+  return iso.endsWith('T00:00:00.000Z') ? iso.slice(0, 10) : iso;
+}
+
+function axisType(model: EChartsModel, mainType: string): string {
+  return text(firstOf(model, mainType)?.get('type'));
+}
+
+function axisName(model: EChartsModel, mainType: string): string {
+  return text(firstOf(model, mainType)?.get('name'));
+}
+
+function firstOf(
+  model: EChartsModel,
+  mainType: string,
+): EChartsComponentModel | undefined {
+  let first: EChartsComponentModel | undefined;
+  model.eachComponent({ mainType }, (component, index) => {
+    if (index === 0) {
+      first = component;
+    }
+  });
+  return first;
+}
+
+function measured(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined && Number.isFinite(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -17,9 +17,10 @@
  * ECharts draws seventeen. Three are the cartesian ones (tier 1 of
  * xability/maidr#1195), three carry one magnitude per named thing (tier 2a),
  * two hand over a set of magnitudes already computed (tier 2b), five carry a
- * hierarchy or a graph (tier 3), and `pictorialBar` is a bar wearing a
- * symbol. Every other series type is refused by name so that gaining a
- * reading later is a decision rather than an accident.
+ * hierarchy or a graph (tier 3), `pictorialBar` is a bar wearing a symbol,
+ * and `themeRiver` and `parallel` own the chart but are read as a set of
+ * series. `boxplot` and `radar` are the two still refused by name, so that
+ * gaining a reading later is a decision rather than an accident.
  *
  * Kept in step with `READ` in `converters.ts`, which is what actually
  * decides -- this type is the public statement of it, and
@@ -39,7 +40,9 @@ export type EChartsSeriesType
     | 'tree'
     | 'sankey'
     | 'graph'
-    | 'pictorialBar';
+    | 'pictorialBar'
+    | 'themeRiver'
+    | 'parallel';
 
 /**
  * One column of a series' internal data list.

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -447,6 +447,8 @@ describe('what the adapter says it reads', () => {
     'sankey',
     'graph',
     'pictorialBar',
+    'themeRiver',
+    'parallel',
   ] as const;
 
   type Declared = typeof DECLARED[number];

--- a/test/adapters/echarts/multiAxis.test.ts
+++ b/test/adapters/echarts/multiAxis.test.ts
@@ -1,0 +1,325 @@
+import type {
+  EChartsComponentModel,
+  EChartsInstance,
+  EChartsList,
+  EChartsSeriesModel,
+} from '@adapters/echarts/types';
+import type { LinePoint, SegmentedPoint } from '@type/grammar';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * The two series types that own the chart but are read as a set of series.
+ *
+ * Both were refused by name until now, so a themeRiver or a parallel chart
+ * threw "Unsupported ECharts series type(s)" and the page lost its reading
+ * outright. The fixtures below carry the shapes measured off echarts 6.1.0
+ * -- a themeRiver's flat `['time','value','name']` rows and a parallel's one
+ * row per observation with the axis names living on separate components --
+ * because those two facts are the whole of what these readings do.
+ */
+
+/** One row of a themeRiver: an instant, a magnitude, and the band it is in. */
+interface Band {
+  time: number;
+  value: number | null;
+  name: string;
+}
+
+/** Midnight UTC on the given day of January 2020, in epoch milliseconds. */
+function january(day: number): number {
+  return Date.UTC(2020, 0, day);
+}
+
+function themeRiverChart(
+  rows: Band[],
+  options: { axisName?: string; axisType?: string; seriesName?: string } = {},
+): EChartsInstance {
+  const list: EChartsList = {
+    dimensions: ['time', 'value', 'name'],
+    count: () => rows.length,
+    getName: index => rows[index].name,
+    get: (dimension, index) =>
+      dimension === 'time' ? rows[index].time : rows[index].value,
+  };
+
+  const series: EChartsSeriesModel = {
+    subType: 'themeRiver',
+    name: options.seriesName ?? 'series 0',
+    getData: () => list,
+    get: key => (key === 'name' ? options.seriesName : undefined),
+  };
+
+  return instanceOf(series, {
+    singleAxis: [{
+      name: options.axisName,
+      type: options.axisType ?? 'time',
+    }],
+  });
+}
+
+/** One `parallelAxis` component, as an author writes it. */
+interface Axis {
+  dim?: number;
+  name?: string;
+}
+
+function parallelChart(
+  rows: (number | null)[][],
+  axes: Axis[],
+  seriesName?: string,
+): EChartsInstance {
+  const dimensions = rows[0]?.map((_, column) => `dim${column}`) ?? [];
+  const list: EChartsList = {
+    dimensions,
+    count: () => rows.length,
+    // Measured: a parallel series names none of its observations.
+    getName: () => '',
+    get: (dimension, index) => rows[index][dimensions.indexOf(dimension)],
+  };
+
+  const series: EChartsSeriesModel = {
+    subType: 'parallel',
+    name: seriesName ?? 'series 0',
+    getData: () => list,
+    get: key => (key === 'name' ? seriesName : undefined),
+  };
+
+  return instanceOf(series, {
+    parallelAxis: axes.map(axis => ({ name: axis.name, dim: axis.dim })),
+  });
+}
+
+function instanceOf(
+  series: EChartsSeriesModel,
+  components: Record<string, Record<string, unknown>[]>,
+): EChartsInstance {
+  return {
+    getModel: () => ({
+      eachSeries: callback => callback(series, 0),
+      eachComponent: (query, callback) => {
+        (components[query.mainType] ?? []).forEach((options, index) => {
+          const component: EChartsComponentModel = { get: key => options[key] };
+          callback(component, index);
+        });
+      },
+    }),
+  };
+}
+
+function container(): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="chart"></div></body>');
+  return dom.window.document.getElementById('chart') as HTMLElement;
+}
+
+function layersOf(chart: EChartsInstance) {
+  return createMaidrFromEChart(chart, container()).subplots[0][0].layers;
+}
+
+const RIVER: Band[] = [
+  { time: january(1), value: 10, name: 'A' },
+  { time: january(2), value: 15, name: 'A' },
+  { time: january(3), value: 12, name: 'A' },
+  { time: january(1), value: 5, name: 'B' },
+  { time: january(2), value: 8, name: 'B' },
+  { time: january(3), value: 20, name: 'B' },
+];
+
+describe('an eCharts theme river', () => {
+  it('is read as the stacked area it draws', () => {
+    const layers = layersOf(themeRiverChart(RIVER, { seriesName: 'Flow' }));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.STACKED_AREA);
+    expect(layers[0].name).toBe('Flow');
+  });
+
+  it('groups its flat rows into a row per band', () => {
+    // The reproduction of what makes this reading necessary: the series
+    // hands over six rows, not two bands, and a segmented trace declines a
+    // flat list.
+    const data = layersOf(themeRiverChart(RIVER))[0].data as SegmentedPoint[][];
+
+    expect(data).toHaveLength(2);
+    expect(data[0].map(point => point.y)).toEqual([10, 15, 12]);
+    expect(data[1].map(point => point.y)).toEqual([5, 8, 20]);
+  });
+
+  it('names each band on every one of its points', () => {
+    // `z` is how a segmented trace tells the bands apart, and `getName()` is
+    // the only place the name lives.
+    const data = layersOf(themeRiverChart(RIVER))[0].data as SegmentedPoint[][];
+
+    expect(data[0].every(point => point.z === 'A')).toBe(true);
+    expect(data[1].every(point => point.z === 'B')).toBe(true);
+  });
+
+  it('stacks the bands in the order they first appear', () => {
+    // Not alphabetical: the order the rows arrive in is the order the chart
+    // stacks them, and sorting would announce a different chart.
+    const rows: Band[] = [
+      { time: january(1), value: 3, name: 'zeta' },
+      { time: january(1), value: 4, name: 'alpha' },
+      { time: january(2), value: 5, name: 'zeta' },
+      { time: january(2), value: 6, name: 'alpha' },
+    ];
+    const data = layersOf(themeRiverChart(rows))[0].data as SegmentedPoint[][];
+
+    expect(data.map(band => band[0].z)).toEqual(['zeta', 'alpha']);
+  });
+
+  it('announces an instant as the date it is, not as epoch milliseconds', () => {
+    // Measured: `time` comes back as 1577836800000. Announced raw that is
+    // unreadable, and it is the value a reader hears on every move.
+    const data = layersOf(themeRiverChart(RIVER))[0].data as SegmentedPoint[][];
+
+    expect(data[0].map(point => point.x)).toEqual([
+      '2020-01-01',
+      '2020-01-02',
+      '2020-01-03',
+    ]);
+  });
+
+  it('keeps the time of day when an instant carries one', () => {
+    // The day alone would round away a chart drawn at finer than daily
+    // resolution, so only an exact UTC midnight is shortened.
+    const noon = Date.UTC(2020, 0, 1, 12, 30);
+    const data = layersOf(themeRiverChart([
+      { time: noon, value: 1, name: 'A' },
+    ]))[0].data as SegmentedPoint[][];
+
+    expect(data[0][0].x).toBe('2020-01-01T12:30:00.000Z');
+  });
+
+  it('leaves a non-time axis as the number it is', () => {
+    const data = layersOf(themeRiverChart(
+      [{ time: 7, value: 1, name: 'A' }],
+      { axisType: 'value' },
+    ))[0].data as SegmentedPoint[][];
+
+    expect(data[0][0].x).toBe(7);
+  });
+
+  it('names its axis from the single axis it is drawn against', () => {
+    const layer = layersOf(themeRiverChart(RIVER, { axisName: 'When' }))[0];
+
+    expect(layer.axes?.x?.label).toBe('When');
+    // A themeRiver draws no value axis, so naming one would be a claim the
+    // chart does not make.
+    expect(layer.axes?.y?.label).toBeUndefined();
+  });
+
+  it('drops a band row that drew nothing rather than reading it as zero', () => {
+    const data = layersOf(themeRiverChart([
+      { time: january(1), value: 10, name: 'A' },
+      { time: january(2), value: null, name: 'A' },
+      { time: january(3), value: 12, name: 'A' },
+    ]))[0].data as SegmentedPoint[][];
+
+    expect(data[0].map(point => point.y)).toEqual([10, 12]);
+  });
+
+  it('is read without an outline', () => {
+    // Measured by colour: the drawing paints one filled path per band, not
+    // one per datum, so the per-point pairing a segmented trace's selectors
+    // need is not on offer. Emitting one anyway would light a whole band on
+    // every move within it.
+    expect(layersOf(themeRiverChart(RIVER))[0].selectors).toBeUndefined();
+  });
+
+  it('is refused when nothing it drew was measurable', () => {
+    expect(() => layersOf(themeRiverChart([
+      { time: january(1), value: null, name: 'A' },
+    ]))).not.toThrow();
+    expect(layersOf(themeRiverChart([
+      { time: january(1), value: null, name: 'A' },
+    ]))).toHaveLength(0);
+  });
+});
+
+describe('an eCharts parallel coordinates plot', () => {
+  const AXES: Axis[] = [
+    { dim: 0, name: 'p' },
+    { dim: 1, name: 'q' },
+    { dim: 2, name: 'r' },
+  ];
+
+  it('is read as one polyline per observation', () => {
+    const layers = layersOf(parallelChart([[1, 2, 3], [4, 5, 6]], AXES, 'Obs'));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.PARALLEL);
+    expect(layers[0].name).toBe('Obs');
+    expect(layers[0].data).toHaveLength(2);
+  });
+
+  it('gives an observation a point per variable, each naming its own axis', () => {
+    // `ParallelTrace` keys each axis's extent by the name its points carry,
+    // not by column position, so the name on `x` is what keeps a value
+    // pitched against its own variable's range (#1182).
+    const data = layersOf(
+      parallelChart([[1, 2, 3]], AXES),
+    )[0].data as LinePoint[][];
+
+    expect(data[0]).toEqual([
+      { x: 'p', y: 1 },
+      { x: 'q', y: 2 },
+      { x: 'r', y: 3 },
+    ]);
+  });
+
+  it('places each axis by its own dim rather than by declaration order', () => {
+    // `dim` is what ties an axis to a column, and an author may write the
+    // components in any order. Taking them as written would label every
+    // value with its neighbour's variable.
+    const data = layersOf(parallelChart(
+      [[10, 20]],
+      [{ dim: 1, name: 'second' }, { dim: 0, name: 'first' }],
+    ))[0].data as LinePoint[][];
+
+    expect(data[0]).toEqual([
+      { x: 'first', y: 10 },
+      { x: 'second', y: 20 },
+    ]);
+  });
+
+  it('falls back to the column name when the author named no axis', () => {
+    // Measured: an unnamed `parallelAxis` answers the empty string, not
+    // `undefined`, so an unnamed axis would otherwise carry no name at all
+    // and every column would collide under one key.
+    const data = layersOf(parallelChart(
+      [[1, 2]],
+      [{ dim: 0 }, { dim: 1 }],
+    ))[0].data as LinePoint[][];
+
+    expect(data[0].map(point => point.x)).toEqual(['dim0', 'dim1']);
+  });
+
+  it('drops a reading the observation never had', () => {
+    // An observation short a value is one point shorter rather than carrying
+    // a zero; every remaining point still names its own axis, which is what
+    // keeps the rest pitched correctly.
+    const data = layersOf(parallelChart(
+      [[1, null, 3]],
+      AXES,
+    ))[0].data as LinePoint[][];
+
+    expect(data[0]).toEqual([
+      { x: 'p', y: 1 },
+      { x: 'r', y: 3 },
+    ]);
+  });
+
+  it('is read without an outline, which is measured rather than conceded', () => {
+    // The polylines are stroked, not filled, so the mark finder pairs
+    // nothing: measured, a two-observation chart yields zero filled marks.
+    expect(layersOf(parallelChart([[1, 2, 3]], AXES))[0].selectors).toBeUndefined();
+  });
+
+  it('emits no layer when no observation had a reading', () => {
+    expect(layersOf(parallelChart([[null, null]], [{ dim: 0 }, { dim: 1 }])))
+      .toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Two more ECharts series types own the chart without sitting on the x/y grid,
and neither carries a hierarchy or a graph — so they get a module of their
own, `multiAxis.ts`. Both were refused by name until now, which meant a
themeRiver or a parallel chart threw `Unsupported ECharts series type(s)` and
lost its reading outright.

| ECharts | read as | payload | highlighted |
|---|---|---|---|
| `themeRiver` | `stacked_area` | `SegmentedPoint[][]` | no — measured |
| `parallel` | `parallel_coordinates` | `LinePoint[][]` | no — measured |

That takes the adapter to **15 of ECharts' 17** series types. `boxplot` and
`radar` are the two still refused.

## themeRiver — the rows are flat, and the time is an epoch

Measured on echarts 6.1.0, the series carries `['time', 'value', 'name']`
with one row **per band per instant** — six rows for three instants of two
bands — and `getName(i)` answers the *band's* name rather than a category
label:

```
count=6  A@2020-01-01=10  A@2020-01-02=15  A@2020-01-03=12
         B@2020-01-01=5   B@2020-01-02=8   B@2020-01-03=20
```

Grouping those rows is the only way the bands come apart. They keep
first-appearance order, which is the order the chart stacks them in — sorting
would announce a different chart.

`time` comes back as `1577836800000`. Announced raw that is what a reader
hears on every move, so an instant is turned back into the date it is:
`2020-01-01` when it lands exactly on a UTC midnight, and the full timestamp
otherwise, so a chart drawn at finer than daily resolution is not rounded.

## parallel — the axis names live off the series

The series carries one row per observation and columns named `dim0`, `dim1`,
… ; the names those columns are drawn under are on the `parallelAxis`
components:

```
parallelAxis: [{dim:0,name:'p'}, {dim:1,name:'q'}, {dim:2,name:'r'}]
```

Each is placed by its own `dim` rather than by the order it was declared in.
An author may write them in any order, and taking them as written would label
every value with its neighbour's variable — verified live with
`[{dim:1,name:'second'},{dim:0,name:'first'}]`, which correctly labels column
0 `first`.

Every point names its own axis in `x`, which is what `ParallelTrace` needs:
it keys each axis's extent by name rather than by column position, so a value
is pitched against its own variable's range even when an observation is short
a reading (#1182).

## Neither is highlighted, for different measured reasons

- **parallel**: the polylines are *stroked*, so the mark finder — which pairs
  filled marks with data — finds none at all. Measured: zero filled marks for
  a two-observation chart. Reading without one is what `gauge`, `sankey` and
  `graph` already do here.
- **themeRiver**: it *does* paint filled marks, but one per **band**, not one
  per datum (two marks for three instants of two bands). `stacked_area` is a
  segmented trace, whose selectors are a row per series *aligned to that
  series' points* — a pairing the drawing does not offer. Repeating the band's
  one mark across its instants would resolve, and would light the whole band
  on every move within it, which is not where the cursor is. Left to a
  follow-up that can verify a shape against a constructed trace rather than
  against a resolving string.

## Also in here

The `READ` docstring still named `pictorialBar` among the refused types after
#1202 gave it a reading. This change rewrites that same sentence, so the
correction rides along: two are left, `boxplot` and `radar`.

## Verification

Live against real echarts 6.1.0 in Chromium, through the bundled adapter:

```json
themeRiver -> {"type":"stacked_area","name":"Flow",
  "axes":{"x":{"label":"When"},"y":{}},
  "data":[[{"x":"2020-01-01","y":10,"z":"A"}, ...],
          [{"x":"2020-01-01","y":5,"z":"B"}, ...]]}
parallel   -> {"type":"parallel_coordinates","name":"Obs",
  "data":[[{"x":"p","y":1},{"x":"q","y":2},{"x":"r","y":3}], ...]}
```

The two-way series-type drift guard in `cartesian.test.ts` fired on the first
compile, as designed, until `DECLARED` gained both types.

Full gate green: `eslint src test scripts`, `tsc --noEmit`, `npm test`
(**5924** unit + 138 esm + component, all passing — 18 new), `npm run build`,
`npm run docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_