### PR TITLE
docs: add npm, jsDelivr, CI, license and docs badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
   <img src="docs/logo.svg" width="350px" alt="A stylized MAIDR logo, with curved characters for M A, a hand pointing for an I, the D character, and R represented in braille."/>
   <hr style="color:transparent" />
   <br />
+
+[![npm](https://img.shields.io/npm/v/maidr.svg)](https://www.npmjs.com/package/maidr)
+[![npm downloads](https://img.shields.io/npm/dt/maidr.svg)](https://www.npmjs.com/package/maidr)
+[![jsDelivr hits](https://img.shields.io/jsdelivr/npm/hm/maidr.svg)](https://www.jsdelivr.com/package/npm/maidr)
+[![CI](https://github.com/xability/maidr/actions/workflows/ci.yml/badge.svg)](https://github.com/xability/maidr/actions/workflows/ci.yml)
+[![License](https://img.shields.io/npm/l/maidr.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-maidr.ai-1f6feb.svg)](https://maidr.ai)
+
 </div>
 
 # MAIDR: Multimodal Access and Interactive Data Representation

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
   <hr style="color:transparent" />
   <br />
 
-[![npm](https://img.shields.io/npm/v/maidr.svg)](https://www.npmjs.com/package/maidr)
-[![npm downloads](https://img.shields.io/npm/dt/maidr.svg)](https://www.npmjs.com/package/maidr)
-[![jsDelivr hits](https://img.shields.io/jsdelivr/npm/hm/maidr.svg)](https://www.jsdelivr.com/package/npm/maidr)
-[![CI](https://github.com/xability/maidr/actions/workflows/ci.yml/badge.svg)](https://github.com/xability/maidr/actions/workflows/ci.yml)
-[![License](https://img.shields.io/npm/l/maidr.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-maidr.ai-1f6feb.svg)](https://maidr.ai)
+[![npm version](https://img.shields.io/npm/v/maidr.svg)](https://www.npmjs.com/package/maidr)
+[![npm total downloads](https://img.shields.io/npm/dt/maidr.svg)](https://www.npmjs.com/package/maidr)
+[![jsDelivr monthly hits](https://img.shields.io/jsdelivr/npm/hm/maidr.svg)](https://www.jsdelivr.com/package/npm/maidr)
+[![CI build status](https://github.com/xability/maidr/actions/workflows/ci.yml/badge.svg)](https://github.com/xability/maidr/actions/workflows/ci.yml)
+[![Package license](https://img.shields.io/npm/l/maidr.svg)](LICENSE)
+[![Documentation site](https://img.shields.io/badge/docs-maidr.ai-1f6feb.svg)](https://maidr.ai)
 
 </div>
 


### PR DESCRIPTION
## Description

The README opened with the logo and went straight into prose. Nothing on it said the package is on npm, what version it is, whether CI is green, or where the docs live. For a library at 4.6.0 with 194 releases, that is a lot of trust signal left on the floor.

Six badges, added inside the existing centred block under the logo. Every value below was parsed out of the returned SVG rather than assumed:

| badge | renders |
|---|---|
| `img.shields.io/npm/v/maidr` | `npm \| v4.6.0` |
| `img.shields.io/npm/dt/maidr` | `downloads \| 25k` |
| `img.shields.io/jsdelivr/npm/hm/maidr` | `jsdelivr \| 1.2k/month` |
| `actions/workflows/ci.yml/badge.svg` | `CI \| passing` |
| `img.shields.io/npm/l/maidr` | `license \| GPL-3.0-or-later` |
| docs badge | static link to maidr.ai |

### Why jsDelivr as well as npm

`py-maidr` and `r-maidr` both load `maidr.js` from `cdn.jsdelivr.net` rather than installing from npm, so the npm download count misses most of the real consumption. The two numbers side by side describe this package's usage far better than either does alone — and it is the one badge here that is specific to how maidr is actually delivered.

### Lifetime rather than monthly downloads

`npm/dt` (25k) over `npm/dm` (2.1k/month), matching the py-maidr and r-maidr READMEs. A lifetime count does not visually regress on a quiet month.

## Deliberately not added

A bundle-size badge. Bundlephobia has been unreliable for a while and a badge that fails to resolve reads as neglect rather than as a missing integration — the same reason the r-maidr PR skipped a codecov badge that renders "unknown".

## Type of Change

- [x] Documentation update

## Checklist

- [x] Self-reviewed
- [x] No new warnings
- [x] Every badge URL verified to return a real value, not a placeholder or an error
- [x] Meaningful `alt` text on each badge — this is an accessibility project, and an empty `[![]()]` would be the wrong thing to ship here
- [x] `node scripts/conflictMarkers.js` clean (1348 tracked files)

README-only; no `src/`, no `package.json`, no generated instruction files, so `sync:copilot:check`, `type-check`, eslint and the test suite are untouched by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
