### PR TITLE
feat(echarts): read a radar, whose outline is a stroke not a fill

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -53,10 +53,9 @@ Two things this example does on purpose:
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
 | `pictorialBar` | `bar` | A bar drawn with a symbol instead of a rectangle; read as the bar it is |
 
-**Not yet supported:** `boxplot` and `radar`. Both are *refused by name*
-rather than mapped onto whichever trace is closest — each wants its own
-measured layout first, and the footer of `src/adapters/echarts/grid.ts`
-records what stands in the way of each. See
+**Not yet supported:** `boxplot` alone. It is *refused by name* rather than
+mapped onto whichever trace is closest, and the footer of
+`src/adapters/echarts/grid.ts` records what stands in the way. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
 
 > **Orientation note:** ECharts has no "horizontal" option. A bar chart is
@@ -176,15 +175,16 @@ fills in document order — reading the default palette had suggested otherwise:
   There is no per-link element to name, so the cursor and the marks would be
   addressing different things.
 
-## Theme rivers and parallel coordinates
+## Theme rivers, parallel coordinates and radars
 
-Two more series types own the chart without sitting on the x/y grid, and
-neither carries a hierarchy or a graph.
+Three more series types own the chart without sitting on the x/y grid, and
+none of them carries a hierarchy or a graph.
 
 | ECharts | read as | payload | highlighted |
 |---|---|---|---|
 | `themeRiver` | `stacked_area` | `SegmentedPoint[][]` | **no** — see below |
 | `parallel` | `parallel_coordinates` | `LinePoint[][]` | **no** — see below |
+| `radar` | `radar` | `LinePoint[][]` | yes — one selector per series |
 
 **A theme river's rows are flat.** Measured, the series carries
 `['time', 'value', 'name']` with one row *per band per instant* — six rows
@@ -218,6 +218,32 @@ series *aligned to that series' points*, and that pairing is not on offer.
 Repeating the band's one mark across its instants would resolve and would
 light the whole band on every move within it, which is not where the cursor
 is.
+
+**A radar's outline is a stroke, not a fill.** This one is worth spelling out
+because the adapter got it wrong once. A radar was refused on the grounds
+that a two-series chart "draws six vertex symbols and also fills its
+alternating ring backgrounds, one of which (`rgb(234,237,245)`) is neither
+furniture nor white, so seven marks are found where six are expected". That
+counts the wrong mark class. `RadarTrace` wants one selector per **series**,
+and the filled marks are one per **vertex** — three per series — so they
+never fitted, ring background or not. Colour-tagging a two-series radar
+shows what does:
+
+```
+FILLED    rgb(234,237,245)  ring background
+          rgb(255,255,255)  ring background   (white -> furniture)
+          #111199 x3        series one's vertex symbols
+          #229922 x3        series two's vertex symbols
+STROKED   #dbdee4           ring outline      unweighted -> furniture
+          #cfd2d7 x3        spokes            unweighted -> furniture
+          #111199 width=2   series one        <- the mark
+          #229922 width=2   series two        <- the mark
+```
+
+One weighted stroke per series, in the series colour — the same shape
+`markPerSeries()` already finds for a line. Its spoke names come from the
+`radar` component's `indicator` array rather than from the series, whose own
+dimensions are the positions `indicator_0`, `indicator_1`, ….
 
 ## Highlighting
 
@@ -266,6 +292,7 @@ silently.
 | `heat` | a row of selectors per grid row, bottom-first | `Heatmap`, which indexes by its own row |
 | `candlestick` | `{ body: [...] }`, one per candle | `Candlestick.mapToSvgElements` |
 | `sunburst` | one selector per node, in tree-walk order | `TreemapTrace` |
+| `radar` | one selector per series, as a stroked outline | `RadarTrace` |
 
 So the marks are stamped twice in one pass — once per mark and once per
 series — and each layer takes the address its own trace can use.

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -38,6 +38,7 @@ import {
   themeRiverLayer,
 } from './multiAxis';
 import { NETWORK, networkLayer } from './network';
+import { drawnOutlineCount, RADAR, radarLayer } from './radar';
 import { markPerDatum, markPerSeries } from './selectors';
 import { SINGLE_VALUE, singleValueLayers } from './single';
 
@@ -82,11 +83,9 @@ const BAR: ReadonlySet<string> = new Set(['bar', 'pictorialBar']);
 /**
  * Everything the adapter reads.
  *
- * ECharts draws seventeen series types. The two still outside this set --
- * `boxplot` and `radar` -- are left unread **by name** rather than mapped
- * onto whichever trace is closest. Each wants its own measured layout
- * before it claims to be readable; `grid.ts`'s footer records what stands
- * in the way of each.
+ * ECharts draws seventeen series types. The one still outside this set --
+ * `boxplot` -- is left unread **by name** rather than mapped onto whichever
+ * trace is closest; `grid.ts`'s footer records what stands in the way.
  *
  * Exported because `EChartsSeriesType` is the public statement of this set
  * and the two have to agree. They drifted once already: tier 2b added
@@ -103,6 +102,7 @@ export const READ: ReadonlySet<string> = new Set([
   ...NETWORK,
   ...THEME_RIVER,
   ...PARALLEL,
+  ...RADAR,
 ]);
 
 /**
@@ -110,9 +110,10 @@ export const READ: ReadonlySet<string> = new Set([
  *
  * A pie, a funnel and a gauge carry one magnitude per named thing; a
  * treemap, sunburst or tree carries a hierarchy; a sankey or graph carries
- * a graph; a themeRiver sits on a `singleAxis` and a parallel on one
- * `parallelAxis` per variable. What they share is that the chart is theirs
- * alone -- none of them sits on the x/y grid.
+ * a graph; a themeRiver sits on a `singleAxis`, a parallel on one
+ * `parallelAxis` per variable, and a radar on a `radar` component. What they
+ * share is that the chart is theirs alone -- none of them sits on the x/y
+ * grid.
  */
 const OWNS_CHART: ReadonlySet<string> = new Set([
   ...SINGLE_VALUE,
@@ -120,6 +121,7 @@ const OWNS_CHART: ReadonlySet<string> = new Set([
   ...NETWORK,
   ...THEME_RIVER,
   ...PARALLEL,
+  ...RADAR,
 ]);
 
 /**
@@ -219,6 +221,11 @@ function readOwning(
     }
     if (PARALLEL.has(seriesModel.subType)) {
       const layer = parallelLayer(seriesModel, model);
+      return layer ? [layer] : [];
+    }
+    if (RADAR.has(seriesModel.subType)) {
+      const outlines = markPerSeries(container, drawnOutlineCount(seriesModel));
+      const layer = radarLayer(seriesModel, model, outlines);
       return layer ? [layer] : [];
     }
     const layer = hierarchyLayer(seriesModel, hierarchyMarks(seriesModel, container));

--- a/src/adapters/echarts/grid.ts
+++ b/src/adapters/echarts/grid.ts
@@ -304,8 +304,8 @@ function whole(value: unknown): number | null {
 }
 
 /*
- * `boxplot` and `radar` are measured and left for a later tier, both because
- * of how they are drawn rather than what they carry.
+ * `boxplot` is the one series type still refused, because of how it is drawn
+ * rather than what it carries.
  *
  * A **box plot** hands over its five-number summary outright --
  * `['base', 'min', 'Q1', 'median', 'Q3', 'max']` -- so the reading is easy and
@@ -315,12 +315,13 @@ function whole(value: unknown): number | null {
  * with. It is also painted `#fff`, which this adapter's paint filter counts as
  * furniture, so it would fail the mark check even if the shape fitted.
  *
- * A **radar** reports one dimension per indicator -- `['indicator_0', …]` --
- * and `RadarTrace` takes one selector per series, which would fit. What does
- * not is the count: measured, a two-series radar draws six vertex symbols and
- * also fills its alternating ring backgrounds, one of which (`rgb(234,237,245)`)
- * is neither furniture nor white, so seven marks are found where six are
- * expected and the check declines. Reading it without an outline is possible
- * and is what a later tier should do deliberately, rather than arriving there
- * by a count that happens to fail.
+ * A **radar** used to stand here beside it, and the reason recorded for it
+ * was wrong. It said a two-series radar draws six vertex symbols plus a ring
+ * background that is neither furniture nor white, so seven marks are found
+ * where six are expected. That counts the wrong mark class: `RadarTrace`
+ * wants one selector per *series*, and the filled marks are one per *vertex*
+ * -- three per series -- so they never fitted, ring background or not. The
+ * series outline is a **stroked** polyline, one per series, weighted and in
+ * the series colour, which is the shape `markPerSeries()` already finds for
+ * a line. See `radar.ts`; it is read, and highlighted.
  */

--- a/src/adapters/echarts/radar.ts
+++ b/src/adapters/echarts/radar.ts
@@ -1,0 +1,152 @@
+/**
+ * The ECharts `radar` series: one closed outline per observation, one spoke
+ * per indicator.
+ *
+ * It owns the chart the way a themeRiver or a parallel does -- it sits on a
+ * `radar` component rather than on the x/y grid -- but it is neither a set of
+ * bands over time nor a polyline across axes, so it gets its own module.
+ *
+ * Measured against **echarts 6.1.0** driven in Chromium.
+ */
+
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { EChartsModel, EChartsSeriesModel } from './types';
+import { TraceType } from '@type/grammar';
+import { nextId } from '../shared/selectorUtil';
+
+/** The series drawn around a `radar` component. */
+export const RADAR: ReadonlySet<string> = new Set(['radar']);
+
+/**
+ * Reads a `radar` as the multi-series outline it draws.
+ *
+ * Measured, the series carries one row per **observation** and one dimension
+ * per **indicator** -- `['indicator_0', 'indicator_1', 'indicator_2']` for a
+ * three-spoke chart -- with `getName(i)` answering the observation's name.
+ * The names the spokes are drawn under are not on the series at all; they are
+ * the `indicator` array of the `radar` component, which also carries the
+ * `min`/`max` ECharts resolved for each.
+ *
+ * Every point names its own spoke in `x` and its own series in `z`, which is
+ * the shape `RadarTrace` is navigated by -- each spoke a column, each series
+ * a row.
+ *
+ * **What made this look unreadable, and why it is not.** The refusal this
+ * replaces counted *filled* marks and found seven where six were expected:
+ * a two-series radar fills six vertex symbols (three per series) plus its
+ * alternating ring backgrounds, one of which (`rgb(234,237,245)`) is neither
+ * white nor furniture. But `RadarTrace` wants one selector **per series**,
+ * and the filled marks are one per *vertex* -- so they never fitted, ring
+ * background or not. What does fit is the series outline: a polyline that is
+ * stroked rather than filled, one per series, weighted and in the series
+ * colour.
+ *
+ *     stroked, unfilled, in a two-series radar
+ *       #dbdee4          the ring outline    unweighted -> furniture
+ *       #cfd2d7 x3       the spokes          unweighted -> furniture
+ *       #111199 width=2  series one          <- the mark
+ *       #229922 width=2  series two          <- the mark
+ *
+ * which is exactly the shape `markPerSeries()` already finds for `line`, and
+ * the grid furniture is unweighted so the existing filter drops it.
+ *
+ * @param seriesModel - The series to read
+ * @param model       - The chart's model, for the indicator names
+ * @param selectors   - One selector per series, when they were found
+ * @returns The layer, or `undefined` when nothing measurable was drawn
+ */
+export function radarLayer(
+  seriesModel: EChartsSeriesModel,
+  model: EChartsModel,
+  selectors: string[] | undefined,
+): MaidrLayer | undefined {
+  const data = seriesModel.getData();
+  const spokes = indicatorNames(model);
+
+  const observations: LinePoint[][] = [];
+  for (let index = 0; index < data.count(); index++) {
+    const series = data.getName(index) || `Series ${index + 1}`;
+    const row: LinePoint[] = [];
+    data.dimensions.forEach((dimension, column) => {
+      const value = data.get(dimension, index);
+      if (!measured(value)) {
+        return;
+      }
+      row.push({ x: spokes[column] || dimension, y: value, z: series });
+    });
+    if (row.length > 0) {
+      observations.push(row);
+    }
+  }
+
+  if (observations.length === 0) {
+    return undefined;
+  }
+
+  const name = text(seriesModel.get('name'));
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.RADAR,
+    ...(name ? { name } : {}),
+    // One selector per series, which is what `RadarTrace` reads. Withheld
+    // unless there is exactly one per series that was read -- a list that
+    // does not line up pairs every series with the wrong outline.
+    ...(selectors && selectors.length === observations.length
+      ? { selectors }
+      : {}),
+    // No x or y of the chart's own: every spoke is a column, and each point
+    // names the one it belongs to.
+    data: observations,
+  };
+}
+
+/**
+ * How many outlines the chart drew, which is how many marks to look for.
+ *
+ * Counted from the series rather than from the drawing, so the count the
+ * mark finder is given is the one the reading will use.
+ *
+ * @param seriesModel - The series to read
+ * @returns The number of observations
+ */
+export function drawnOutlineCount(seriesModel: EChartsSeriesModel): number {
+  return seriesModel.getData().count();
+}
+
+/**
+ * The names the spokes are drawn under.
+ *
+ * They live on the `radar` component's `indicator` array, in the order the
+ * series' dimensions are in. ECharts resolves a `min` and `max` onto each
+ * entry, but the name is the author's.
+ *
+ * @param model - The chart's model
+ * @returns One name per spoke, empty where the author wrote none
+ */
+function indicatorNames(model: EChartsModel): string[] {
+  const names: string[] = [];
+  model.eachComponent({ mainType: 'radar' }, (component, index) => {
+    if (index !== 0) {
+      return;
+    }
+    const indicator = component.get('indicator');
+    if (!Array.isArray(indicator)) {
+      return;
+    }
+    indicator.forEach((entry, at) => {
+      names[at] = entry !== null && typeof entry === 'object' && 'name' in entry
+        ? text((entry as { name?: unknown }).name)
+        : '';
+    });
+  });
+  return names;
+}
+
+function measured(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined && Number.isFinite(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -18,9 +18,9 @@
  * xability/maidr#1195), three carry one magnitude per named thing (tier 2a),
  * two hand over a set of magnitudes already computed (tier 2b), five carry a
  * hierarchy or a graph (tier 3), `pictorialBar` is a bar wearing a symbol,
- * and `themeRiver` and `parallel` own the chart but are read as a set of
- * series. `boxplot` and `radar` are the two still refused by name, so that
- * gaining a reading later is a decision rather than an accident.
+ * and `themeRiver`, `parallel` and `radar` own the chart but are read as a
+ * set of series. `boxplot` is the one still refused by name, so that gaining
+ * a reading later is a decision rather than an accident.
  *
  * Kept in step with `READ` in `converters.ts`, which is what actually
  * decides -- this type is the public statement of it, and
@@ -42,7 +42,8 @@ export type EChartsSeriesType
     | 'graph'
     | 'pictorialBar'
     | 'themeRiver'
-    | 'parallel';
+    | 'parallel'
+    | 'radar';
 
 /**
  * One column of a series' internal data list.

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -449,6 +449,7 @@ describe('what the adapter says it reads', () => {
     'pictorialBar',
     'themeRiver',
     'parallel',
+    'radar',
   ] as const;
 
   type Declared = typeof DECLARED[number];
@@ -522,14 +523,15 @@ describe('what the adapter will not claim', () => {
   it('refuses a chart of series it has no reading for', () => {
     // By name, rather than mapped onto whichever trace is closest. ECharts
     // draws seventeen series types and each wanted its own measured layout
-    // first (#1195). `pie` used to stand here, then `treemap`; both read now.
-    // `radar` is one of the five left, and its own reason is recorded in
-    // `grid.ts` -- its ring backgrounds are neither furniture nor white, so
-    // it finds seven marks where six were expected.
+    // first (#1195). `pie` used to stand here, then `treemap`, then `radar`;
+    // all three read now. `boxplot` is the last one left, and its reason is
+    // recorded in `grid.ts` -- `BoxSelector` wants a selector per part and
+    // ECharts draws the box and both whiskers as one path, so there is
+    // nothing to name the parts with.
     expect(() => layersOf(
-      { series: [{ type: 'radar', values: [1, 2, 3] }] },
+      { series: [{ type: 'boxplot', values: [1, 2, 3] }] },
       drawnChart(3, 0),
-    )).toThrow(/Unsupported ECharts series type\(s\): radar/);
+    )).toThrow(/Unsupported ECharts series type\(s\): boxplot/);
   });
 
   it('drops the highlighting when the drawing holds a different number of marks', () => {

--- a/test/adapters/echarts/radar.test.ts
+++ b/test/adapters/echarts/radar.test.ts
@@ -1,0 +1,241 @@
+import type {
+  EChartsComponentModel,
+  EChartsInstance,
+  EChartsList,
+  EChartsSeriesModel,
+} from '@adapters/echarts/types';
+import type { LinePoint } from '@type/grammar';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * A radar was refused by name, and the reason recorded for it was wrong.
+ *
+ * `grid.ts`'s footer said a two-series radar draws "six vertex symbols and
+ * also fills its alternating ring backgrounds, one of which
+ * (`rgb(234,237,245)`) is neither furniture nor white, so seven marks are
+ * found where six are expected". That counts the wrong mark class:
+ * `RadarTrace` wants one selector **per series**, and the filled marks are
+ * one per *vertex* -- three per series -- so they never fitted, ring
+ * background or not.
+ *
+ * Measured by colour-tagging a two-series, three-indicator radar, the series
+ * outline is a *stroked* polyline, one per series, weighted and in the series
+ * colour, with the ring and spokes unweighted beside it:
+ *
+ *     #dbdee4          ring outline   unweighted -> furniture
+ *     #cfd2d7 x3       spokes         unweighted -> furniture
+ *     #111199 width=2  series one     <- the mark
+ *     #229922 width=2  series two     <- the mark
+ *
+ * which is the shape `markPerSeries()` already finds for a line. The fixture
+ * below draws exactly that.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** One observation: a name and a reading per indicator. */
+interface Observation {
+  name: string;
+  values: (number | null)[];
+}
+
+function radarChart(
+  observations: Observation[],
+  indicators: (string | null)[],
+  seriesName?: string,
+): EChartsInstance {
+  const dimensions = indicators.map((_, column) => `indicator_${column}`);
+  const list: EChartsList = {
+    dimensions,
+    count: () => observations.length,
+    getName: index => observations[index].name,
+    get: (dimension, index) =>
+      observations[index].values[dimensions.indexOf(dimension)],
+  };
+
+  const series: EChartsSeriesModel = {
+    subType: 'radar',
+    name: seriesName ?? 'series 0',
+    getData: () => list,
+    get: key => (key === 'name' ? seriesName : undefined),
+  };
+
+  const components: Record<string, Record<string, unknown>[]> = {
+    radar: [{
+      indicator: indicators.map(name =>
+        (name === null ? { max: 10 } : { name, max: 10 })),
+    }],
+  };
+
+  return {
+    getModel: () => ({
+      eachSeries: callback => callback(series, 0),
+      eachComponent: (query, callback) => {
+        (components[query.mainType] ?? []).forEach((options, index) => {
+          const component: EChartsComponentModel = { get: key => options[key] };
+          callback(component, index);
+        });
+      },
+    }),
+  };
+}
+
+/**
+ * A drawn radar: `outlines` weighted strokes in the series colour, plus the
+ * furniture the detection was measured against -- the unweighted ring and
+ * spokes, and the filled vertex symbols and ring backgrounds that the old
+ * refusal counted.
+ */
+function drawnRadar(outlines: number): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('chart') as HTMLElement;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+
+  const add = (attributes: Record<string, string>): void => {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    Object.entries(attributes).forEach(([key, value]) =>
+      path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  // The ring backgrounds: one white, one not. Both filled, neither a mark.
+  add({ fill: 'rgb(255,255,255)' });
+  add({ fill: 'rgb(234,237,245)' });
+  // The ring outline and the spokes: stroked but unweighted.
+  add({ fill: 'none', stroke: '#dbdee4' });
+  add({ fill: 'none', stroke: '#cfd2d7' });
+  add({ fill: 'none', stroke: '#cfd2d7' });
+  add({ fill: 'none', stroke: '#cfd2d7' });
+  // The vertex symbols: filled, three per outline. What the old count found.
+  for (let index = 0; index < outlines * 3; index++) {
+    add({ fill: '#5070dd' });
+  }
+  // The series outlines: stroked and weighted. What the reading pairs.
+  for (let index = 0; index < outlines; index++) {
+    add({ 'fill': 'none', 'stroke': '#5070dd', 'stroke-width': '2' });
+  }
+
+  container.appendChild(svg);
+  return container;
+}
+
+function layersOf(chart: EChartsInstance, container: HTMLElement) {
+  return createMaidrFromEChart(chart, container).subplots[0][0].layers;
+}
+
+const INDICATORS = ['alpha', 'beta', 'gamma'];
+const TWO: Observation[] = [
+  { name: 'one', values: [1, 2, 3] },
+  { name: 'two', values: [4, 5, 6] },
+];
+
+describe('an eCharts radar', () => {
+  it('is read as the radar it draws rather than refused', () => {
+    // The reproduction: before this, `createMaidrFromEChart` threw
+    // "Unsupported ECharts series type(s): radar" and the page lost its
+    // reading outright.
+    const layers = layersOf(radarChart(TWO, INDICATORS, 'R'), drawnRadar(2));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.RADAR);
+    expect(layers[0].name).toBe('R');
+  });
+
+  it('gives each observation a row and each indicator a point', () => {
+    const data = layersOf(
+      radarChart(TWO, INDICATORS),
+      drawnRadar(2),
+    )[0].data as LinePoint[][];
+
+    expect(data).toHaveLength(2);
+    expect(data[0]).toEqual([
+      { x: 'alpha', y: 1, z: 'one' },
+      { x: 'beta', y: 2, z: 'one' },
+      { x: 'gamma', y: 3, z: 'one' },
+    ]);
+  });
+
+  it('names every point with the observation it belongs to', () => {
+    // `z` is how a reader tells the outlines apart, and `getName()` is the
+    // only place the observation's name lives.
+    const data = layersOf(
+      radarChart(TWO, INDICATORS),
+      drawnRadar(2),
+    )[0].data as LinePoint[][];
+
+    expect(data[1].every(point => point.z === 'two')).toBe(true);
+  });
+
+  it('names the spokes from the radar component, not from the series', () => {
+    // The series' own dimensions are `indicator_0`, `indicator_1`, … --
+    // positions, not names. Announcing those would tell a reader nothing
+    // about what each spoke measures.
+    const data = layersOf(
+      radarChart(TWO, INDICATORS),
+      drawnRadar(2),
+    )[0].data as LinePoint[][];
+
+    expect(data[0].map(point => point.x)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('falls back to the column name for an unnamed indicator', () => {
+    const data = layersOf(
+      radarChart([{ name: 'solo', values: [1, 2] }], ['named', null]),
+      drawnRadar(1),
+    )[0].data as LinePoint[][];
+
+    expect(data[0].map(point => point.x)).toEqual(['named', 'indicator_1']);
+  });
+
+  it('names an unnamed observation by position rather than not at all', () => {
+    const data = layersOf(
+      radarChart([{ name: '', values: [1, 2, 3] }], INDICATORS),
+      drawnRadar(1),
+    )[0].data as LinePoint[][];
+
+    expect(data[0][0].z).toBe('Series 1');
+  });
+
+  it('drops a spoke the observation had no reading for', () => {
+    // One point shorter rather than a fabricated zero; the points that remain
+    // still name their own spokes, so the rest stay put.
+    const data = layersOf(
+      radarChart([{ name: 'solo', values: [1, null, 3] }], INDICATORS),
+      drawnRadar(1),
+    )[0].data as LinePoint[][];
+
+    expect(data[0]).toEqual([
+      { x: 'alpha', y: 1, z: 'solo' },
+      { x: 'gamma', y: 3, z: 'solo' },
+    ]);
+  });
+
+  it('takes one selector per outline, not one per vertex', () => {
+    // The correction this reading rests on. The fixture draws six filled
+    // vertex symbols and two weighted strokes; the reading must pair the
+    // strokes, because `RadarTrace` reads one selector per series.
+    const layer = layersOf(radarChart(TWO, INDICATORS), drawnRadar(2))[0];
+
+    expect(Array.isArray(layer.selectors)).toBe(true);
+    expect(layer.selectors).toHaveLength(2);
+  });
+
+  it('withholds the selectors when they do not line up with the rows', () => {
+    // A list that does not match pairs every series with the wrong outline,
+    // which is worse than no highlighting at all.
+    const layer = layersOf(radarChart(TWO, INDICATORS), drawnRadar(3))[0];
+
+    expect(layer.selectors).toBeUndefined();
+  });
+
+  it('emits no layer when no observation had a reading', () => {
+    expect(layersOf(
+      radarChart([{ name: 'empty', values: [null, null, null] }], INDICATORS),
+      drawnRadar(1),
+    )).toHaveLength(0);
+  });
+});

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -368,17 +368,17 @@ describe('a chart that declares both families', () => {
 });
 
 describe('an eCharts chart of a type outside the set', () => {
-  // `treemap` stood here until tier 3 gave it a reading. `radar` is one of
-  // the five still refused, and it has its own measured reason: its ring
-  // backgrounds are neither furniture nor white, so it finds seven marks
-  // where six were expected.
+  // `treemap` stood here until tier 3 gave it a reading, then `radar` until
+  // its outline turned out to be a stroked polyline after all. `boxplot` is
+  // the last one refused: `BoxSelector` wants a selector per part and
+  // ECharts draws the box and both whiskers as one path.
   it('is refused rather than read as whichever trace is closest', () => {
-    expect(() => layerFor({ type: 'radar', values: [1] }, 1))
+    expect(() => layerFor({ type: 'boxplot', values: [1] }, 1))
       .toThrow(/Unsupported ECharts series type/);
   });
 
   it('names the single-value types among the ones it does read', () => {
-    expect(() => layerFor({ type: 'radar', values: [1] }, 1))
+    expect(() => layerFor({ type: 'boxplot', values: [1] }, 1))
       .toThrow(/pie, funnel, gauge/);
   });
 });


### PR DESCRIPTION
## What

A `radar` was refused by name — and **the reason recorded for it was wrong**.
It is now read, and highlighted. That takes the adapter to **16 of ECharts'
17** series types; `boxplot` is the last one refused.

## The refusal counted the wrong mark class

`grid.ts`'s footer said:

> a two-series radar draws six vertex symbols and also fills its alternating
> ring backgrounds, one of which (`rgb(234,237,245)`) is neither furniture nor
> white, so seven marks are found where six are expected

`RadarTrace` wants one selector per **series**. The filled marks are one per
**vertex** — three per series — so they never fitted, ring background or not.
Excluding the ring background would have produced six marks for two series and
still been wrong.

Colour-tagging a two-series, three-indicator radar (each series given its own
`itemStyle.color`) shows what actually fits:

```
FILLED    rgb(234,237,245)  ring background
          rgb(255,255,255)  ring background   (white -> furniture)
          #111199 x3        series one's vertex symbols
          #229922 x3        series two's vertex symbols
STROKED   #dbdee4           ring outline      unweighted -> furniture
          #cfd2d7 x3        spokes            unweighted -> furniture
          #111199 width=2   series one        <- the mark
          #229922 width=2   series two        <- the mark
```

One weighted stroke per series, in the series colour — exactly the shape
`markPerSeries()` already finds for a `line`, and the grid furniture is
unweighted so the existing filter drops it. Nothing new was needed to locate
them.

## The reading

The series carries one row per observation and one dimension per indicator
(`['indicator_0', 'indicator_1', …]`), with `getName(i)` answering the
observation's name. The spoke names are **not on the series** — they are the
`indicator` array of the `radar` component. Announcing the series' own
dimensions would tell a reader nothing about what each spoke measures.

Every point names its own spoke in `x` and its own series in `z`, which is how
`RadarTrace` is navigated: each spoke a column, each series a row.

Selectors are withheld unless there is exactly one per row that was read — a
list that does not line up pairs every series with the wrong outline, which is
worse than no highlighting at all.

## Verification

Live against real echarts 6.1.0 in Chromium, through the bundled adapter:

```json
{"type":"radar","name":"R",
 "data":[[{"x":"alpha","y":1,"z":"one"},{"x":"beta","y":2,"z":"one"},{"x":"gamma","y":3,"z":"one"}],
         [{"x":"alpha","y":4,"z":"two"},{"x":"beta","y":5,"z":"two"},{"x":"gamma","y":6,"z":"two"}]],
 "selectors":2,"resolved":2}
```

Both selectors resolve. A gappy observation (`[1, null, 3]`) drops the middle
spoke and still resolves 1/1.

Three existing tests used `radar` as their example of a refused type and
failed on the first run; they now use `boxplot`. `grid.ts`'s footer and
`docs/echarts.md` are corrected to record what was actually measured, rather
than leaving the wrong reason in place.

Full gate green: `eslint src test scripts`, `tsc --noEmit`, `npm test`
(**5934** unit + esm + component, all passing — 10 new), `npm run build`,
`npm run docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_