### PR TITLE
feat(echarts): read a box plot, without the outline it cannot give

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -53,9 +53,10 @@ Two things this example does on purpose:
 | `scatter` | `point` | A `symbolSize` reading a third column becomes `ScatterPoint.z`, which is audible |
 | `pictorialBar` | `bar` | A bar drawn with a symbol instead of a rectangle; read as the bar it is |
 
-**Not yet supported:** `boxplot` alone. It is *refused by name* rather than
-mapped onto whichever trace is closest, and the footer of
-`src/adapters/echarts/grid.ts` records what stands in the way. See
+**Every series type the adapter has measured now has a reading.** A type
+outside that set is still refused *by name* rather than mapped onto whichever
+trace is closest — an ECharts extension such as `wordCloud` registers its own,
+and core gains types between releases. See
 [#1195](https://github.com/xability/maidr/issues/1195) for the tiers.
 
 > **Orientation note:** ECharts has no "horizontal" option. A bar chart is
@@ -104,6 +105,7 @@ drawing:
 |---|---|---|---|
 | `heatmap` | `['x', 'y', 'value']` | `heat` | yes — a selector per cell |
 | `candlestick` | `['base', 'open', 'close', 'lowest', 'highest']` | `candlestick` | yes — a selector per candle |
+| `boxplot` | `['base', 'min', 'Q1', 'median', 'Q3', 'max']` | `box` | **no** — see below |
 
 Both draw exactly one filled mark per datum — a cell, a candle body with its
 wick — which is the same shape the bar reading already counts and stamps.
@@ -124,6 +126,28 @@ selector.
 every other candlestick producer in this tree. A period missing any of the four
 prices draws no candle, so it is left out of the reading entirely — counting it
 would expect a mark that was never drawn.
+
+**A box plot is read but not outlined.** The values need no deriving — the
+five-number summary arrives already computed. The *highlight* is what cannot
+be had: `BoxSelector` wants a selector per part (the whiskers, the box, the
+median, each outlier) and ECharts draws all of them as **one path**.
+Colour-tagged, a two-box chart yields exactly two filled paths, and each `d`
+runs box-rectangle, `Z`, then the whiskers:
+
+```
+M177.5 234.59 L227.5 234.59 L227.5 150.41 L177.5 150.41 Z M202.5 27…
+```
+
+There is nothing to name the parts with. The default paint is also `#fff`,
+which the mark filter counts as furniture, so the mark would be dropped even
+if the shape fitted.
+
+**Its outliers are empty, because the series carries none.** ECharts draws
+them as a *separate* `scatter` series by its own convention — there is no
+seventh dimension holding them. An accompanying scatter is read as the
+scatter it is, and keeps its own highlighting: the boxplot is deliberately
+excluded from the per-datum mark pool, so it cannot spend a slot and shift
+the scatter's selectors onto the wrong elements.
 
 ## Hierarchies and graphs
 

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -18,6 +18,7 @@ import type {
 import { Orientation, TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
 import {
+  boxplotLayer,
   candlestickLayer,
   categoriesOf,
   drawnCandleCount,
@@ -83,9 +84,14 @@ const BAR: ReadonlySet<string> = new Set(['bar', 'pictorialBar']);
 /**
  * Everything the adapter reads.
  *
- * ECharts draws seventeen series types. The one still outside this set --
- * `boxplot` -- is left unread **by name** rather than mapped onto whichever
- * trace is closest; `grid.ts`'s footer records what stands in the way.
+ * Every series type this adapter has measured now has a reading, so nothing
+ * is refused for want of one. A type outside this set is still refused **by
+ * name** rather than mapped onto whichever trace is closest -- an ECharts
+ * extension such as `wordCloud` registers its own, and core gains types
+ * between releases.
+ *
+ * Two of the readings carry no outline, for reasons measured off the drawing
+ * rather than assumed; `grid.ts`'s footer records both.
  *
  * Exported because `EChartsSeriesType` is the public statement of this set
  * and the two have to agree. They drifted once already: tier 2b added
@@ -324,7 +330,11 @@ function buildLayers(
   // the series were declared. A heat cell and a candle body join that pool:
   // both are one filled mark per datum, which is the only thing the count
   // check asks of a series.
-  const marked = series.filter(seriesModel => seriesModel.subType !== 'line');
+  // A boxplot is excluded alongside a line: it paints one path per box, but
+  // that path is box AND whiskers together, which no selector shape wants --
+  // counting it would spend a slot and shift every later series' marks.
+  const marked = series.filter(seriesModel =>
+    seriesModel.subType !== 'line' && seriesModel.subType !== 'boxplot');
   const perDatum = markPerDatum(
     container,
     marked.map(seriesModel => drawnMarks(seriesModel, axes, grid)),
@@ -389,6 +399,9 @@ function otherLayer(
       return heatmapLayer(seriesModel, grid, axes, eachMark);
     case 'candlestick':
       return candlestickLayer(seriesModel, axes, eachMark);
+    case 'boxplot':
+      // Read without an outline; `grid.ts` records what was measured.
+      return boxplotLayer(seriesModel, axes);
     default:
       return scatterLayer(seriesModel, axes, wholeSeries);
   }

--- a/src/adapters/echarts/grid.ts
+++ b/src/adapters/echarts/grid.ts
@@ -18,11 +18,16 @@
  */
 
 import type {
+  BoxPoint,
   CandlestickPoint,
   HeatmapData,
   MaidrLayer,
 } from '@type/grammar';
-import type { EChartsComponentModel, EChartsSeriesModel } from './types';
+import type {
+  EChartsComponentModel,
+  EChartsList,
+  EChartsSeriesModel,
+} from './types';
 import { TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
 
@@ -30,6 +35,7 @@ import { nextId } from '../shared/selectorUtil';
 export const GRID_VALUE: ReadonlySet<string> = new Set([
   'heatmap',
   'candlestick',
+  'boxplot',
 ]);
 
 /** The category names an axis was drawn with, in axis order. */
@@ -303,19 +309,113 @@ function whole(value: unknown): number | null {
   return value;
 }
 
+/**
+ * Reads a `boxplot` as the five-number summary it hands over.
+ *
+ * Measured, the series carries `['base', 'min', 'Q1', 'median', 'Q3', 'max']`
+ * with one row per box and `getName(i)` answering the category, so the
+ * reading is a transcription -- nothing is derived from the drawing.
+ *
+ * **It is read without an outline, and that is a property of the drawing
+ * rather than a gap in the measurement.** `BoxSelector` wants one selector
+ * for each part -- the whiskers, the box, the median, each outlier -- and ECharts
+ * draws all of them as **one path**. Colour-tagged, a two-box chart yields
+ * exactly two filled paths, and each one's `d` is the box rectangle, a `Z`,
+ * and then the whiskers:
+ *
+ *     M177.5 234.59 L227.5 234.59 L227.5 150.41 L177.5 150.41 Z M202.5 27...
+ *
+ * There is nothing to name the parts with. On top of that the default paint
+ * is `#fff`, which this adapter's filter counts as furniture, so the mark
+ * would be dropped even if the shape fitted. Reading without an outline is
+ * what `gauge`, `sankey`, `graph`, `parallel` and `themeRiver` already do
+ * here: the values, the text and the braille all still work; only the
+ * highlight is absent.
+ *
+ * **Outliers are empty rather than guessed.** ECharts draws them as a
+ * separate `scatter` series by its own convention, so a boxplot series
+ * carries none of them -- there is no seventh dimension holding them. An
+ * accompanying scatter is read as the scatter it is.
+ *
+ * @param seriesModel - The series to read
+ * @param names       - The axis titles
+ * @returns The layer
+ */
+export function boxplotLayer(
+  seriesModel: EChartsSeriesModel,
+  names: AxisNames,
+): MaidrLayer {
+  const data = seriesModel.getData();
+  const points: BoxPoint[] = [];
+
+  for (let index = 0; index < data.count(); index++) {
+    const summary = summaryOf(data, index);
+    if (!summary) {
+      continue;
+    }
+    points.push({
+      z: data.getName(index) || `${index + 1}`,
+      // ECharts draws outliers as a separate series; see the note above.
+      lowerOutliers: [],
+      min: summary.min,
+      q1: summary.q1,
+      q2: summary.q2,
+      q3: summary.q3,
+      max: summary.max,
+      upperOutliers: [],
+    });
+  }
+
+  const named = seriesModel.get('name');
+  const name = typeof named === 'string' ? named : '';
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.BOX,
+    ...(name ? { name } : {}),
+    axes: {
+      x: { label: names.x || undefined },
+      y: { label: names.y || undefined },
+    },
+    data: points,
+  };
+}
+
+/**
+ * One box's five numbers, or `undefined` when it is short of them.
+ *
+ * @param data  - The series' data list
+ * @param index - The box to read
+ * @returns The summary, or `undefined` when any of the five is missing
+ */
+function summaryOf(
+  data: EChartsList,
+  index: number,
+): { min: number; q1: number; q2: number; q3: number; max: number } | undefined {
+  const min = data.get('min', index);
+  const q1 = data.get('Q1', index);
+  const q2 = data.get('median', index);
+  const q3 = data.get('Q3', index);
+  const max = data.get('max', index);
+  if (
+    !measured(min) || !measured(q1) || !measured(q2)
+    || !measured(q3) || !measured(max)
+  ) {
+    return undefined;
+  }
+  return { min, q1, q2, q3, max };
+}
+
 /*
- * `boxplot` is the one series type still refused, because of how it is drawn
- * rather than what it carries.
+ * Every one of ECharts' seventeen series types now has a reading.
  *
- * A **box plot** hands over its five-number summary outright --
- * `['base', 'min', 'Q1', 'median', 'Q3', 'max']` -- so the reading is easy and
- * the highlighting is not: `BoxSelector` wants a selector per part (the
- * whiskers, the box, the median, each outlier), and ECharts draws the whole
- * box and both whiskers as **one path**. There is nothing to name the parts
- * with. It is also painted `#fff`, which this adapter's paint filter counts as
- * furniture, so it would fail the mark check even if the shape fitted.
+ * Two of them are read **without an outline**, and both for reasons measured
+ * rather than assumed. A `boxplot` draws its box and both whiskers as one
+ * path, so there is nothing to give `BoxSelector` its per-part selectors --
+ * see `boxplotLayer` above. A `parallel` strokes its polylines rather than
+ * filling them, so the mark finder pairs nothing.
  *
- * A **radar** used to stand here beside it, and the reason recorded for it
+ * A **radar** used to stand here as refused, and the reason recorded for it
  * was wrong. It said a two-series radar draws six vertex symbols plus a ring
  * background that is neither furniture nor white, so seven marks are found
  * where six are expected. That counts the wrong mark class: `RadarTrace`
@@ -324,4 +424,8 @@ function whole(value: unknown): number | null {
  * series outline is a **stroked** polyline, one per series, weighted and in
  * the series colour, which is the shape `markPerSeries()` already finds for
  * a line. See `radar.ts`; it is read, and highlighted.
+ *
+ * The lesson generalises, and is why the boxplot note above records the `d`
+ * attribute it was measured from: a refusal is a claim about the drawing,
+ * and it has to be checked against the drawing rather than carried forward.
  */

--- a/src/adapters/echarts/types.ts
+++ b/src/adapters/echarts/types.ts
@@ -14,13 +14,15 @@
 /**
  * The series types this adapter reads.
  *
- * ECharts draws seventeen. Three are the cartesian ones (tier 1 of
+ * Three are the cartesian ones (tier 1 of
  * xability/maidr#1195), three carry one magnitude per named thing (tier 2a),
  * two hand over a set of magnitudes already computed (tier 2b), five carry a
  * hierarchy or a graph (tier 3), `pictorialBar` is a bar wearing a symbol,
- * and `themeRiver`, `parallel` and `radar` own the chart but are read as a
- * set of series. `boxplot` is the one still refused by name, so that gaining
- * a reading later is a decision rather than an accident.
+ * `themeRiver`, `parallel` and `radar` own the chart but are read as a set of
+ * series, and `boxplot` hands over a five-number summary. Two of them are
+ * read without an outline, which `grid.ts` records. A type outside this
+ * union is refused by name, so gaining a reading later is a decision rather
+ * than an accident.
  *
  * Kept in step with `READ` in `converters.ts`, which is what actually
  * decides -- this type is the public statement of it, and
@@ -43,7 +45,8 @@ export type EChartsSeriesType
     | 'pictorialBar'
     | 'themeRiver'
     | 'parallel'
-    | 'radar';
+    | 'radar'
+    | 'boxplot';
 
 /**
  * One column of a series' internal data list.

--- a/test/adapters/echarts/boxplot.test.ts
+++ b/test/adapters/echarts/boxplot.test.ts
@@ -1,0 +1,239 @@
+import type {
+  EChartsInstance,
+  EChartsList,
+  EChartsSeriesModel,
+} from '@adapters/echarts/types';
+import type { BoxPoint } from '@type/grammar';
+import { createMaidrFromEChart } from '@adapters/echarts/converters';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * A box plot was refused by name, and unlike `radar` the reason recorded for
+ * it was right — but it was the reason to withhold the *outline*, not the
+ * reason to withhold the *reading*.
+ *
+ * ECharts hands the five-number summary over outright, as
+ * `['base', 'min', 'Q1', 'median', 'Q3', 'max']`, so the values need no
+ * deriving. What cannot be had is the highlight: `BoxSelector` wants a
+ * selector per part and ECharts draws box and both whiskers as one path.
+ * Colour-tagged, a two-box chart yields exactly two filled paths, each `d`
+ * running box-rectangle, `Z`, then whiskers:
+ *
+ *     M177.5 234.59 L227.5 234.59 L227.5 150.41 L177.5 150.41 Z M202.5 27…
+ *
+ * So it is read without an outline, which is what `gauge`, `sankey`, `graph`,
+ * `parallel` and `themeRiver` already do.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** One box: a category and its five numbers, any of which may be missing. */
+interface Box {
+  name: string;
+  values: (number | null)[];
+}
+
+const DIMENSIONS = ['base', 'min', 'Q1', 'median', 'Q3', 'max'];
+
+function boxplotChart(
+  boxes: Box[],
+  options: { seriesName?: string; xName?: string; yName?: string } = {},
+): EChartsInstance {
+  const list: EChartsList = {
+    dimensions: DIMENSIONS,
+    count: () => boxes.length,
+    getName: index => boxes[index].name,
+    get: (dimension, index) =>
+      boxes[index].values[DIMENSIONS.indexOf(dimension)],
+  };
+
+  const series: EChartsSeriesModel = {
+    subType: 'boxplot',
+    name: options.seriesName ?? 'series 0',
+    getData: () => list,
+    get: key => (key === 'name' ? options.seriesName : undefined),
+  };
+
+  const components: Record<string, Record<string, unknown>[]> = {
+    xAxis: [{ name: options.xName, type: 'category' }],
+    yAxis: [{ name: options.yName, type: 'value' }],
+    title: [],
+  };
+
+  return {
+    getModel: () => ({
+      eachSeries: callback => callback(series, 0),
+      eachComponent: (query, callback) => {
+        (components[query.mainType] ?? []).forEach((opts, index) =>
+          callback({ get: key => opts[key] }, index));
+      },
+    }),
+  };
+}
+
+/** A drawn box plot: `boxes` filled paths, plus the gridlines around them. */
+function drawnBoxplot(boxes: number): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('chart') as HTMLElement;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+
+  const add = (attributes: Record<string, string>): void => {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    Object.entries(attributes).forEach(([key, value]) =>
+      path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  add({ fill: 'none', stroke: '#dbdee4' });
+  add({ fill: 'none', stroke: '#54555a' });
+  // One filled path per box — box AND whiskers together.
+  for (let index = 0; index < boxes; index++) {
+    add({ fill: '#5070dd', stroke: '#5070dd' });
+  }
+
+  container.appendChild(svg);
+  return container;
+}
+
+function layersOf(chart: EChartsInstance, container: HTMLElement) {
+  return createMaidrFromEChart(chart, container).subplots[0][0].layers;
+}
+
+const TWO: Box[] = [
+  { name: 'A', values: [0, 1, 2, 3, 4, 5] },
+  { name: 'B', values: [1, 2, 3, 4, 5, 6] },
+];
+
+describe('an eCharts box plot', () => {
+  it('is read as a box rather than refused', () => {
+    // The reproduction: before this, `createMaidrFromEChart` threw
+    // "Unsupported ECharts series type(s): boxplot".
+    const layers = layersOf(boxplotChart(TWO, { seriesName: 'B' }), drawnBoxplot(2));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.BOX);
+    expect(layers[0].name).toBe('B');
+  });
+
+  it('transcribes the five numbers it was handed', () => {
+    // Nothing is derived from the drawing: the summary is already computed,
+    // and `min`/`Q1`/`median`/`Q3`/`max` map straight onto the trace.
+    const data = layersOf(boxplotChart(TWO), drawnBoxplot(2))[0].data as BoxPoint[];
+
+    expect(data).toHaveLength(2);
+    expect(data[0]).toEqual({
+      z: 'A',
+      lowerOutliers: [],
+      min: 1,
+      q1: 2,
+      q2: 3,
+      q3: 4,
+      max: 5,
+      upperOutliers: [],
+    });
+  });
+
+  it('names each box by its category', () => {
+    const data = layersOf(boxplotChart(TWO), drawnBoxplot(2))[0].data as BoxPoint[];
+
+    expect(data.map(box => box.z)).toEqual(['A', 'B']);
+  });
+
+  it('names an unnamed box by position rather than not at all', () => {
+    const data = layersOf(
+      boxplotChart([{ name: '', values: [0, 1, 2, 3, 4, 5] }]),
+      drawnBoxplot(1),
+    )[0].data as BoxPoint[];
+
+    expect(data[0].z).toBe('1');
+  });
+
+  it('carries no outliers, because the series holds none', () => {
+    // ECharts draws outliers as a SEPARATE scatter series by its own
+    // convention, so a boxplot series has no dimension holding them.
+    // Inventing any would announce marks this series never drew.
+    const data = layersOf(boxplotChart(TWO), drawnBoxplot(2))[0].data as BoxPoint[];
+
+    expect(data.every(box => box.lowerOutliers.length === 0)).toBe(true);
+    expect(data.every(box => box.upperOutliers.length === 0)).toBe(true);
+  });
+
+  it('drops a box short of one of its five numbers', () => {
+    // Half a summary is not a box: announcing it would put a `null` where a
+    // quartile belongs and read as a value.
+    const data = layersOf(
+      boxplotChart([
+        { name: 'whole', values: [0, 1, 2, 3, 4, 5] },
+        { name: 'partial', values: [1, 2, null, 4, 5, 6] },
+      ]),
+      drawnBoxplot(2),
+    )[0].data as BoxPoint[];
+
+    expect(data.map(box => box.z)).toEqual(['whole']);
+  });
+
+  it('is read without an outline', () => {
+    // Measured: box and both whiskers are one path, so there is nothing to
+    // give `BoxSelector` its per-part selectors. The fixture draws exactly
+    // that — one filled path per box — and the reading still declines it.
+    expect(layersOf(boxplotChart(TWO), drawnBoxplot(2))[0].selectors)
+      .toBeUndefined();
+  });
+
+  it('does not consume a mark slot from a series drawn beside it', () => {
+    // The failure this guards: a boxplot's one-path-per-box would otherwise
+    // be counted into the per-datum mark pool, spending slots and shifting
+    // every later series' selectors onto the wrong elements.
+    const chart: EChartsInstance = {
+      getModel: () => ({
+        eachSeries: (callback) => {
+          const boxes: EChartsList = {
+            dimensions: DIMENSIONS,
+            count: () => 2,
+            getName: index => TWO[index].name,
+            get: (dimension, index) =>
+              TWO[index].values[DIMENSIONS.indexOf(dimension)],
+          };
+          callback({
+            subType: 'boxplot',
+            name: 'boxes',
+            getData: () => boxes,
+            get: () => undefined,
+          }, 0);
+
+          const bars: EChartsList = {
+            dimensions: ['x', 'y'],
+            count: () => 3,
+            getName: index => ['p', 'q', 'r'][index],
+            get: (dimension, index) => (dimension === 'y' ? [7, 8, 9][index] : index),
+          };
+          callback({
+            subType: 'bar',
+            name: 'bars',
+            getData: () => bars,
+            get: () => undefined,
+          }, 1);
+        },
+        eachComponent: (query, callback) => {
+          const components: Record<string, Record<string, unknown>[]> = {
+            xAxis: [{ type: 'category' }],
+            yAxis: [{ type: 'value' }],
+            title: [],
+          };
+          (components[query.mainType] ?? []).forEach((opts, index) =>
+            callback({ get: key => opts[key] }, index));
+        },
+      }),
+    };
+
+    // Three bar marks drawn, and nothing else the pool should see.
+    const layers = layersOf(chart, drawnBoxplot(3));
+    const bar = layers.find(layer => layer.type === TraceType.BAR);
+
+    expect(bar).toBeDefined();
+    expect(bar?.selectors).toHaveLength(3);
+  });
+});

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -450,6 +450,7 @@ describe('what the adapter says it reads', () => {
     'themeRiver',
     'parallel',
     'radar',
+    'boxplot',
   ] as const;
 
   type Declared = typeof DECLARED[number];
@@ -522,16 +523,17 @@ describe('an eCharts pictorial bar', () => {
 describe('what the adapter will not claim', () => {
   it('refuses a chart of series it has no reading for', () => {
     // By name, rather than mapped onto whichever trace is closest. ECharts
-    // draws seventeen series types and each wanted its own measured layout
-    // first (#1195). `pie` used to stand here, then `treemap`, then `radar`;
-    // all three read now. `boxplot` is the last one left, and its reason is
-    // recorded in `grid.ts` -- `BoxSelector` wants a selector per part and
-    // ECharts draws the box and both whiskers as one path, so there is
-    // nothing to name the parts with.
+    // and each wanted its own measured layout first (#1195). `pie` stood
+    // here, then `treemap`, then `radar`, then `boxplot` -- all read now.
+    // The subject is no longer a core type but one from outside it:
+    // `wordCloud` is an ECharts *extension*, which core does not register
+    // and this adapter has never measured. That is the case that has to keep
+    // refusing, and unlike the others it cannot be read out from under the
+    // test by the next tier.
     expect(() => layersOf(
-      { series: [{ type: 'boxplot', values: [1, 2, 3] }] },
+      { series: [{ type: 'wordCloud', values: [1, 2, 3] }] },
       drawnChart(3, 0),
-    )).toThrow(/Unsupported ECharts series type\(s\): boxplot/);
+    )).toThrow(/Unsupported ECharts series type\(s\): wordCloud/);
   });
 
   it('drops the highlighting when the drawing holds a different number of marks', () => {

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -369,16 +369,17 @@ describe('a chart that declares both families', () => {
 
 describe('an eCharts chart of a type outside the set', () => {
   // `treemap` stood here until tier 3 gave it a reading, then `radar` until
-  // its outline turned out to be a stroked polyline after all. `boxplot` is
-  // the last one refused: `BoxSelector` wants a selector per part and
-  // ECharts draws the box and both whiskers as one path.
+  // its outline turned out to be a stroked polyline after all, then
+  // `boxplot`. Every core type is read now, so the subject is `wordCloud` --
+  // an ECharts extension core does not register and this adapter has never
+  // measured.
   it('is refused rather than read as whichever trace is closest', () => {
-    expect(() => layerFor({ type: 'boxplot', values: [1] }, 1))
+    expect(() => layerFor({ type: 'wordCloud', values: [1] }, 1))
       .toThrow(/Unsupported ECharts series type/);
   });
 
   it('names the single-value types among the ones it does read', () => {
-    expect(() => layerFor({ type: 'boxplot', values: [1] }, 1))
+    expect(() => layerFor({ type: 'wordCloud', values: [1] }, 1))
       .toThrow(/pie, funnel, gauge/);
   });
 });


### PR DESCRIPTION
## What

A box plot was refused by name. Unlike `radar`, the reason recorded for it was
**right** — but it was the reason to withhold the *outline*, not the reason to
withhold the *reading*.

ECharts hands the five-number summary over outright, as
`['base', 'min', 'Q1', 'median', 'Q3', 'max']` with one row per box and
`getName(i)` answering the category. The values need no deriving at all.

## Why there is no outline

`BoxSelector` wants one selector for each part — the whiskers, the box, the
median, each outlier — and ECharts draws all of them as **one path**.
Colour-tagged, a two-box chart yields exactly two filled paths, and each `d`
runs box-rectangle, `Z`, then the whiskers:

```
M177.5 234.59 L227.5 234.59 L227.5 150.41 L177.5 150.41 Z M202.5 27…
```

There is nothing to name the parts with. The default paint is also `#fff`,
which the mark filter counts as furniture, so the mark would be dropped even
if the shape fitted.

Reading without an outline is what `gauge`, `sankey`, `graph`, `parallel` and
`themeRiver` already do here — values, text and braille all work; only the
highlight is absent.

## Outliers, and the slot they must not steal

Outliers are emitted **empty rather than guessed**. ECharts draws them as a
*separate* `scatter` series by its own convention, so a boxplot series carries
no dimension holding them.

The accompanying scatter is read as the scatter it is, and **keeps its own
highlighting**: the boxplot is deliberately excluded from the per-datum mark
pool. Counting it would spend a slot and shift every later series' selectors
onto the wrong elements. Verified live and pinned by a test:

```json
withScatter -> [ {"type":"box","n":2,"selectors":0,"resolved":0},
                 {"type":"point","name":"out","n":2,"selectors":1,"resolved":1} ]
```

## Two prose corrections, both about claims I could not check

- The comments asserted **"ECharts draws seventeen series types."** I probed
  what echarts 6.1.0 actually registers and the result came back inconsistent
  (it missed `bar`/`line`/`scatter`, which certainly exist), so the probe does
  not establish a count. Rather than restate a number I cannot verify — or
  invent a new one — the count is removed and the prose speaks in terms of the
  set the adapter has measured.
- The refused-type tests used `boxplot`. Every core type is read now, and a
  core name can be read out from under the test by the next tier, so the
  subject is `wordCloud` — an ECharts *extension* core does not register.

## Verification

Live against real echarts 6.1.0 in Chromium: the summary transcribes exactly,
and the mixed boxplot-plus-scatter case above confirms the slot is not stolen.

Full gate green: `eslint src test scripts`, `tsc --noEmit`, `npm test`
(**5942** unit + esm + component, all passing — 8 new), `npm run build`,
`npm run docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_