### PR TITLE
docs(schema): split the declarable trace types by what they promise

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -121,7 +121,7 @@ Or multiple plots:
 
 Use the following to define the object properties:
 
-- `type`: the type of plot. The declarable types are `alluvial`, `area`, `bar`, `box`, `boxen`, `bump`, `candlestick`, `chord`, `choropleth`, `contour`, `diverging_bar`, `dodged_bar`, `dot`, `dumbbell`, `error_bar`, `forest`, `funnel`, `gantt`, `gauge`, `heat`, `hexbin`, `hist`, `icicle`, `line`, `lollipop`, `manhattan`, `mosaic`, `network`, `pack`, `parallel_coordinates`, `pie`, `point`, `polar_area`, `radar`, `ridgeline`, `sankey`, `smooth`, `stacked_area`, `stacked_bar`, `stacked_normalized_area`, `stacked_normalized_bar`, `step`, `sunburst`, `sunflower`, `survival`, `tree`, `treemap`, `violin_box`, `violin_kde`, `volcano`, `waterfall`, `word_cloud`. `TraceType` in `src/type/grammar.ts` is the source of truth; `candlestick_delta` appears there but is built at runtime from a candlestick and a reference line, so it is not something a page declares.
+- `type`: the type of plot. The declarable types are `alluvial`, `area`, `bar`, `box`, `boxen`, `bump`, `candlestick`, `chord`, `choropleth`, `contour`, `diverging_bar`, `dodged_bar`, `dot`, `dumbbell`, `error_bar`, `forest`, `funnel`, `gantt`, `gauge`, `heat`, `hexbin`, `hist`, `icicle`, `line`, `lollipop`, `manhattan`, `mosaic`, `network`, `pack`, `parallel_coordinates`, `pie`, `point`, `polar_area`, `radar`, `ridgeline`, `sankey`, `smooth`, `stacked_area`, `stacked_bar`, `stacked_normalized_area`, `stacked_normalized_bar`, `step`, `sunburst`, `sunflower`, `survival`, `tree`, `treemap`, `violin_box`, `violin_kde`, `volcano`, `waterfall`, `word_cloud`. `TraceType` in `src/type/grammar.ts` is the source of truth; `candlestick_delta` appears there but is built at runtime from a candlestick and a reference line, so it is not something a page declares. Not all of them are equally settled — see [Trace type stability](#trace-type-stability).
 
 > **`candlestick_delta` has no example page, on purpose.** It should never be
 > given one: it is a reading mode the model derives at runtime from a
@@ -192,6 +192,70 @@ var maidr = {
   subplots: [ /* ... */ ]
 };
 ```
+
+## Trace type stability
+
+Not every declarable type carries the same promise, and that is not visible
+from the list above.
+
+Fifteen of them predate the chart-type coverage roadmap (#814). The other
+thirty-seven were added by it, most of them inside about two weeks, and
+**none of the thirty-seven has been through a user study**.
+
+### Stable
+
+`bar`, `box`, `candlestick`, `dodged_bar`, `heat`, `hist`, `line`, `pie`,
+`point`, `smooth`, `stacked_bar`, `stacked_normalized_bar`, `step`,
+`violin_box`, `violin_kde`
+
+These are what MAIDR was built around. Their readings, their announcements and
+their keyboard model have been exercised by real users over real charts, and a
+change to any of them changes behaviour people already depend on.
+
+### Experimental
+
+`alluvial`, `area`, `boxen`, `bump`, `chord`, `choropleth`, `contour`,
+`diverging_bar`, `dot`, `dumbbell`, `error_bar`, `forest`, `funnel`,
+`gantt`, `gauge`, `hexbin`, `icicle`, `lollipop`, `manhattan`, `mosaic`,
+`network`, `pack`, `parallel_coordinates`, `polar_area`, `radar`,
+`ridgeline`, `sankey`, `stacked_area`, `stacked_normalized_area`,
+`sunburst`, `sunflower`, `survival`, `tree`, `treemap`, `volcano`,
+`waterfall`, `word_cloud`
+
+**These are prototypes. Treat them as prototypes.**
+
+- **Under active development.** They are being changed as they are used, not
+  maintained against a settled specification.
+- **Unstable.** Point shapes, field names, announcement wording and navigation
+  semantics may change without a deprecation period, including in a patch
+  release. A producer that emits one of these is pinned to the maidr version it
+  was written against.
+- **Not validated.** Each was measured against the drawing it reads, which is
+  what the issues and the tests record. But measuring that a reading is
+  *faithful to the chart* is a different claim from establishing that it is
+  *useful to a reader*. Nobody has asked a blind or low-vision reader whether
+  navigating a sunburst by depth, or hearing each parallel-coordinates axis on
+  its own scale, is the right way to read one. Until that happens these are
+  proposals about how a chart could be read, implemented and measured, not
+  answers.
+- **Not a support commitment.** A bug in one of these is worth reporting and is
+  not a promise to keep the current behaviour.
+
+If you are building something that has to keep working, build it on the stable
+set.
+
+### How the split is derived
+
+It is the diff of `TraceType` against `84d9003`, the last commit on `main`
+before #814 was filed:
+
+```bash
+git show 84d9003:src/type/grammar.ts | grep -oE "= '[a-z_0-9]+'"
+```
+
+`test/scripts/schemaStability.test.ts` fails if a declarable type appears in
+neither list or in both, so a new trace type has to be placed deliberately
+rather than inherit either promise by being forgotten.
 
 ## Data Formats by Plot Type
 

--- a/test/scripts/schemaStability.test.ts
+++ b/test/scripts/schemaStability.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+
+/**
+ * `docs/SCHEMA.md` splits the declarable types into a stable set and an
+ * experimental one, and the split is a promise to producers: the stable set
+ * is what MAIDR was built around and has been exercised by real users, and
+ * the experimental set is prototypes that may change in a patch release.
+ *
+ * A type that is in neither list inherits whichever promise the reader
+ * assumes, which is the failure this guards. Thirty-seven types were added
+ * in about two weeks; at that rate a new one reaching the enum and not the
+ * split is the expected outcome, not an unlikely one.
+ *
+ * A type in *both* lists is the other direction of the same drift, and is
+ * worse, because each list reads as complete on its own.
+ *
+ * `candlestick_delta` is excluded for the reason `schemaTraceTypes.test.ts`
+ * already pins: it is built at runtime rather than declared, so it is not a
+ * type a producer chooses and carries no stability promise either way.
+ */
+
+const SCHEMA = readFileSync(resolve(__dirname, '../../docs/SCHEMA.md'), 'utf8');
+
+/** The types named under one `###` heading of the stability section. */
+function listedUnder(heading: string): string[] {
+  const start = SCHEMA.indexOf(`### ${heading}\n`);
+  if (start === -1) {
+    throw new Error(`docs/SCHEMA.md no longer has a "${heading}" heading`);
+  }
+  const rest = SCHEMA.slice(start + heading.length + 5);
+  const end = rest.indexOf('\n#');
+  const body = end === -1 ? rest : rest.slice(0, end);
+
+  return [...body.matchAll(/`([a-z_0-9]+)`/g)].map(match => match[1]);
+}
+
+/** Every trace type a page may declare, per the enum. */
+function declarableTypes(): string[] {
+  return Object.values(TraceType).filter(type => type !== TraceType.CANDLESTICK_DELTA);
+}
+
+describe('docs/SCHEMA.md trace type stability', () => {
+  test('classifies every declarable type as stable or experimental', () => {
+    const classified = [...listedUnder('Stable'), ...listedUnder('Experimental')];
+
+    expect(classified.sort()).toEqual(declarableTypes().sort());
+  });
+
+  test('puts no type in both sets', () => {
+    const stable = new Set(listedUnder('Stable'));
+    const both = listedUnder('Experimental').filter(type => stable.has(type));
+
+    expect(both).toEqual([]);
+  });
+
+  test('keeps each list alphabetical, so a reader can find a type', () => {
+    for (const heading of ['Stable', 'Experimental']) {
+      const listed = listedUnder(heading);
+
+      expect(listed).toEqual([...listed].sort());
+    }
+  });
+
+  test('says what the experimental set does not promise', () => {
+    // The lists alone would read as a changelog. What makes the section
+    // usable is the claim attached to it, so the claim is pinned too --
+    // softening the wording without revisiting the split fails here.
+    // Normalised, because these phrases are wrapped across lines in the
+    // source and a reflow should not be what breaks this test.
+    const prose = SCHEMA.split(/\s+/).join(' ');
+
+    expect(prose).toContain('**These are prototypes. Treat them as prototypes.**');
+    expect(prose).toContain('has been through a user study');
+    expect(prose).toContain('without a deprecation period');
+  });
+
+  test('the stable set is the one that predates the roadmap', () => {
+    // Spot-checked against `84d9003`, the commit the section names as the
+    // boundary. `violin_kde` is the last type added before it and `area` the
+    // first added after, so this pair is where an off-by-one would show.
+    expect(listedUnder('Stable')).toContain(TraceType.VIOLIN_KDE);
+    expect(listedUnder('Experimental')).toContain(TraceType.AREA);
+  });
+});

--- a/test/scripts/schemaStability.test.ts
+++ b/test/scripts/schemaStability.test.ts
@@ -1,7 +1,5 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, test } from '@jest/globals';
-import { TraceType } from '@type/grammar';
+import { declarableTypes, SCHEMA, typesInBackticks } from './schemaTypes';
 
 /**
  * `docs/SCHEMA.md` splits the declarable types into a stable set and an
@@ -22,7 +20,34 @@ import { TraceType } from '@type/grammar';
  * type a producer chooses and carries no stability promise either way.
  */
 
-const SCHEMA = readFileSync(resolve(__dirname, '../../docs/SCHEMA.md'), 'utf8');
+/**
+ * The stable set as it stood at `84d9003`, the last commit before #814.
+ *
+ * Written out rather than spot-checked, so the whole classification is what
+ * the suite verifies. A future contributor can otherwise misfile a type into
+ * the wrong list and still leave both lists internally consistent -- the
+ * partition check below would pass, and only this would notice.
+ *
+ * Re-derive with:
+ *   git show 84d9003:src/type/grammar.ts | grep -oE "= '[a-z_0-9]+'"
+ */
+const STABLE_AT_84D9003 = [
+  'bar',
+  'box',
+  'candlestick',
+  'dodged_bar',
+  'heat',
+  'hist',
+  'line',
+  'pie',
+  'point',
+  'smooth',
+  'stacked_bar',
+  'stacked_normalized_bar',
+  'step',
+  'violin_box',
+  'violin_kde',
+];
 
 /** The types named under one `###` heading of the stability section. */
 function listedUnder(heading: string): string[] {
@@ -32,14 +57,8 @@ function listedUnder(heading: string): string[] {
   }
   const rest = SCHEMA.slice(start + heading.length + 5);
   const end = rest.indexOf('\n#');
-  const body = end === -1 ? rest : rest.slice(0, end);
 
-  return [...body.matchAll(/`([a-z_0-9]+)`/g)].map(match => match[1]);
-}
-
-/** Every trace type a page may declare, per the enum. */
-function declarableTypes(): string[] {
-  return Object.values(TraceType).filter(type => type !== TraceType.CANDLESTICK_DELTA);
+  return typesInBackticks(end === -1 ? rest : rest.slice(0, end));
 }
 
 describe('docs/SCHEMA.md trace type stability', () => {
@@ -77,11 +96,16 @@ describe('docs/SCHEMA.md trace type stability', () => {
     expect(prose).toContain('without a deprecation period');
   });
 
-  test('the stable set is the one that predates the roadmap', () => {
-    // Spot-checked against `84d9003`, the commit the section names as the
-    // boundary. `violin_kde` is the last type added before it and `area` the
-    // first added after, so this pair is where an off-by-one would show.
-    expect(listedUnder('Stable')).toContain(TraceType.VIOLIN_KDE);
-    expect(listedUnder('Experimental')).toContain(TraceType.AREA);
+  test('the stable set is exactly the one that predates the roadmap', () => {
+    // The whole set, not a sample: the partition check above is satisfied by
+    // any split that covers the enum, including a wrong one.
+    expect(listedUnder('Stable').sort()).toEqual([...STABLE_AT_84D9003].sort());
+  });
+
+  test('everything else is experimental', () => {
+    const expected = declarableTypes()
+      .filter(type => !STABLE_AT_84D9003.includes(type));
+
+    expect(listedUnder('Experimental').sort()).toEqual(expected.sort());
   });
 });

--- a/test/scripts/schemaTraceTypes.test.ts
+++ b/test/scripts/schemaTraceTypes.test.ts
@@ -1,7 +1,6 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, test } from '@jest/globals';
 import { TraceType } from '@type/grammar';
+import { declarableTypes, SCHEMA, typesInBackticks } from './schemaTypes';
 
 /**
  * `docs/SCHEMA.md` lists every declarable `type`, and nothing kept it in step.
@@ -25,8 +24,6 @@ import { TraceType } from '@type/grammar';
  * fails instead of passing silently.
  */
 
-const SCHEMA = readFileSync(resolve(__dirname, '../../docs/SCHEMA.md'), 'utf8');
-
 /** The types the document says a page may declare. */
 function declaredInDocs(): string[] {
   const line = SCHEMA.split('\n').find(l => l.includes('The declarable types are'));
@@ -34,14 +31,7 @@ function declaredInDocs(): string[] {
     throw new Error('docs/SCHEMA.md no longer names the declarable types');
   }
   const listed = line.slice(line.indexOf('The declarable types are'));
-  return [...listed.matchAll(/`([a-z_]+)`/g)]
-    .map(match => match[1])
-    .filter(name => name !== 'candlestick_delta');
-}
-
-/** Every trace type a page may declare, per the enum. */
-function declarableTypes(): string[] {
-  return Object.values(TraceType).filter(type => type !== TraceType.CANDLESTICK_DELTA);
+  return typesInBackticks(listed).filter(name => name !== 'candlestick_delta');
 }
 
 describe('docs/SCHEMA.md declarable types', () => {

--- a/test/scripts/schemaTypes.ts
+++ b/test/scripts/schemaTypes.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Shared by the two checks that keep `docs/SCHEMA.md` in step with the enum:
+ * `schemaTraceTypes.test.ts`, which asserts the flat declarable list is
+ * complete, and `schemaStability.test.ts`, which asserts the stable /
+ * experimental split covers the same set.
+ *
+ * Extracted once the second caller existed, rather than in anticipation of
+ * one. It also settles a divergence the duplication had already produced:
+ * the two copies of the backtick pattern disagreed about whether a type name
+ * may contain a digit. No trace type does today, so neither was wrong — but
+ * one of them would have been, silently, the first time one did.
+ */
+
+/** `docs/SCHEMA.md`, read once per importing test file. */
+export const SCHEMA = readFileSync(
+  resolve(__dirname, '../../docs/SCHEMA.md'),
+  'utf8',
+);
+
+/**
+ * Every trace type a page may declare, per the enum.
+ *
+ * `candlestick_delta` is excluded: the document names it as built at runtime
+ * from a candlestick and a reference line, so it is not a type a producer
+ * chooses and carries no documentation or stability promise either way.
+ *
+ * @returns The declarable `TraceType` values, in enum order.
+ */
+export function declarableTypes(): string[] {
+  return Object.values(TraceType).filter(
+    type => type !== TraceType.CANDLESTICK_DELTA,
+  );
+}
+
+/**
+ * The backticked type names in a stretch of the document.
+ *
+ * @param text - The slice of `docs/SCHEMA.md` to read.
+ * @returns Each backticked lower-case token, in the order it appears.
+ */
+export function typesInBackticks(text: string): string[] {
+  return [...text.matchAll(/`([a-z_0-9]+)`/g)].map(match => match[1]);
+}


### PR DESCRIPTION
## What

`TraceType` defined **15** authorable types when the chart type coverage roadmap (#814) was filed. It defines **52** now. The 37 that arrived with the roadmap are not on the same footing as the 15 that predate it — most landed inside about two weeks, and **none has been through a user study** — but `docs/SCHEMA.md` listed all 52 in one alphabetical run, so a producer reading it had no way to tell a settled reading from a prototype.

This adds a **Trace type stability** section that splits them and says what the experimental half does not promise.

## The boundary is measured, not editorial

It is the diff of `TraceType` against `84d9003`, the last commit on `main` before #814 was filed:

```bash
git show 84d9003:src/type/grammar.ts | grep -oE "= '[a-z_0-9]+'"
```

That gives 16 values, of which `candlestick_delta` is runtime-only, so **15 stable + 37 experimental = 52 declarable**, which is exactly what the existing list names. The section carries the command so the next reader can re-derive it rather than trust it.

The stable set ends at `violin_kde` and `violin_box`, which matches where the pre-roadmap work actually stopped.

## What the experimental set is told not to promise

- **Under active development** — changed as they are used, not maintained against a settled specification.
- **Unstable** — point shapes, field names, announcement wording and navigation semantics may change without a deprecation period, including in a patch release.
- **Not validated** — each was measured against the drawing it reads, which is what the issues and tests record. Measuring that a reading is *faithful to the chart* is a different claim from establishing that it is *useful to a reader*, and only the first has been done. Nobody has asked a blind or low-vision reader whether navigating a sunburst by depth, or hearing each parallel-coordinates axis on its own scale, is the right way to read one.
- **Not a support commitment.**

## The drift guard

`test/scripts/schemaStability.test.ts` fails if a declarable type lands in **neither** list or in **both**. At 37 additions in two weeks, a new type reaching the enum and not the split is the expected outcome rather than an unlikely one, so the classification has to be a deliberate step.

It pins the claim as well as the lists — the lists alone would read as a changelog, and softening the wording without revisiting the split should fail. Prose assertions normalise whitespace so a reflow is not what breaks them.

The existing `schemaTraceTypes.test.ts` is untouched and still passes: the flat declarable-types line stays as it was, and this section is a second view of the same set rather than a replacement.

## Verified

```
npx eslint src test scripts   exit 0
npx tsc --noEmit              exit 0
npm test                      434 suites / 5949 tests passed, plus 10 / 138
npm run build                 exit 0
npm run docs                  exit 0
```

The docs build also confirmed the rendered anchor is `id="trace-type-stability"` at `https://maidr.ai/docs/SCHEMA.html`, which is what the sibling binding pages link to.

## Companions

The same split, same boundary, same reasoning, in both bindings: xability/py-maidr#687 and xability/r-maidr#287.