### PR TITLE
docs(observable): tell deck authors how to keep off-slide charts out of the tab order

### DIFF
--- a/docs/observable.md
+++ b/docs/observable.md
@@ -134,6 +134,50 @@ filters:
 maidr-version: "4.2.0"
 ```
 
+### revealjs slides
+
+An `{ojs}` cell draws its chart straight into the slide, so the deck's own tab
+order is the browser's: **Tab** reaches the chart, the arrow keys explore it,
+and **Shift+Tab** goes back to whatever precedes it on the slide, from where
+**Space** advances the deck.
+
+One reveal.js behaviour gets in the way, and it has nothing to do with MAIDR.
+reveal.js keeps the slides on either side of the current one rendered so that
+transitions stay smooth, and marking them `hidden` does not take them out of
+the tab order — reveal's own inline style overrides the attribute. On a deck
+with a chart on every slide, a single **Tab** therefore lands on an off-screen
+slide's chart rather than the one in front of the reader. This is
+[hakimel/reveal.js#1587](https://github.com/hakimel/reveal.js/issues/1587),
+open since 2016.
+
+The fix is now on reveal.js `master`, which marks every slide but the current
+one `inert`. It has not reached a published release yet, and Quarto carries its
+own copy of reveal.js — Quarto 1.10 ships 5.1.0 — so it will arrive in a Quarto
+release some time after reveal.js cuts one. Nothing will need to change in your
+deck when it does.
+
+Until then,
+[quarto-revealjs-a11y](https://github.com/mcanouil/quarto-revealjs-a11y) does
+the same thing for a Quarto deck. It is a separate extension, installed
+alongside this one:
+
+```bash
+quarto add mcanouil/quarto-revealjs-a11y
+```
+
+```yaml
+filters:
+  - maidr
+format:
+  revealjs:
+    revealjs-plugins:
+      - a11y
+```
+
+Use **0.2.3 or newer**. Earlier versions took off-slide elements out of the tab
+order by setting `tabindex="-1"` on them and could not find them again to put
+them back, which left the chart on the *current* slide unreachable as well.
+
 ## Observable's own runtimes
 
 The two quick starts cover a page you control. Observable ships two other ways

--- a/docs/observable.md
+++ b/docs/observable.md
@@ -134,7 +134,7 @@ filters:
 maidr-version: "4.2.0"
 ```
 
-### revealjs slides
+### Reveal.js slides
 
 An `{ojs}` cell draws its chart straight into the slide, so the deck's own tab
 order is the browser's: **Tab** reaches the chart, the arrow keys explore it,


### PR DESCRIPTION
## Description

Adds a `### revealjs slides` section to `docs/observable.md`, under the Quarto part, telling deck authors what to expect from the keyboard in an `{ojs}` slide deck and how to fix the one thing that is broken there.

An `{ojs}` cell draws its chart straight into the slide, so there is no iframe and no handoff involved: getting into the chart and back out is the browser's own tab order, and it needs nothing from us. What does get in the way is reveal.js. It keeps the slides on either side of the current one rendered so transitions stay smooth, and marking them `hidden` does not take them out of the tab order, because reveal's own inline style overrides the attribute. On a deck with a chart on every slide, a single Tab lands on an off-screen slide's chart instead of the one in front of the reader.

## Related Issues

Upstream: hakimel/reveal.js#1587, open since 2016. The fix has since landed on reveal.js `master`, which marks every slide but the current one `inert`. It is not in a published release yet, and Quarto carries its own copy — Quarto 1.10 ships reveal.js 5.1.0 — so it will reach decks in some Quarto release after reveal.js cuts one.

Follow-up to #1111 and #1121, which fixed the iframe half of this for the R and Python bindings.

## Changes Made

`docs/observable.md`, 44 lines added, no other file touched:

- what the keyboard does in an `{ojs}` deck today
- why one Tab can land on an off-screen slide's chart, with the upstream issue
- that reveal.js `master` fixes it and nothing in the deck will need to change when Quarto ships it
- until then, `quarto add mcanouil/quarto-revealjs-a11y` plus the YAML to enable it next to the `maidr` filter
- that 0.2.3 or newer is required: earlier versions parked off-slide elements at `tabindex="-1"` and could not find them again to restore them, which left the chart on the *current* slide unreachable too

## Screenshots (if applicable)

Not applicable — the change is prose. Verified in a real browser instead; see below.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas. — not applicable, no code changed
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable. — not applicable, no code changed

## Additional Notes

Every claim in the section was checked in Chromium against a four-slide Quarto `revealjs` deck of `{ojs}` Plot cells with the `maidr` filter enabled, rather than reasoned about.

Without the extension, from any slide the first Tab lands on slide 1's chart:

```
slide 2: button@slide-1 -> div@slide-1 -> button@slide-2 -> div@slide-2
slide 3: button@slide-1 -> div@slide-1 -> button@slide-2* -> div@slide-2*
slide 4: button@slide-1 -> div@slide-1 -> button@slide-2 -> div@slide-2
```

With quarto-revealjs-a11y 0.2.3, only the current slide is reachable, and the loop closes:

```
slide 1: chart after 3 Tab(s) -> div[application] @slide-1* | Shift+Tab -> button @slide-1* | Space 1->2
slide 2: chart after 3 Tab(s) -> div[application] @slide-2* | Shift+Tab -> button @slide-2* | Space 2->3
slide 3: chart after 3 Tab(s) -> div[application] @slide-3* | Shift+Tab -> button @slide-3* | Space 3->4
```

The 0.2.2 warning is from a measured regression, not caution: with 0.2.2 the chart on the current slide stayed at `tabindex="-1"` with the saved value still parked on it, and 42 consecutive Tab presses never reached it. Its restore query was `[tabindex]:not([tabindex="-1"])`, which cannot match anything it had itself set to `-1`. 0.2.3 replaced that mechanism with `inert` on the slide.

Also verified: `node scripts/build-site.js` renders `docs/observable.md` cleanly and the new section appears in `_site/observable.html`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eadkcqpkod61zhhbfy8Wj8)_