### PR TITLE
fix(echarts): give the theme river the outline it can have

### DIFF
--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -206,7 +206,7 @@ none of them carries a hierarchy or a graph.
 
 | ECharts | read as | payload | highlighted |
 |---|---|---|---|
-| `themeRiver` | `stacked_area` | `SegmentedPoint[][]` | **no** — see below |
+| `themeRiver` | `stacked_area` | `SegmentedPoint[][]` | yes — one selector per band |
 | `parallel` | `parallel_coordinates` | `LinePoint[][]` | **no** — see below |
 | `radar` | `radar` | `LinePoint[][]` | yes — one selector per series |
 
@@ -233,15 +233,18 @@ by column position, so a value is pitched against its own variable's range
 even when an observation is short a reading
 ([#1182](https://github.com/xability/maidr/issues/1182)).
 
-**Neither is highlighted, and for different reasons.** A parallel plot's
+**A parallel plot is not highlighted; a theme river is.** A parallel plot's
 polylines are *stroked*, so the mark finder — which pairs filled marks with
 data — finds none at all: measured, zero marks for a two-observation chart.
-A theme river does paint filled marks, but one per **band**, not one per
-datum; `stacked_area` is a segmented trace, whose selectors are a row per
-series *aligned to that series' points*, and that pairing is not on offer.
-Repeating the band's one mark across its instants would resolve and would
-light the whole band on every move within it, which is not where the cursor
-is.
+
+The theme river took a correction. It shipped without an outline first, on
+the reasoning that `stacked_area` is a segmented trace whose selectors are a
+row per series *aligned to that series' points* — a pairing the drawing does
+not offer, since it paints one filled path per **band** rather than one per
+datum. The premise was wrong: `src/model/factory.ts` routes `STACKED_AREA` to
+`AreaTrace`, which extends `LineTrace`, and a line takes **one selector per
+series**. One filled path per band is exactly that shape. Verified live —
+three bands give three selectors that resolve to three *distinct* paths.
 
 **A radar's outline is a stroke, not a fill.** This one is worth spelling out
 because the adapter got it wrong once. A radar was refused on the grounds

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -33,6 +33,7 @@ import {
   OUTLINED_HIERARCHY,
 } from './hierarchy';
 import {
+  drawnBandCount,
   PARALLEL,
   parallelLayer,
   THEME_RIVER,
@@ -222,7 +223,8 @@ function readOwning(
       return layer ? [layer] : [];
     }
     if (THEME_RIVER.has(seriesModel.subType)) {
-      const layer = themeRiverLayer(seriesModel, model);
+      const bands = markPerDatum(container, [drawnBandCount(seriesModel)]);
+      const layer = themeRiverLayer(seriesModel, model, bands?.points[0]);
       return layer ? [layer] : [];
     }
     if (PARALLEL.has(seriesModel.subType)) {

--- a/src/adapters/echarts/multiAxis.ts
+++ b/src/adapters/echarts/multiAxis.ts
@@ -46,23 +46,29 @@ export const PARALLEL: ReadonlySet<string> = new Set(['parallel']);
  * "1577836800000", so it is turned back into the date it is -- see
  * {@link instant}.
  *
- * **It is read without an outline.** Measured by colour, the drawing paints
- * one filled path per *band*, not one per datum: three instants of two bands
- * gave two marks. `TraceType.STACKED_AREA` is a segmented trace, and a
- * segmented trace's selectors are a row per series *aligned to that series'
- * points* -- which is a pairing the drawing does not offer. Repeating the
- * band's one mark across its instants would resolve, and would light the
- * whole band on every move within it, which is not what the cursor is on.
- * So the outline is left to a follow-up that can verify a shape against a
- * constructed trace rather than against a resolving string.
+ * **One selector per band, which took a correction to get right.** This was
+ * first shipped without an outline, on the reasoning that
+ * `TraceType.STACKED_AREA` is a segmented trace whose selectors are a row per
+ * series aligned to that series' points -- a pairing the drawing does not
+ * offer, since it paints one filled path per *band* rather than one per
+ * datum. The premise was wrong: `factory.ts` routes `STACKED_AREA` to
+ * `AreaTrace`, which extends `LineTrace`, and a line takes **one selector per
+ * series**. One filled path per band is exactly that shape.
+ *
+ * The marks are filled rather than stroked, so they are found with
+ * `markPerDatum` over a count of bands rather than with `markPerSeries`.
+ * Withheld unless there is one per band that was read: a list that does not
+ * line up pairs every band with the wrong path.
  *
  * @param seriesModel - The series to read
  * @param model       - The chart's model, for the axis name
+ * @param selectors   - One selector per band, when they were found
  * @returns The layer, or `undefined` when nothing measurable was drawn
  */
 export function themeRiverLayer(
   seriesModel: EChartsSeriesModel,
   model: EChartsModel,
+  selectors: string[] | undefined,
 ): MaidrLayer | undefined {
   const data = seriesModel.getData();
   const dated = axisType(model, 'singleAxis') === 'time';
@@ -104,10 +110,33 @@ export function themeRiverLayer(
       // not make.
       y: {},
     },
-    // A row per band. `SegmentedTrace` declines a flat list, and a flat one
-    // is what the series hands over.
+    // One per band, in the order the bands are stacked -- `AreaTrace`
+    // inherits `LineTrace`'s pairing, which takes the list row by row.
+    ...(selectors && selectors.length === order.length ? { selectors } : {}),
+    // A row per band; the series hands over a flat list.
     data: order.map(band => bands.get(band) ?? []),
   };
+}
+
+/**
+ * How many bands a theme river drew, which is how many marks to look for.
+ *
+ * Counted from the series by the same grouping the reading uses, so the count
+ * handed to the mark finder is the one the layer will carry.
+ *
+ * @param seriesModel - The series to read
+ * @returns The number of distinct bands that carry a measured value
+ */
+export function drawnBandCount(seriesModel: EChartsSeriesModel): number {
+  const data = seriesModel.getData();
+  const bands = new Set<string>();
+  for (let index = 0; index < data.count(); index++) {
+    if (!measured(data.get('value', index))) {
+      continue;
+    }
+    bands.add(data.getName(index) || `Band ${bands.size + 1}`);
+  }
+  return bands.size;
 }
 
 /**

--- a/test/adapters/echarts/multiAxis.test.ts
+++ b/test/adapters/echarts/multiAxis.test.ts
@@ -114,8 +114,32 @@ function container(): HTMLElement {
   return dom.window.document.getElementById('chart') as HTMLElement;
 }
 
-function layersOf(chart: EChartsInstance) {
-  return createMaidrFromEChart(chart, container()).subplots[0][0].layers;
+/** A drawn theme river: `bands` filled paths, plus gridline furniture. */
+function drawnRiver(bands: number): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="chart"></div></body>');
+  const doc = dom.window.document;
+  const host = doc.getElementById('chart') as HTMLElement;
+  const svg = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+  const add = (attributes: Record<string, string>): void => {
+    const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+    Object.entries(attributes).forEach(([key, value]) =>
+      path.setAttribute(key, value));
+    svg.appendChild(path);
+  };
+
+  add({ fill: 'none', stroke: '#dbdee4' });
+  // One filled path per band -- what the drawing actually paints.
+  for (let index = 0; index < bands; index++) {
+    add({ fill: '#5070dd' });
+  }
+
+  host.appendChild(svg);
+  return host;
+}
+
+function layersOf(chart: EChartsInstance, host: HTMLElement = container()) {
+  return createMaidrFromEChart(chart, host).subplots[0][0].layers;
 }
 
 const RIVER: Band[] = [
@@ -221,12 +245,36 @@ describe('an eCharts theme river', () => {
     expect(data[0].map(point => point.y)).toEqual([10, 12]);
   });
 
-  it('is read without an outline', () => {
-    // Measured by colour: the drawing paints one filled path per band, not
-    // one per datum, so the per-point pairing a segmented trace's selectors
-    // need is not on offer. Emitting one anyway would light a whole band on
-    // every move within it.
-    expect(layersOf(themeRiverChart(RIVER))[0].selectors).toBeUndefined();
+  it('takes one selector per band', () => {
+    // This shipped without an outline first, on the reasoning that
+    // `STACKED_AREA` is a segmented trace needing a selector per *point*.
+    // The premise was wrong -- `factory.ts` routes it to `AreaTrace`, which
+    // extends `LineTrace` and takes one selector per *series*. One filled
+    // path per band is exactly that shape.
+    const layer = layersOf(themeRiverChart(RIVER), drawnRiver(2))[0];
+
+    expect(layer.selectors).toHaveLength(2);
+  });
+
+  it('withholds the selectors when they do not line up with the bands', () => {
+    // A list that does not match pairs every band with the wrong path,
+    // which is worse than no highlighting at all.
+    expect(layersOf(themeRiverChart(RIVER), drawnRiver(3))[0].selectors)
+      .toBeUndefined();
+  });
+
+  it('counts only the bands that carry a measured value', () => {
+    // The count handed to the mark finder has to be the one the layer will
+    // carry, or a band dropped for having nothing drawn would shift the
+    // pairing by one.
+    const layer = layersOf(themeRiverChart([
+      { time: january(1), value: 10, name: 'A' },
+      { time: january(1), value: null, name: 'ghost' },
+      { time: january(1), value: 5, name: 'B' },
+    ]), drawnRiver(2))[0];
+
+    expect(layer.data).toHaveLength(2);
+    expect(layer.selectors).toHaveLength(2);
   });
 
   it('is refused when nothing it drew was measurable', () => {


### PR DESCRIPTION
## What

The theme river shipped without an outline (#1203) on a premise that was
**wrong**. It can be highlighted, and now is.

## The wrong premise

The reasoning recorded was that `TraceType.STACKED_AREA` is a *segmented*
trace, whose selectors are a row per series aligned to that series' points —
a pairing the drawing does not offer, since it paints one filled path per
**band** rather than one per datum. Repeating the band's mark across its
instants would have resolved while lighting the whole band on every move.

But `src/model/factory.ts` routes `STACKED_AREA` to **`AreaTrace`**, not to
`SegmentedTrace`:

```ts
case TraceType.AREA:
case TraceType.NORMALIZED_AREA:
case TraceType.STACKED_AREA:
  return new AreaTrace(layer);
```

and `AreaTrace extends LineTrace` — so it takes **one selector per series**.
One filled path per band is exactly that shape, and was all along.

## The fix

The marks are *filled* rather than stroked, so they are located with
`markPerDatum` over a count of bands rather than with `markPerSeries`. The
count is derived by the same grouping the reading uses, so a band dropped for
carrying nothing measurable cannot shift the pairing by one. Selectors are
withheld unless there is one per band that was read.

## Verification

Live against echarts 6.1.0 in Chromium, three bands:

```json
{"type":"stacked_area","rows":3,"bands":["A","B","C"],
 "selectors":3,"resolved":3,"distinct":3}
```

`distinct: 3` is the part that matters — not merely three selectors that
*resolve*, which a repeated selector would also have managed, but three that
resolve to three **different** paths.

Full gate green: `eslint src test scripts`, `tsc --noEmit`, `npm test`
(**5944**, 2 net new), `npm run build`, `npm run docs`.

## Worth noting for the next reader

This is the **second** refusal in this adapter to fall to the same mistake —
`radar` was the first (#1205) — and both were about assuming which trace class
handles a type instead of reading `factory.ts`. The note in `multiAxis.ts` now
records the correction rather than the wrong reason, as `grid.ts`'s does for
radar.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_