### PR TITLE
fix(chartjs): bind after the first update, so a box plot, violin or error bar is read at all

### DIFF
--- a/examples/chartjs/boxplot-horizontal.html
+++ b/examples/chartjs/boxplot-horizontal.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Horizontal Boxplot Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@sgratzl/chartjs-chart-boxplot@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Horizontal Boxplot</h1>
+    <p>
+      The same summaries as <a href="boxplot.html">the upright example</a>, with
+      <code>indexAxis: 'y'</code> — the groups run down the page and the
+      measurement across it. MAIDR announces a horizontal box plot and reads it
+      against the axes as drawn: left and right move through one group's
+      sections, up and down between the groups.
+    </p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="boxplot-horizontal-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      new Chart(document.getElementById('boxplot-horizontal-chart'), {
+        type: 'boxplot',
+        data: {
+          labels: ['Group A', 'Group B', 'Group C'],
+          datasets: [{
+            label: 'Distribution',
+            data: [
+              { min: 15, q1: 25, median: 35, q3: 45, max: 55, outliers: [5, 8, 62, 70] },
+              { min: 20, q1: 30, median: 42, q3: 52, max: 65, outliers: [12, 72] },
+              { min: 10, q1: 22, median: 30, q3: 40, max: 50, outliers: [58] },
+            ],
+            backgroundColor: 'rgba(135, 206, 235, 0.5)',
+            borderColor: 'rgb(135, 206, 235)',
+            borderWidth: 1,
+          }],
+        },
+        options: {
+          indexAxis: 'y',
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { title: { display: true, text: 'Distribution by Group' } },
+          scales: {
+            // With `indexAxis: 'y'` the x scale is the measured one, so the
+            // titles already name the axes as drawn and MAIDR passes them
+            // through unswapped.
+            x: { title: { display: true, text: 'Value' } },
+            y: { title: { display: true, text: 'Group' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/victory/App.tsx
+++ b/examples/victory/App.tsx
@@ -7,6 +7,7 @@ import { CandlestickExample } from './examples/CandlestickExample';
 import { DotPlotExample } from './examples/DotPlotExample';
 import { ErrorBarExample } from './examples/ErrorBarExample';
 import { HistogramExample } from './examples/HistogramExample';
+import { HorizontalBoxPlotExample } from './examples/HorizontalBoxPlotExample';
 import { LineChartExample } from './examples/LineChartExample';
 import { MultiPanelExample } from './examples/MultiPanelExample';
 import { PolarAreaExample } from './examples/PolarAreaExample';
@@ -27,6 +28,7 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Stacked Area', component: StackedAreaExample },
   { name: 'Histogram', component: HistogramExample },
   { name: 'Box Plot', component: BoxPlotExample },
+  { name: 'Box Plot (horizontal)', component: HorizontalBoxPlotExample },
   { name: 'Candlestick', component: CandlestickExample },
   { name: 'Error Bar', component: ErrorBarExample },
   { name: 'Waterfall', component: WaterfallExample },

--- a/examples/victory/examples/HorizontalBoxPlotExample.tsx
+++ b/examples/victory/examples/HorizontalBoxPlotExample.tsx
@@ -1,0 +1,39 @@
+import type { JSX } from 'react';
+import { VictoryAxis, VictoryBoxPlot, VictoryChart } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+// The same summaries the upright example uses, drawn on their side.
+//
+// `horizontal` may sit on the chart, as here, or on the box plot itself;
+// either way MAIDR announces a horizontal box plot and reads it against the
+// axes as drawn — the group off the y axis, the measurement off the x. The
+// five numbers do not move with it: a box carries no `x`/`y` pair to exchange,
+// unlike a bar.
+const data = [
+  { x: 'A', min: 2, q1: 5, median: 8, q3: 12, max: 16 },
+  { x: 'B', min: 4, q1: 7, median: 10, q3: 14, max: 20 },
+  { x: 'C', min: 1, q1: 4, median: 6, q3: 9, max: 13 },
+];
+
+export function HorizontalBoxPlotExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Box Plot (horizontal)</h2>
+      <p>
+        The same distribution with its groups running down the page. Left and
+        right move through one group's sections; up and down move between the
+        groups.
+      </p>
+      <MaidrVictory
+        id="victory-box-horizontal"
+        title="Distribution by Group"
+      >
+        <VictoryChart domainPadding={24} horizontal>
+          <VictoryAxis label="Group" />
+          <VictoryAxis dependentAxis label="Value" />
+          <VictoryBoxPlot data={data} boxWidth={20} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/src/adapters/chartjs/plugin.tsx
+++ b/src/adapters/chartjs/plugin.tsx
@@ -289,9 +289,20 @@ function renderMaidr(
 // Plugin lifecycle
 // ---------------------------------------------------------------------------
 
+/**
+ * Charts whose extraction has already been declined, so it is not retried.
+ *
+ * The binding runs on `afterUpdate`, which fires on every update rather than
+ * once -- a hover, a resize or a `chart.update()` each reach it. A chart that
+ * bound successfully is held in {@link chartBindings} and skipped by the guard
+ * below; a chart whose type has no reading is not, so it would be re-extracted
+ * and re-warned on every update without this.
+ */
+const declinedCharts = new WeakSet<ChartJsChart>();
+
 function initMaidrForChart(chart: ChartJsChart): void {
   // Guard against duplicate initialization
-  if (chartBindings.has(chart))
+  if (chartBindings.has(chart) || declinedCharts.has(chart))
     return;
 
   const pluginOptions = getPluginOptions(chart);
@@ -308,6 +319,7 @@ function initMaidrForChart(chart: ChartJsChart): void {
   try {
     ({ maidr: extracted, layerDatasetIndices } = extractChartData(chart, pluginOptions));
   } catch (error) {
+    declinedCharts.add(chart);
     console.warn(
       `MAIDR Chart.js plugin: skipping chart. ${
         error instanceof Error ? error.message : String(error)
@@ -449,7 +461,24 @@ function destroyMaidrForChart(chart: ChartJsChart): void {
 export const maidrPlugin: ChartJsPlugin = {
   id: 'maidr',
 
-  afterInit(chart: ChartJsChart) {
+  // `afterUpdate`, not `afterInit`: Chart.js parses its datasets during the
+  // first update, and several readings are taken from that parse rather than
+  // from the author's rows -- a box plot's and a violin's five-number
+  // summaries among them, which the plugin computes and `dataset.data` never
+  // holds, and an error bar's bounds with them.
+  //
+  // Measured on chart.js 4 with `@sgratzl/chartjs-chart-boxplot`, a
+  // three-box chart reports `getDatasetMeta(0)._parsed.length` as 0 at
+  // `afterInit` and 3 at `afterUpdate`. Binding at init therefore read an
+  // empty summary, and every Chart.js box plot, violin and error-bar chart --
+  // the repository's own `examples/chartjs/boxplot.html` included -- announced
+  // "No trace info available" and navigated nothing.
+  //
+  // Both hooks run inside `new Chart(...)`, so nothing arrives later than it
+  // did; what changes is that the parse has happened by the time the data is
+  // read. Repeat updates are cheap: a bound chart is held in `chartBindings`
+  // and a declined one in `declinedCharts`, and both are skipped above.
+  afterUpdate(chart: ChartJsChart) {
     initMaidrForChart(chart);
   },
 

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -157,8 +157,11 @@ function isBarFamily(kind: VictoryLayerData['kind']): boolean {
  * here is *announced* by its orientation and reads its axis labels through it,
  * while only the bar family also has its `x` and `y` exchanged. A box plot and
  * an error bar carry no pair to exchange -- `BoxTrace` and `ErrorBarTrace`
- * read the group off `axes.y` when the layer is horizontal, and
- * {@link toMaidrLayer} has already swapped the labels by then.
+ * read the group off `axes.y` when the layer is horizontal, which is where
+ * {@link toMaidrLayer}'s swap has put it once this key is set. The swap and
+ * the reading are gated on the same key, so what a missing key cost was never
+ * a crossed label: it was a sideways chart announcing itself as an upright one
+ * and arrowing across its groups instead of along its measurement axis.
  *
  * Left out: a line, an area, a scatter and a candlestick, none of which the
  * grammar's `IS_ORIENTED` table gives an orientation to.
@@ -1710,7 +1713,10 @@ export function toMaidrLayer(
 
     // An interval keeps its `x` and its bounds under `horz` -- the grammar's
     // table says so -- and reads the sample off `axes.y`, which the swap above
-    // has already put the category label on.
+    // puts the category label on once this key is set. As with the box, the
+    // labels were not wrong before: the swap is gated on the same key, so both
+    // halves moved together either way. What the key buys is the announcement
+    // and the walk matching the chart as drawn.
     case 'errorBar':
       return {
         id: layer.id,
@@ -1732,10 +1738,18 @@ export function toMaidrLayer(
 
     // A `<VictoryBoxPlot horizontal>` draws its groups down the page, and the
     // key says so. Nothing is exchanged in the payload -- a `BoxPoint` has no
-    // `x` or `y` -- but the labels above have already swapped with the axes
-    // they name, and `BoxTrace` reads the group off `axes.y` when the layer
-    // is horizontal. Without the key it read the group off `axes.x`, which by
-    // then held the measurement.
+    // `x` or `y` -- and the labels do not move on their own either: the swap
+    // above is gated on this same key, so without it the pair stayed put and
+    // `BoxTrace`'s upright branch read the group off `axes.x`, which still
+    // held it. The labels were therefore right before this and are right
+    // after; what the key buys is the two things that were wrong -- the chart
+    // announced itself as a vertical box plot, and left and right walked
+    // across groups that are stacked down the page rather than along the
+    // measurement axis they are drawn on. Measured in Chromium on the
+    // `Box Plot (horizontal)` example, before and after:
+    //
+    //   before   "vertical box"     right: A -> B (across the groups)
+    //   after    "horizontal box"   right: C's minimum, quartiles ... ; up: C -> B
     case 'box':
       return {
         id: layer.id,

--- a/test/adapters/chartjs/pluginLifecycle.esm-test.ts
+++ b/test/adapters/chartjs/pluginLifecycle.esm-test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The Chart.js plugin bound before Chart.js had parsed anything, so every
+ * reading taken from the parse came out empty.
+ *
+ * `afterInit` fires before the first update, and the first update is where
+ * Chart.js parses each dataset. Several readings are taken from that parse
+ * rather than from the author's rows — a box plot's and a violin's
+ * five-number summaries, which the boxplot plugin computes and `dataset.data`
+ * never holds, and an error bar's bounds with them.
+ *
+ * Measured in Chromium on chart.js 4 with `@sgratzl/chartjs-chart-boxplot`,
+ * logging `getDatasetMeta(0)._parsed.length` from a plugin of its own on a
+ * three-box chart:
+ *
+ *   afterInit     0
+ *   afterUpdate   3
+ *   afterRender   3
+ *
+ * So the layer was built from nothing, and the announcement on the
+ * repository's own `examples/chartjs/boxplot.html` was:
+ *
+ *   before   "No trace info available", then "No more data to display"
+ *   after    "Group is Group A, Lower outlier(s) for Value are [5, 8]"
+ *
+ * The same for `barWithErrorBars`, which reads the parse for its bounds:
+ * silent before, "Group is alpha, value Value is 10" after. A bar chart and a
+ * radar were unaffected either way — their readings come from
+ * `chart.data.datasets`, which is populated from the moment the chart is
+ * constructed.
+ *
+ * This test drives the two hooks in the order Chart.js runs them, over a chart
+ * whose parse arrives between them, and asserts the emitted figure holds the
+ * summary rather than nothing. `afterInit` is deliberately checked to be
+ * absent: an implementation that binds there again cannot see the parse, and
+ * the empty layer it builds is what the reader was left with.
+ */
+
+import type { ChartJsChart, ChartJsParsedValue } from '@adapters/chartjs/types';
+import { maidrPlugin } from '@adapters/chartjs/plugin';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { act } from '@testing-library/react';
+
+/** The parse the boxplot plugin leaves for one box, once it has run. */
+const PARSED: ChartJsParsedValue = {
+  x: 0,
+  items: [1, 2, 2, 3, 4, 4, 5, 6, 7, 9],
+  outliers: [],
+  whiskerMax: 9,
+  whiskerMin: 1,
+  max: 9,
+  median: 4,
+  min: 1,
+  q1: 2.25,
+  q3: 5.75,
+  y: 4,
+};
+
+/**
+ * A box plot chart whose parse arrives when `parse()` is called, the way
+ * Chart.js fills `_parsed` during its first update.
+ *
+ * @returns The chart, and the call that populates its parse
+ */
+function boxplotChart(): { chart: ChartJsChart; parse: () => void } {
+  let parsed: ChartJsParsedValue[] = [];
+  const canvas = document.createElement('canvas');
+  document.body.appendChild(canvas);
+
+  const chart = {
+    canvas,
+    data: {
+      labels: ['alpha'],
+      datasets: [{ label: 'Samples', data: [[1, 2, 2, 3, 4, 4, 5, 6, 7, 9]] }],
+    },
+    options: {},
+    config: { type: 'boxplot' },
+    getDatasetMeta: () => ({ data: [], type: 'boxplot', _parsed: parsed }),
+    setActiveElements: () => {},
+    update: () => {},
+  } as unknown as ChartJsChart;
+
+  return {
+    chart,
+    parse: () => {
+      parsed = [PARSED];
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  jest.restoreAllMocks();
+});
+
+describe('when the Chart.js plugin binds', () => {
+  it('does not bind before the parse exists', () => {
+    // The hook that cannot see the summary is gone, rather than kept and
+    // worked around: `afterInit` runs before Chart.js has parsed a thing.
+    expect(maidrPlugin.afterInit).toBeUndefined();
+    expect(typeof maidrPlugin.afterUpdate).toBe('function');
+  });
+
+  it('reads the summary the first update parsed', async () => {
+    const { chart, parse } = boxplotChart();
+    parse();
+
+    // `act`, because the plugin mounts the MAIDR interface through a React
+    // root: `render()` schedules the work rather than committing it.
+    await act(async () => {
+      maidrPlugin.afterUpdate?.(chart, {}, {});
+    });
+
+    // The reader's own evidence: the instruction MAIDR renders names the
+    // chart. Built from an empty parse it announces no plot info at all.
+    const instruction = document.body.querySelector('[aria-label*="maidr plot"]')
+      ?.getAttribute('aria-label') ?? '';
+
+    expect(instruction).toContain('box');
+  });
+
+  it('binds once, however many updates follow', async () => {
+    // `afterUpdate` fires on every hover, resize and `chart.update()`, so the
+    // guard is what keeps one chart from being wrapped again and again.
+    const { chart, parse } = boxplotChart();
+    parse();
+
+    await act(async () => {
+      maidrPlugin.afterUpdate?.(chart, {}, {});
+      maidrPlugin.afterUpdate?.(chart, {}, {});
+      maidrPlugin.afterUpdate?.(chart, {}, {});
+    });
+
+    expect(document.body.querySelectorAll('[aria-label*="maidr plot"]')).toHaveLength(1);
+  });
+
+  it('warns once for a chart it cannot read, not once per update', () => {
+    // Same reason, other branch: an unsupported type is declined, and without
+    // a record of that it would be re-extracted and re-warned on every update.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const canvas = document.createElement('canvas');
+    document.body.appendChild(canvas);
+    const chart = {
+      canvas,
+      data: { labels: [], datasets: [] },
+      options: {},
+      config: { type: 'no-such-chart' },
+      getDatasetMeta: () => ({ data: [], type: 'no-such-chart', _parsed: [] }),
+      setActiveElements: () => {},
+      update: () => {},
+    } as unknown as ChartJsChart;
+
+    maidrPlugin.afterUpdate?.(chart, {}, {});
+    maidrPlugin.afterUpdate?.(chart, {}, {});
+    maidrPlugin.afterUpdate?.(chart, {}, {});
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/adapters/victory/distributionOrientation.test.ts
+++ b/test/adapters/victory/distributionOrientation.test.ts
@@ -10,16 +10,23 @@
  *
  * That family test is the right one for the payload -- the grammar's table has
  * only the bar family exchanging `x` and `y` -- but it is the wrong one for
- * the *announcement*. A box plot and an interval read their axis labels
- * through the orientation instead: `BoxTrace` and `ErrorBarTrace` take the
- * group off `axes.y` and the measurement off `axes.x` when the layer is
- * horizontal, and `toMaidrLayer` has already swapped the labels by then --
- * Victory keeps `x = category` in its own data however the chart is drawn, so
- * the pair of axis labels moves with the drawing.
+ * the *announcement*, and for the walk that follows it.
  *
- * Without the key the two halves disagreed: the labels swapped and the reading
- * did not, so the group was announced against the measurement's axis title and
- * the measurement against the group's.
+ * **What was not wrong: the axis labels.** `toMaidrLayer` swaps them on the
+ * same key this attaches, so before it neither the labels nor the reading
+ * moved, and they agreed with each other. An earlier version of this file said
+ * the opposite -- that the labels had swapped and the reading had not -- which
+ * is impossible in the code as written. Measured in Chromium on the
+ * `Box Plot (horizontal)` example of `npm run dev:victory`, before and after:
+ *
+ *   before   "vertical box plot"     right -> Group is A, then Group is B
+ *   after    "horizontal box plot"   right -> C's sections; up -> B, then A
+ *
+ * Both readings name the group against `Group` and the measurement against
+ * `Value`. What the key fixes is that the first announces a chart drawn the
+ * other way round, and walks left and right across groups that are stacked
+ * down the page -- while the values, which are what left and right traverse on
+ * screen, are reached with up and down.
  */
 
 import type { BoxPoint, ErrorBarPoint, MaidrLayer } from '@type/grammar';


### PR DESCRIPTION
# Pull Request

## Description

Two things, both found by going back and checking #1209's claims in a real
browser instead of trusting the reasoning behind them.

**1. Every Chart.js box plot, violin and error-bar chart is silent on `main`.**
The plugin binds on `afterInit`, which runs before Chart.js parses its
datasets — and those three readings are taken from the parse rather than from
the author's rows: the boxplot plugin computes the five-number summary itself,
and `dataset.data` never holds it. So the layer was built from nothing.

Measured in Chromium on chart.js 4 with `@sgratzl/chartjs-chart-boxplot`,
logging `getDatasetMeta(0)._parsed.length` from a plugin of its own on a
three-box chart:

| hook | `_parsed.length` |
|---|---|
| `afterInit` | 0 |
| `afterUpdate` | 3 |
| `afterRender` | 3 |

and on the repository's **own** `examples/chartjs/boxplot.html`:

| | announced |
|---|---|
| before | "No trace info available", then "No more data to display" |
| after | "Group is Group A, Lower outlier(s) for Value are [5, 8]" |

A `barWithErrorBars` chart was silent for the same reason and reads now
("Group is alpha, value Value is 10"). A bar chart and a radar were unaffected
either way — their readings come from `chart.data.datasets`, which is filled
from construction.

**2. #1209 described the Victory half of its own fix incorrectly.** It said the
axis labels had swapped while the reading had not, so a horizontal box plot
named the group against the measurement's axis. That is impossible in the code
as written: `toMaidrLayer` swaps the labels on the same key the layer was
missing, so before it neither moved and the two agreed. The code change was
right; the account of what it fixed was not. Measured, before and after:

| | announced | right arrow |
|---|---|---|
| before | "vertical box plot" | Group is A → Group is B (across the groups) |
| after | "horizontal box plot" | C's sections; up → B, then A |

Both name the group against `Group`. What the key actually fixes is that the
first announces a chart drawn the other way round, and walks left and right
across groups that are stacked down the page — while the values they are drawn
along are reached with up and down.

## Related Issues

Follow-up to #1209. The Chart.js binding bug predates it: the box plot reading
has been taken from the parse since #1049, and the plugin has bound at
`afterInit` throughout.

## Changes Made

- **`src/adapters/chartjs/plugin.tsx`** — bind on `afterUpdate` rather than
  `afterInit`. Both hooks run inside `new Chart(...)`, so nothing arrives later
  than it did; what changes is that the parse has happened by the time the data
  is read. `afterUpdate` fires again on every hover, resize and update, so a
  chart whose type has no reading is now recorded as declined — otherwise it
  would be re-extracted and re-warned each time.
- **`test/adapters/chartjs/pluginLifecycle.esm-test.ts`** — drives the hooks in
  the order Chart.js runs them over a chart whose parse arrives between them,
  and asserts the mounted interface names a box plot rather than nothing. Also
  pins the once-only binding and the once-only warning. It is an ESM test
  because the plugin mounts the React interface, which reaches the
  `unified`/`react-markdown` stack.
- **`examples/chartjs/boxplot-horizontal.html`**, **`examples/victory/examples/HorizontalBoxPlotExample.tsx`**
  (plus its entry in the example app) — the two charts whose behaviour #1209
  asserted without a browser. Both are now checkable in one.
- **`src/adapters/victory/converters.ts`**, **`test/adapters/victory/distributionOrientation.test.ts`**
  — comments and the test's account of the bug corrected. No behaviour change.

## Screenshots (if applicable)

Not applicable — the change is in what is announced. The announcements are
quoted above.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all
pass (6013 unit + 142 component/ESM tests, 454 suites). The new lifecycle test
fails on `main`: all four cases.

Two limits worth stating plainly:

- **The Chart.js violin is verified only up to its announcement.** It binds and
  says "horizontal violin_box plot" with both layers, but the canvas-hosted
  violin would not take keyboard focus in my headless harness, so the
  per-point reading after activation is not measured. The box plot beside it,
  through the same plugin and the same activation path, is.
- **What made #1209's Victory claim wrong was reasoning from code instead of
  running it.** The correction here comes from `npm run dev:victory` with the
  adapter reverted and restored; the same method is what turned up the Chart.js
  binding bug, which no amount of reading the extractor would have shown.

---
_Generated by [Claude Code](https://claude.ai/code/session_0175KUdwfNYKRoqirPMiyALD)_