### PR TITLE
fix(funnel): read a funnel by the direction its magnitude runs

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -152,6 +152,8 @@ A `PieSeries` lives in amCharts' separate `percent.js` module and is bound to no
 
 A `FunnelSeries` lives in the same `percent.js` module, inside a `SlicedChart` rather than a `PieChart`, and is likewise bound to no axis — its dimensions default to `Stage` and `Value`. Its pyramid and pictorial-stack siblings carry the same ordered `category`/`value` stages and are read the same way.
 
+**A default funnel is announced as horizontal, and that is not a contradiction of amCharts' own `orientation`.** The two settings name different directions: amCharts' names the direction the stages progress, MAIDR's names the direction the magnitude runs — the convention by which a chart with its bars running left to right is a *horizontal* bar chart. Measured through the series' own API for values 100/60/20, a default `FunnelSeries` draws uniform band heights of 100 against widths of 500/300/100: the value is a horizontal extent, so MAIDR reads it with the count in `x` and the stage in `y`. Set `orientation: "horizontal"` and the two flip, giving the layer MAIDR calls upright. A `PyramidSeries` is neither — its bands encode the value as an *area*, with no dimension proportional to it — so it is left with no orientation at all.
+
 `RadarLineSeries` and `RadarColumnSeries` need `radar.js` on top of `xy.js`; a `RadarChart` extends `XYChart`, so the binder finds it with the rest.
 
 The **declared** rows are declared rather than detected — see [Declaring What a Chart Means](#declaring-what-a-chart-means) below.

--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -80,8 +80,18 @@ so the reading is that pair.
 | ECharts | read as | highlighted |
 |---|---|---|
 | `pie` | `pie` | yes — one selector naming every slice |
-| `funnel` | `funnel` | yes — one selector per stage |
+| `funnel` | `funnel` | yes — one selector per stage. `orient` is read; see below |
 | `gauge` | `gauge` | **no** — see below |
+
+**A funnel's `orient` and MAIDR's `orientation` name opposite directions, on
+purpose.** ECharts names the direction its stages progress; MAIDR names the
+direction the magnitude runs — the convention by which a chart with its bars
+running left to right is a *horizontal* bar chart. Measured in Chromium for
+values 100/60/20, `orient: 'vertical'` (the default) draws uniform band heights
+of 80 against widths of 360/216/72, so the value is a horizontal extent and the
+layer is read with the count in `x` and the stage in `y`. `orient: 'horizontal'`
+is the transpose — uniform widths of 120 against heights of 240/144/48 — and is
+the one MAIDR calls upright.
 
 A gauge draws **two** filled marks for its one datum: the track and the
 progress arc, measured as `#e8ebf0` and the series colour. The count check

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -1264,16 +1264,58 @@ function buildFunnelLayer(
   data: BarPoint[],
   options?: AmChartsBinderOptions,
 ): MaidrLayer {
+  const horizontal = drawsStagesDownThePage(series);
+  const stageLabel = options?.axisLabels?.x ?? FUNNEL_STAGE_AXIS;
+  const valueLabel = options?.axisLabels?.y ?? FUNNEL_VALUE_AXIS;
+
   return {
     id: layerId(series),
     type: TraceType.FUNNEL,
     title: seriesName(series),
-    axes: {
-      x: { label: options?.axisLabels?.x ?? FUNNEL_STAGE_AXIS },
-      y: { label: options?.axisLabels?.y ?? FUNNEL_VALUE_AXIS },
-    },
-    data,
+    ...(horizontal ? { orientation: Orientation.HORIZONTAL } : {}),
+    // `axes.x` names whichever axis the point's `x` lies on, so the pair is
+    // written in the order the payload puts them. The caller's own labels are
+    // a naming of the two dimensions -- stage and value -- and travel with
+    // them rather than with the letters.
+    axes: horizontal
+      ? { x: { label: valueLabel }, y: { label: stageLabel } }
+      : { x: { label: stageLabel }, y: { label: valueLabel } },
+    // `FunnelTrace` extends `BarTrace`, so a horizontal layer carries its
+    // magnitude in `x`.
+    data: horizontal ? data.map(point => ({ x: point.y, y: point.x })) : data,
   };
+}
+
+/**
+ * The one sliced series whose value is a horizontal extent.
+ *
+ * amCharts' `orientation` names the direction the STAGES progress; MAIDR's
+ * `orientation` names the direction the MAGNITUDE runs -- the convention a
+ * "horizontal bar chart" is named by. On a funnel the two are opposites.
+ * Measured in Chromium on amCharts 5 through the series' own API, values
+ * 100/60/20:
+ *
+ *   FunnelSeries, orientation 'vertical' (default)   heights 100 100 100   widths 500 300 100
+ *   FunnelSeries, orientation 'horizontal'           widths 160 160 160   heights 320 192 64
+ *   PyramidSeries (default)                          widths 373 471 500   heights 239 63 18
+ *
+ * So the default funnel stacks its stages down the page and encodes the value
+ * as the band's WIDTH: the magnitude runs horizontally, and the layer is
+ * `horz`. Its horizontal orientation is the transpose, which MAIDR calls
+ * vertical.
+ *
+ * A **pyramid** is neither: no dimension of it is proportional to the value --
+ * measured, 373/471/500 and 239/63/18 for 100/60/20 -- because a pyramid
+ * encodes the value as the band's AREA. It has no magnitude axis to name, so
+ * it keeps the upright default rather than being given a direction it does not
+ * have. The pictorial stack, which shares this builder, is left with it.
+ *
+ * @param series - The sliced series being read
+ * @returns True when the value is drawn as a horizontal extent
+ */
+function drawsStagesDownThePage(series: AmXYSeries): boolean {
+  return series.className === 'FunnelSeries'
+    && series.get('orientation') !== 'horizontal';
 }
 
 /**

--- a/src/adapters/echarts/single.ts
+++ b/src/adapters/echarts/single.ts
@@ -16,7 +16,7 @@
 
 import type { BarPoint, GaugePoint, MaidrLayer, PiePoint } from '@type/grammar';
 import type { EChartsSeriesModel } from './types';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
 import { markPerDatum } from './selectors';
 
@@ -139,22 +139,58 @@ function pieLayer(
  * @param selectors   - One selector per stage, when the marks were found
  * @returns The layer
  */
+/**
+ * What a funnel's two dimensions are called. A funnel series sits on no axis,
+ * so there is no axis name to read and the core's `X` / `Y` fallback would
+ * name the stage and its count after coordinates the chart does not have.
+ */
+const FUNNEL_STAGE_AXIS = 'Stage';
+const FUNNEL_COUNT_AXIS = 'Count';
+
 function funnelLayer(
   seriesModel: EChartsSeriesModel,
   read: Reading[],
   selectors: string[] | undefined,
 ): MaidrLayer {
-  const data: BarPoint[] = read.map(({ name, value }, index) => ({
-    x: name || `Stage ${index + 1}`,
-    y: value,
-  }));
+  // ECharts' `orient` and MAIDR's `orientation` name two different directions,
+  // and on a funnel they are opposites -- deliberately, and this is the whole
+  // reason the mapping is spelled out here.
+  //
+  // ECharts names the direction the STAGES progress. MAIDR names the direction
+  // the MAGNITUDE runs, which is the convention a "horizontal bar chart" is
+  // named by and the one `MaidrLayer.orientation` is written against: `horz`
+  // means the value is in `x`. Measured in Chromium on echarts 5, values
+  // 100/60/20:
+  //
+  //   orient: 'vertical' (default)   heights 80, 80, 80   widths 360, 216, 72
+  //   orient: 'horizontal'           widths 120,120,120   heights 240,144,48
+  //
+  // The default stacks its stages down the page with uniform band heights and
+  // encodes the value as the band's WIDTH, so the magnitude runs horizontally
+  // and the layer is `horz`. `orient: 'horizontal'` is the transpose of that,
+  // and is the one MAIDR calls vertical.
+  const horizontal = seriesModel.get('orient') !== 'horizontal';
+
+  const data: BarPoint[] = read.map(({ name, value }, index) => {
+    const stage = name || `Stage ${index + 1}`;
+    // `FunnelTrace` extends `BarTrace`, so a horizontal layer carries its
+    // magnitude in `x` -- the exchange the grammar's table calls for.
+    return horizontal ? { x: value, y: stage } : { x: stage, y: value };
+  });
   const name = authored(seriesModel);
 
   return {
     id: nextId('layer'),
     type: TraceType.FUNNEL,
     ...(name ? { name } : {}),
+    ...(horizontal ? { orientation: Orientation.HORIZONTAL } : {}),
     ...(selectors ? { selectors } : {}),
+    // A funnel is bound to no axis, so without these the reader is told the
+    // stage's count is "X". Named in the order the payload puts them, so
+    // `axes.x` is whichever axis the point's `x` lies on.
+    axes: horizontal
+      ? { x: { label: FUNNEL_COUNT_AXIS }, y: { label: FUNNEL_STAGE_AXIS } }
+      : { x: { label: FUNNEL_STAGE_AXIS }, y: { label: FUNNEL_COUNT_AXIS } },
     data,
   };
 }

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -1563,8 +1563,21 @@ function extractLayer(
     // A funnel is a bar chart whose order means something: same points, same
     // orientation handling, and the retention between stages is derived by
     // the trace rather than carried in the payload.
+    //
+    // Its axes are named rather than passed through: a funnel is drawn on a
+    // panel plotly gives no axis titles, so the layout carries none and the
+    // core's `X` / `Y` fallback would announce "X is 100" for a count. The
+    // same two names the Highcharts, amCharts and ECharts adapters give it.
     case TraceType.FUNNEL:
-      return extractBarLayer(trace, calcdata, TraceType.FUNNEL, id, title, selectors, axes);
+      return extractBarLayer(
+        trace,
+        calcdata,
+        TraceType.FUNNEL,
+        id,
+        title,
+        selectors,
+        funnelAxes(trace, axes),
+      );
 
     case TraceType.WATERFALL:
       return extractWaterfallLayer(trace, calcdata, id, title, selectors, axes);
@@ -1929,6 +1942,39 @@ function extractBarLayer(
     axes,
     ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
     data: orderedData,
+  };
+}
+
+/** The two dimensions a funnel has, for a chart that names neither. */
+const FUNNEL_STAGE_AXIS = 'Stage';
+const FUNNEL_COUNT_AXIS = 'Count';
+
+/**
+ * What a funnel's two dimensions are called, when plotly names neither.
+ *
+ * A funnel sits on a panel whose axes carry no titles, so `axes` arrives empty
+ * and a reader is told the count is "X". These name what each side actually
+ * holds -- and in the order the payload puts them, since `axes.x` names
+ * whichever axis the point's `x` lies on and a horizontal funnel carries its
+ * count there.
+ *
+ * A title plotly *does* carry is left alone: an author who named the axes
+ * means those names.
+ *
+ * @param trace - The funnel trace, read for which way it is drawn
+ * @param axes  - What the layout named, which is usually nothing
+ * @returns The axes to emit
+ */
+function funnelAxes(
+  trace: PlotlyTrace,
+  axes: MaidrLayer['axes'],
+): MaidrLayer['axes'] {
+  const horizontal = trace.orientation !== 'v';
+  const stage = { label: FUNNEL_STAGE_AXIS };
+  const count = { label: FUNNEL_COUNT_AXIS };
+  return {
+    x: axes?.x ?? (horizontal ? count : stage),
+    y: axes?.y ?? (horizontal ? stage : count),
   };
 }
 

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -1958,6 +1958,11 @@ const FUNNEL_COUNT_AXIS = 'Count';
  * whichever axis the point's `x` lies on and a horizontal funnel carries its
  * count there.
  *
+ * `Stage` and `Count` are the pair the Highcharts, ECharts and AnyChart
+ * adapters already fall back to. The amCharts one says `Stage` and `Value`,
+ * which is the odd one out and is left as it is here: renaming what a chart
+ * announces is not this fix's to make.
+ *
  * A title plotly *does* carry is left alone: an author who named the axes
  * means those names.
  *

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1400,6 +1400,24 @@ export interface MaidrLayer {
    * a reading is announced against, and the payload is written the same way
    * whichever value is set.
    *
+   * **What the two words name.** Orientation is the direction the *magnitude*
+   * runs, not which axis happens to be called `x`. That is the convention the
+   * whole field uses: a horizontal bar chart is one whose bars run left to
+   * right, with the categories down the y axis — and it is how the drawing
+   * libraries name the same switch. Chart.js: `indexAxis: 'y'` gives
+   * "horizontal bars", the y axis holding the categories and the x axis the
+   * values. Highcharts: `chart.inverted` makes "the x axis vertical and y axis
+   * horizontal". Matplotlib 3.10 replaced `boxplot(vert=False)` with
+   * `orientation='horizontal'`, which "plots the boxes horizontally". Plotly
+   * states it outright: with `'h'`, "the value of each bar spans along the
+   * horizontal".
+   *
+   * A producer therefore reads its chart, not its API's vocabulary. Where a
+   * library names the *other* direction — ECharts' and amCharts' funnel
+   * `orient`/`orientation` name the way the stages progress, so their default
+   * funnels encode the value as a band's width and are `horz` here — the
+   * adapter translates, and says so where it does.
+   *
    * The rule is: **the bar family swaps `x` and `y`; nothing else does.**
    *
    * | trace | `vert` | `horz` |

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -630,13 +630,50 @@ describe('fromAmCharts (sliced chart)', () => {
     const layer = result.subplots[0][0].layers[0];
     expect(layer.type).toBe(TraceType.FUNNEL);
     expect(layer.title).toBe('Checkout');
-    // A sliced chart is bound to no axis, so the dimensions name what they hold.
-    expect(layer.axes).toEqual({ x: { label: 'Stage' }, y: { label: 'Value' } });
+    // A `FunnelSeries` in its default `orientation: 'vertical'` stacks its
+    // stages down the page and encodes the value as each band's WIDTH --
+    // measured in Chromium through the series' own API, uniform heights of
+    // 100 against widths of 500/300/100 for values 100/60/20. The magnitude
+    // therefore runs horizontally, which is what MAIDR's `orientation` names,
+    // and `FunnelTrace` reads it off `x`.
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    // A sliced chart is bound to no axis, so the dimensions name what they
+    // hold -- in the order the payload puts them.
+    expect(layer.axes).toEqual({ x: { label: 'Value' }, y: { label: 'Stage' } });
     expect(layer.data as BarPoint[]).toEqual([
-      { x: 'Visited', y: 10000 },
-      { x: 'Signed up', y: 2400 },
-      { x: 'Purchased', y: 100 },
+      { x: 10000, y: 'Visited' },
+      { x: 2400, y: 'Signed up' },
+      { x: 100, y: 'Purchased' },
     ]);
+  });
+
+  it('leaves a horizontal funnel upright, which is the transpose of that', () => {
+    // amCharts' `orientation` names the direction the stages progress, so its
+    // 'horizontal' is the one whose value is a vertical extent -- measured,
+    // uniform widths of 160 against heights of 320/192/64.
+    const sliced = fakeSlicedChart({
+      series: [fakeFunnelSeries('Checkout', STAGES, 'FunnelSeries', 'horizontal')],
+    });
+
+    const layer = fromAmCharts(fakeRoot([sliced])).subplots[0][0].layers[0];
+
+    expect(layer.orientation).toBeUndefined();
+    expect(layer.axes).toEqual({ x: { label: 'Stage' }, y: { label: 'Value' } });
+    expect((layer.data as BarPoint[])[0]).toEqual({ x: 'Visited', y: 10000 });
+  });
+
+  it('gives a pyramid no orientation, because it encodes an area', () => {
+    // Neither dimension of a pyramid is proportional to the value -- measured,
+    // widths 373/471/500 and heights 239/63/18 for 100/60/20 -- so there is no
+    // magnitude axis to name and it keeps the upright default.
+    const sliced = fakeSlicedChart({
+      series: [fakeFunnelSeries('Checkout', STAGES, 'PyramidSeries')],
+    });
+
+    const layer = fromAmCharts(fakeRoot([sliced])).subplots[0][0].layers[0];
+
+    expect(layer.orientation).toBeUndefined();
+    expect((layer.data as BarPoint[])[0]).toEqual({ x: 'Visited', y: 10000 });
   });
 
   it('reads a pyramid as the same ordered stages a funnel is', () => {
@@ -660,8 +697,8 @@ describe('fromAmCharts (sliced chart)', () => {
     const layer = fromAmCharts(fakeRoot([sliced])).subplots[0][0].layers[0];
 
     expect(layer.data as BarPoint[]).toEqual([
-      { x: 'Visited', y: 10000 },
-      { x: 'Purchased', y: 100 },
+      { x: 10000, y: 'Visited' },
+      { x: 100, y: 'Purchased' },
     ]);
   });
 
@@ -679,8 +716,12 @@ describe('fromAmCharts (sliced chart)', () => {
       axisLabels: { x: 'Step', y: 'People' },
     });
 
+    // The caller names the two dimensions -- the stage and the count -- and
+    // the names travel with them rather than with the letters: `axes.x` is
+    // whichever axis the point's `x` lies on, which on this funnel is the
+    // count.
     expect(result.subplots[0][0].layers[0].axes)
-      .toEqual({ x: { label: 'Step' }, y: { label: 'People' } });
+      .toEqual({ x: { label: 'People' }, y: { label: 'Step' } });
   });
 });
 

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -325,11 +325,19 @@ export function fakeFunnelSeries(
   name: string,
   stages: Array<{ category: string; value: number | null; slice?: unknown }>,
   className = 'FunnelSeries',
+  orientation?: 'vertical' | 'horizontal',
 ): AmXYSeries {
   return fakeSeries({
     className,
     name,
-    settings: { categoryField: 'category', valueField: 'value' },
+    settings: {
+      categoryField: 'category',
+      valueField: 'value',
+      // amCharts' own name for the direction the STAGES progress, which is
+      // the opposite of the one MAIDR's `orientation` names. Omitted for the
+      // default, exactly as a chart that never set it reports.
+      ...(orientation ? { orientation } : {}),
+    },
     data: stages,
   });
 }

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -24,7 +24,7 @@ import { createMaidrFromEChart } from '@adapters/echarts/converters';
 import { afterAll, afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { FunnelTrace } from '@model/funnel';
 import { PieTrace } from '@model/pie';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -35,6 +35,8 @@ interface FakeSeries {
   name?: string;
   min?: number;
   max?: number;
+  /** ECharts' own name for the direction a funnel's STAGES progress. */
+  orient?: 'vertical' | 'horizontal';
 }
 
 function fakeSeriesModel(series: FakeSeries): EChartsSeriesModel {
@@ -42,6 +44,7 @@ function fakeSeriesModel(series: FakeSeries): EChartsSeriesModel {
     name: series.name,
     min: series.min,
     max: series.max,
+    orient: series.orient,
   };
   const list: EChartsList = {
     dimensions: ['value'],
@@ -241,6 +244,13 @@ describe('an eCharts funnel chart', () => {
     // The order is the reading: MAIDR pitches each stage against the one
     // before it, so a sorted funnel would announce a retention the chart
     // never showed.
+    //
+    // The pair reads `{x: count, y: stage}` because an ECharts funnel's
+    // default `orient: 'vertical'` stacks its stages down the page and
+    // encodes the value as each band's WIDTH -- measured in Chromium,
+    // uniform heights of 80 against widths of 360/216/72 for values
+    // 100/60/20 -- so the magnitude runs horizontally and `FunnelTrace`,
+    // which extends `BarTrace`, reads it off `x`.
     const layer = layerFor(
       {
         type: 'funnel',
@@ -251,11 +261,38 @@ describe('an eCharts funnel chart', () => {
     );
 
     expect(layer.type).toBe(TraceType.FUNNEL);
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 100, y: 'Visit' },
+      { x: 60, y: 'Cart' },
+      { x: 30, y: 'Buy' },
+    ]);
+  });
+
+  it('reads an `orient: horizontal` funnel as the upright one it is', () => {
+    // The transpose of the default, and the one place ECharts' word and
+    // MAIDR's agree on neither: ECharts names the direction the stages
+    // progress, MAIDR the direction the magnitude runs. Measured in Chromium,
+    // `orient: 'horizontal'` draws uniform widths of 120 against heights of
+    // 240/144/48 for values 100/60/30 -- the value is a vertical extent, so
+    // the layer is the upright one and keeps `{x: stage, y: count}`.
+    const layer = layerFor(
+      {
+        type: 'funnel',
+        orient: 'horizontal',
+        names: ['Visit', 'Cart', 'Buy'],
+        values: [100, 60, 30],
+      },
+      3,
+    );
+
+    expect(layer.orientation).toBeUndefined();
     expect(layer.data as BarPoint[]).toEqual([
       { x: 'Visit', y: 100 },
       { x: 'Cart', y: 60 },
       { x: 'Buy', y: 30 },
     ]);
+    expect(layer.axes).toEqual({ x: { label: 'Stage' }, y: { label: 'Count' } });
   });
 
   it('names each stage separately, which is the shape FunnelTrace reads', () => {

--- a/test/adapters/plotly/funnelAxes.test.ts
+++ b/test/adapters/plotly/funnelAxes.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * A plotly funnel announced its count as "X".
+ *
+ * A funnel is drawn on a panel plotly gives no axis titles, so the `axes` the
+ * extractor is handed arrive empty and the core falls back to naming the two
+ * dimensions after coordinates the chart does not have. Measured in Chromium
+ * on plotly.js 2.35.2, the first stage of `{y: stages, x: counts}`:
+ *
+ *   before   "Stage is Visits, X is 100"
+ *   after    "Stage is Visits, Count is 100"
+ *
+ * The Highcharts, amCharts and ECharts adapters all name the same two
+ * dimensions `Stage` and `Count` for the same reason.
+ *
+ * The pair is written in the order the payload puts them: `axes.x` names
+ * whichever axis the point's `x` lies on, and a funnel drawn with its stages
+ * down the page carries the count there. That is the same rule the rest of the
+ * grammar's `orientation` table follows, and plotly resolves the orientation
+ * itself -- `{y: stages, x: counts}` comes back as `orientation: 'h'`.
+ */
+
+import type { PlotlyCalcData, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import type { MaidrLayer } from '@type/grammar';
+import { extractPlotlyData } from '@adapters/plotly/extractor';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { Orientation } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const STAGES = ['Visits', 'Signups', 'Buys'];
+const COUNTS = [100, 60, 20];
+
+/**
+ * A rendered plotly div holding one funnel trace.
+ *
+ * @param horizontal - Whether the stages run down the page, which is plotly's
+ *                     own default and what it resolves `orientation: 'h'` for
+ * @param titled     - Whether the layout names its axes, which a funnel's
+ *                     panel normally does not
+ * @returns The graph div
+ */
+function graphDiv(horizontal: boolean, titled = false): PlotlyGraphDiv {
+  const div = document.createElement('div');
+  div.id = 'chart';
+  div.className = 'js-plotly-plot';
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'main-svg');
+  div.appendChild(svg);
+  document.body.appendChild(div);
+
+  const gd = div as PlotlyGraphDiv;
+  (gd as unknown as { _fullData: unknown })._fullData = [
+    {
+      type: 'funnel',
+      orientation: horizontal ? 'h' : 'v',
+      x: horizontal ? COUNTS : STAGES,
+      y: horizontal ? STAGES : COUNTS,
+    } as unknown as PlotlyTrace,
+  ];
+  (gd as unknown as { _fullLayout: unknown })._fullLayout = {
+    xaxis: titled ? { title: { text: 'People' } } : {},
+    yaxis: titled ? { title: { text: 'Step' } } : {},
+  };
+  (gd as unknown as { calcdata: PlotlyCalcData[][] }).calcdata = [
+    COUNTS.map(count => ({ s: count }) as PlotlyCalcData),
+  ];
+  return gd;
+}
+
+/**
+ * The layer a funnel trace converts to.
+ * @param horizontal - Whether the stages run down the page
+ * @param titled     - Whether the layout names its axes
+ * @returns The emitted layer
+ */
+function layerFor(horizontal: boolean, titled = false): MaidrLayer {
+  const layer = extractPlotlyData(graphDiv(horizontal, titled))?.subplots[0][0].layers[0];
+  if (!layer)
+    throw new Error('no layer emitted');
+  return layer;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('a plotly funnel with its stages down the page', () => {
+  it('is read as a horizontal one, which is where its bars run', () => {
+    expect(layerFor(true).orientation).toBe(Orientation.HORIZONTAL);
+  });
+
+  it('names the count axis rather than leaving it as "X"', () => {
+    expect(layerFor(true).axes).toEqual({
+      x: { label: 'Count' },
+      y: { label: 'Stage' },
+    });
+  });
+});
+
+describe('a plotly funnel with its stages across the page', () => {
+  it('names the two the other way round, as the payload puts them', () => {
+    const layer = layerFor(false);
+
+    expect(layer.orientation).toBeUndefined();
+    expect(layer.axes).toEqual({
+      x: { label: 'Stage' },
+      y: { label: 'Count' },
+    });
+  });
+});
+
+describe('a plotly funnel whose layout names its axes', () => {
+  it('keeps the author\'s names', () => {
+    // A fallback is for a chart that named nothing. An author who titled the
+    // axes meant those titles.
+    expect(layerFor(true, true).axes).toEqual({
+      x: { label: 'People' },
+      y: { label: 'Step' },
+    });
+  });
+});

--- a/test/adapters/plotly/funnelAxes.test.ts
+++ b/test/adapters/plotly/funnelAxes.test.ts
@@ -13,8 +13,10 @@
  *   before   "Stage is Visits, X is 100"
  *   after    "Stage is Visits, Count is 100"
  *
- * The Highcharts, amCharts and ECharts adapters all name the same two
- * dimensions `Stage` and `Count` for the same reason.
+ * The Highcharts, ECharts and AnyChart adapters fall back to the same pair for
+ * the same reason. The amCharts one says `Stage` and `Value` instead -- the odd
+ * one out of the four, noted rather than changed here, since what a chart
+ * announces is not this fix's to rename.
  *
  * The pair is written in the order the payload puts them: `axes.x` names
  * whichever axis the point's `x` lies on, and a funnel drawn with its stages


### PR DESCRIPTION
# Pull Request

## Description

#1209 left one question open: the funnel family's orientation was inconsistent
across adapters, and I could not say which reading was right. This settles it
against the published conventions and against measured geometry, and closes the
inconsistency.

**The convention.** Orientation names the direction the **magnitude** runs, not
which axis happens to be called `x`. Every definition of a horizontal bar chart
says so — bars running left to right, categories down the y axis — and so does
every library that offers the switch:

| library | API | what it says |
|---|---|---|
| Chart.js | `indexAxis: 'y'` | "horizontal bars"; y holds the categories, x the values |
| Highcharts | `chart.inverted` | "invert the axes so that the x axis is vertical and y axis is horizontal" |
| Matplotlib 3.10 | `orientation='horizontal'` (replacing `vert=False`) | "plots the boxes horizontally" |
| Plotly | `orientation='h'` | "the value of each bar spans along the horizontal" |

That is the rule MAIDR's `MaidrLayer.orientation` was already written against,
so **nothing merged in #1209 or #1210 needs reverting** — bars, histograms, box
plots, violins, dot plots, lollipops, dumbbells and error bars all follow it.

**Where two libraries name the other direction.** ECharts' funnel `orient` and
amCharts' `orientation` name the way the *stages progress*. Measured in
Chromium for values 100/60/20:

| chart | uniform | proportional to the value | magnitude runs |
|---|---|---|---|
| ECharts `orient: 'vertical'` (default) | heights 80, 80, 80 | widths 360, 216, 72 | horizontally |
| ECharts `orient: 'horizontal'` | widths 120, 120, 120 | heights 240, 144, 48 | vertically |
| amCharts `orientation: 'vertical'` (default) | heights 100, 100, 100 | widths 500, 300, 100 | horizontally |
| amCharts `orientation: 'horizontal'` | widths 160, 160, 160 | heights 320, 192, 64 | vertically |

So both defaults draw the value as a band's **width** and were announced as
upright funnels — while the identical figure from Plotly was announced, right,
as a horizontal one. The same chart now reads the same way whichever library
drew it:

```
before  ECharts: "vertical funnel"    "Stage is Visits, Y is 100"
after   ECharts: "horizontal funnel"  "Stage is Visits, Count is 100"
        Plotly:  "horizontal funnel"  "Stage is Visits, Count is 100"
```

## Related Issues

Follow-up to #1209, which flagged this as needing its own decision, and to
#1210. No issue filed; the question came from the maintainer directly.

## Changes Made

- **`src/adapters/echarts/single.ts`** — read `series.orient`; the default
  emits `horz` with the count in `x`, `orient: 'horizontal'` stays upright.
- **`src/adapters/amcharts/adapter.ts`** — same for `FunnelSeries`, keyed on
  the series class so its siblings are not swept in.
- **`src/adapters/plotly/extractor.ts`** — name a funnel's two dimensions when
  the layout names neither, which is always: a funnel's panel carries no axis
  titles, so the count was announced as "X".
- **`src/type/grammar.ts`** — write the convention down where `orientation` is
  defined, with the four library statements, so the next adapter reads its
  chart rather than its API's vocabulary.
- Tests for each, and the two docs pages that describe these funnels.

**Deliberately left alone, having measured them:**

- **Highcharts** — "Each element of the funnel has a height that relates to the
  value", and measured 166/100/33 for 100/60/20. Height-encoded, so its upright
  reading was already right.
- **AnyChart** — measured 172/103/34 against widths 343/198/147: height-encoded
  too.
- **An amCharts pyramid** — *neither* dimension is proportional to the value
  (measured 373/471/500 and 239/63/18), because a pyramid encodes it as an
  **area**. It has no magnitude axis to name, so it keeps none rather than
  being given a direction it does not have. Its pictorial-stack sibling goes
  with it.

## Screenshots (if applicable)

Not applicable — the change is in what is announced, and the announcements are
quoted above.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all
pass (6020 unit + 142 component/ESM tests, 455 suites).

Three existing expectations changed with the behaviour rather than being
worked around — the amCharts funnel payload, its axis-label override, and the
ECharts stage order — each now carrying the measurement that decides it.

One limit: the amCharts geometry was read through the series' own API
(`slice.width()` / `slice.height()`) rather than from the DOM, because amCharts
5 draws to canvas. The ECharts, Highcharts and AnyChart figures were measured
from their rendered SVG.

---
_Generated by [Claude Code](https://claude.ai/code/session_0175KUdwfNYKRoqirPMiyALD)_