### PR TITLE
fix(model): stop reading a null gap as a measured zero

### DIFF
--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -1,6 +1,7 @@
 import type { LinePoint, MaidrLayer, StepDirection } from '@type/grammar';
 import type { DescriptionState, TextState, TraceState } from '@type/state';
 import { TraceType } from '@type/grammar';
+import { toBarValue } from './bar';
 import { LineTrace } from './line';
 import { STEP_DIRECTION_LABEL, stepDataVertices } from './step';
 
@@ -241,7 +242,7 @@ export class AreaTrace extends LineTrace {
     for (const series of this.points) {
       for (const point of series) {
         const key = String(point.x);
-        const value = Number(point.y);
+        const value = toBarValue(point.y);
         const running = totals.get(key);
         if (!isMeasured(value)) {
           // A column reached only by gaps has no total, only an absence.
@@ -297,7 +298,7 @@ export class AreaTrace extends LineTrace {
       return baseText;
     }
 
-    const value = Number(point.y);
+    const value = toBarValue(point.y);
     // A zero total is reachable — series that cancel out, or a column of
     // zeros — and dividing by it yields Infinity or NaN. Report the total and
     // stay silent about the share rather than announcing a share of nothing.

--- a/src/model/bump.ts
+++ b/src/model/bump.ts
@@ -2,6 +2,7 @@ import type { RotorFilterUnit } from '@model/abstract';
 import type { MaidrLayer } from '@type/grammar';
 import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
 import { MathUtil } from '@util/math';
+import { isMeasured } from './bar';
 import { LineTrace } from './line';
 
 /**
@@ -92,9 +93,18 @@ export class BumpTrace extends LineTrace {
       0,
     );
 
+    // A period the competitor was not ranked in holds NaN, and a move into
+    // or out of it would be NaN too -- which is not `undefined`, so the text
+    // would read it out as a change and the rotor gate would count it as a
+    // rank that moved. There is no previous rank to compare against, which
+    // is the first period's situation, and it is treated the same way.
     this.moves = this.lineValues.map(row =>
-      row.map((rank, column) =>
-        (column === 0 ? undefined : row[column - 1] - rank)));
+      row.map((rank, column) => {
+        const previous = row[column - 1];
+        return column === 0 || !isMeasured(rank) || !isMeasured(previous)
+          ? undefined
+          : previous - rank;
+      }));
 
     // Precomputed, as `Candlestick` precomputes its trend units and for the
     // same reason: the ranks are fixed at construction and the rotor service

--- a/src/model/funnel.ts
+++ b/src/model/funnel.ts
@@ -125,18 +125,27 @@ export class FunnelTrace extends BarTrace {
       return base;
     }
 
+    const retention = this.retention[stage];
+    const share = this.share[stage];
+
     return {
       ...base,
-      // What fraction of the previous stage got here.
-      z: { label: 'Retained', value: asPercent(this.retention[stage]) },
+      // What fraction of the previous stage got here. When there is no ratio
+      // -- this stage or the one before it measured nothing -- the NaN goes
+      // through as a number rather than formatted: a non-finite number is
+      // what `TextService` reads as "missing", while the string "NaN%" is a
+      // value like any other and would be announced as one.
+      z: { label: 'Retained', value: isMeasured(retention) ? asPercent(retention) : retention },
       // The population that entered, with this stage's share of it. Renders as
       // ", Entered is 10000, 24.0% of it" -- the cumulative view, which the
       // per-stage retention does not give and which a reader would otherwise
-      // have to multiply out across every stage they had passed.
+      // have to multiply out across every stage they had passed. Without a
+      // measured share the clause is dropped, as `AreaTrace` drops it:
+      // "NaN% of it" claims a fraction of a population that was never counted.
       stack: {
         label: 'Entered',
         value: this.counts[0],
-        share: this.share[stage],
+        share: isMeasured(share) ? share : undefined,
       },
     };
   }

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -680,6 +680,14 @@ export class LineTrace extends AbstractTrace {
     const currentY = this.points[this.row][this.col].y;
     const intersections: AudioState[] = [];
 
+    // A gap shares nothing with any other line. Without this, `null === null`
+    // matches every other line that also has no reading at this x, and two
+    // absences are announced and sonified as a crossing the chart never drew.
+    if (!isMeasured(toBarValue(currentY))) {
+      this.currentIntersectionsCache = { key, value: intersections };
+      return intersections;
+    }
+
     for (let r = 0; r < this.points.length; r++) {
       const c = this.points[r].findIndex(
         p => p.x === currentX && p.y === currentY,

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -1454,9 +1454,13 @@ export class LineTrace extends AbstractTrace {
     }> = [];
 
     // Numeric coordinates for segment math; categorical x values resolve to
-    // ordinal positions on the shared domain (see numericX).
+    // ordinal positions on the shared domain (see numericX). `toBarValue`
+    // for y, as the constructor uses: `Number(null)` is 0, which puts a
+    // vertex on the x axis where the chart draws a gap, and every line
+    // passing between that phantom vertex and the gap's neighbours would
+    // then be reported as crossing this one.
     const numericLines = this.points.map(line =>
-      line.map(point => ({ x: this.numericX(point.x), y: Number(point.y) })),
+      line.map(point => ({ x: this.numericX(point.x), y: toBarValue(point.y) })),
     );
     const currentLine = numericLines[currentGroup];
 
@@ -1482,6 +1486,17 @@ export class LineTrace extends AbstractTrace {
       const seg1End = currentLine[segIndex + 1];
       const seg2Start = numericLines[otherLine][otherSegIndex];
       const seg2End = numericLines[otherLine][otherSegIndex + 1];
+
+      // A segment with a gap at either end is not drawn, so nothing can
+      // cross it. The arithmetic below would reject a NaN endpoint anyway,
+      // but only because every comparison against NaN is false; skip it
+      // deliberately rather than by that accident.
+      if (
+        !Number.isFinite(seg1Start.y) || !Number.isFinite(seg1End.y)
+        || !Number.isFinite(seg2Start.y) || !Number.isFinite(seg2End.y)
+      ) {
+        return;
+      }
 
       const intersection = this.getSegmentIntersection(seg1Start, seg1End, seg2Start, seg2End);
       if (!intersection) {

--- a/test/model/areaGaps.test.ts
+++ b/test/model/areaGaps.test.ts
@@ -1,0 +1,120 @@
+import type { AreaTrace } from '@model/area';
+import type { NotificationService } from '@service/notification';
+import type { LinePoint } from '@type/grammar';
+import type { NonEmptyTraceState, TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A stacked area whose series have gaps (#925).
+ *
+ * `computeColumnTotals` guards a column reached only by gaps so that it has
+ * no total, and `text` withholds the share of a point that measured nothing.
+ * Both guards read the sample through `Number(point.y)`, and `Number(null)`
+ * is `0` -- a measured zero, which the guards accept. So a column of nothing
+ * but gaps announced "Total is 0" and pulled the description's minimum total
+ * down to 0, and a lone gap in a measured column announced itself as
+ * "0.0% of it".
+ */
+
+const SUBSCRIPTIONS: LinePoint[] = [
+  { x: 'Q1', y: 10, z: 'Subscriptions' },
+  { x: 'Q2', y: null, z: 'Subscriptions' },
+  { x: 'Q3', y: 30, z: 'Subscriptions' },
+];
+
+/** `Services` measured every quarter. */
+const SERVICES: LinePoint[] = [
+  { x: 'Q1', y: 5, z: 'Services' },
+  { x: 'Q2', y: 20, z: 'Services' },
+  { x: 'Q3', y: 70, z: 'Services' },
+];
+
+/** `Services` with the same quarter unmeasured. */
+const SERVICES_GAPPED: LinePoint[] = [
+  { x: 'Q1', y: 5, z: 'Services' },
+  { x: 'Q2', y: null, z: 'Services' },
+  { x: 'Q3', y: 70, z: 'Services' },
+];
+
+function stackedArea(data: LinePoint[][], row: number, col: number): AreaTrace {
+  const trace = TraceFactory.create({
+    id: 'test-area-gaps',
+    type: TraceType.STACKED_AREA,
+    title: 'Revenue',
+    axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+    data,
+  }) as AreaTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+function nonEmptyState(trace: AreaTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+function announce(state: TraceState): string {
+  const text = new TextService({ notify: jest.fn() } as unknown as NotificationService);
+  const listener = jest.fn();
+  const disposable = text.onChange(listener);
+
+  text.update(state);
+  disposable.dispose();
+  return (listener.mock.calls[0][0] as { value: string }).value;
+}
+
+describe('a column where every series has a gap', () => {
+  test('has no total to announce', () => {
+    // The chart draws no stack at Q2, so there is no height to report;
+    // "Total is 0" would claim one.
+    const trace = stackedArea([SUBSCRIPTIONS, SERVICES_GAPPED], 0, 1);
+
+    expect(announce(trace.state)).toBe('Quarter is Q2, Revenue is missing, Group is Subscriptions');
+    expect(nonEmptyState(trace).text.stack).toBeUndefined();
+  });
+
+  test('does not drag the minimum total down to zero', () => {
+    const stats = stackedArea([SUBSCRIPTIONS, SERVICES_GAPPED], 0, 0).description.stats;
+
+    expect(stats).toContainEqual({ label: 'Minimum total', value: 15 });
+    expect(stats).toContainEqual({ label: 'Maximum total', value: 100 });
+  });
+});
+
+describe('a gap in a column other series did measure', () => {
+  test('announces the total of the measured series and no share', () => {
+    // The stack at Q2 is the 20 that Services measured. The gap is not a
+    // zero-height band inside it, so it has no share of it to report.
+    const trace = stackedArea([SUBSCRIPTIONS, SERVICES], 0, 1);
+
+    expect(announce(trace.state)).toBe('Quarter is Q2, Revenue is missing, Group is Subscriptions, Total is 20');
+    expect(nonEmptyState(trace).text.stack).toEqual({ label: 'Total', value: 20, share: undefined });
+  });
+
+  test('the measured series in that column keeps its full share', () => {
+    const trace = stackedArea([SUBSCRIPTIONS, SERVICES], 1, 1);
+
+    expect(announce(trace.state)).toBe('Quarter is Q2, Revenue is 20, Group is Services, Total is 20, 100.0% of it');
+  });
+});
+
+describe('a measured zero is still a reading', () => {
+  test('counts towards the total and announces its share', () => {
+    // The distinction the guard exists to draw: a series that really did
+    // read nothing this quarter is a zero-height band, and says so.
+    const zero: LinePoint[] = [
+      { x: 'Q1', y: 10, z: 'Subscriptions' },
+      { x: 'Q2', y: 0, z: 'Subscriptions' },
+      { x: 'Q3', y: 30, z: 'Subscriptions' },
+    ];
+    const trace = stackedArea([zero, SERVICES], 0, 1);
+
+    expect(announce(trace.state)).toBe('Quarter is Q2, Revenue is 0, Group is Subscriptions, Total is 20, 0.0% of it');
+  });
+});

--- a/test/model/bumpGaps.test.ts
+++ b/test/model/bumpGaps.test.ts
@@ -1,0 +1,122 @@
+import type { BumpTrace } from '@model/bump';
+import type { NotificationService } from '@service/notification';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState, TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A bump chart where a competitor has no rank for a period (#925).
+ *
+ * A rank that was never measured arrives as `null` and is held as `NaN`. The
+ * move into or out of such a period is `NaN` too, and `NaN` is not
+ * `undefined`: the text saw a move where there was none to report, and read
+ * it out as "Change is missing" -- on the gap and again on the first
+ * measured period after it. The rotor gate had the same blind spot, offering
+ * "Rank gained" and "Rank lost" on a table whose only non-zero moves were
+ * gaps.
+ */
+
+/** Two competitors who miss R2 and otherwise never move. */
+const FROZEN_WITH_GAP: LinePoint[][] = [
+  [
+    { x: 'R1', y: 1, z: 'Ash' },
+    { x: 'R2', y: null, z: 'Ash' },
+    { x: 'R3', y: 1, z: 'Ash' },
+  ],
+  [
+    { x: 'R1', y: 2, z: 'Birch' },
+    { x: 'R2', y: null, z: 'Birch' },
+    { x: 'R3', y: 2, z: 'Birch' },
+  ],
+];
+
+/** The same two, swapping places across the round neither was ranked in. */
+const SWAP_ACROSS_GAP: LinePoint[][] = [
+  [
+    { x: 'R1', y: 1, z: 'Ash' },
+    { x: 'R2', y: null, z: 'Ash' },
+    { x: 'R3', y: 2, z: 'Ash' },
+    { x: 'R4', y: 1, z: 'Ash' },
+  ],
+  [
+    { x: 'R1', y: 2, z: 'Birch' },
+    { x: 'R2', y: null, z: 'Birch' },
+    { x: 'R3', y: 1, z: 'Birch' },
+    { x: 'R4', y: 2, z: 'Birch' },
+  ],
+];
+
+function createLayer(data: LinePoint[][]): MaidrLayer {
+  return {
+    id: 'test-bump-gaps',
+    type: TraceType.BUMP,
+    title: 'League table',
+    axes: { x: { label: 'Round' }, y: { label: 'Rank' } },
+    data,
+  };
+}
+
+function bump(data: LinePoint[][], row: number, col: number): BumpTrace {
+  const trace = TraceFactory.create(createLayer(data)) as BumpTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+function nonEmptyState(trace: BumpTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+function announce(state: TraceState): string {
+  const text = new TextService({ notify: jest.fn() } as unknown as NotificationService);
+  const listener = jest.fn();
+  const disposable = text.onChange(listener);
+
+  text.update(state);
+  disposable.dispose();
+  return (listener.mock.calls[0][0] as { value: string }).value;
+}
+
+describe('a period the competitor was not ranked in', () => {
+  test('reports no move, since there is no rank to have moved', () => {
+    const trace = bump(SWAP_ACROSS_GAP, 0, 1);
+
+    expect(nonEmptyState(trace).text.stack).toBeUndefined();
+    expect(announce(trace.state)).toBe('Round is R2, Rank is missing, Competitor is Ash');
+  });
+
+  test('the first ranked period after it reports no move either', () => {
+    // There is no previous rank to compare against, which is the first
+    // period's situation exactly, and it is read the same way.
+    const trace = bump(SWAP_ACROSS_GAP, 0, 2);
+
+    expect(nonEmptyState(trace).text.stack).toBeUndefined();
+    expect(announce(trace.state)).toBe('Round is R3, Rank is 2, Competitor is Ash');
+  });
+
+  test('a move between two ranked periods is still reported', () => {
+    expect(nonEmptyState(bump(SWAP_ACROSS_GAP, 0, 3)).text.stack)
+      .toEqual({ label: 'Places gained', value: 1 });
+  });
+});
+
+describe('the rotor across a gap', () => {
+  test('offers nothing on a table where no measured rank ever moved', () => {
+    expect(bump(FROZEN_WITH_GAP, 0, 0).getRotorFilterUnits()).toEqual([]);
+  });
+
+  test('does not stop on the gap or on the period after it', () => {
+    // Ash's only gain is into R4. From R1, the gap at R2 and the return at
+    // R3 are not moves, so the filter has to pass over both.
+    const trace = bump(SWAP_ACROSS_GAP, 0, 0);
+
+    expect(trace.moveToRotorFilter('gained', 'right')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe('R4');
+  });
+});

--- a/test/model/funnelGaps.test.ts
+++ b/test/model/funnelGaps.test.ts
@@ -1,0 +1,108 @@
+import type { FunnelTrace } from '@model/funnel';
+import type { NotificationService } from '@service/notification';
+import type { BarPoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState, TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A funnel with a stage that measured nothing, read through the text service.
+ *
+ * `FunnelTrace.ratio` answers `NaN` for a stage that is zero or absent, and
+ * its docstring promises the text reads that as "missing". The promise only
+ * holds if the ratio reaches `TextService` as a non-finite *number*: formatted
+ * into a percentage string first it arrives as the literal "NaN%", which the
+ * service has no reason to treat as anything but a value.
+ */
+
+function createLayer(data: BarPoint[]): MaidrLayer {
+  return {
+    id: 'test-funnel-gaps',
+    type: TraceType.FUNNEL,
+    title: 'Checkout funnel',
+    axes: { x: { label: 'Stage' }, y: { label: 'People' } },
+    data,
+  };
+}
+
+function funnel(stage: number, data: BarPoint[]): FunnelTrace {
+  const trace = TraceFactory.create(createLayer(data)) as FunnelTrace;
+  trace.moveToIndex(0, stage);
+  return trace;
+}
+
+function nonEmptyState(trace: FunnelTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+function announce(state: TraceState): string {
+  const text = new TextService({ notify: jest.fn() } as unknown as NotificationService);
+  const listener = jest.fn();
+  const disposable = text.onChange(listener);
+
+  text.update(state);
+  disposable.dispose();
+  return (listener.mock.calls[0][0] as { value: string }).value;
+}
+
+describe('a stage following one that measured nothing', () => {
+  const AFTER_EMPTY: BarPoint[] = [
+    { x: 'a', y: 10 },
+    { x: 'b', y: 0 },
+    { x: 'c', y: 5 },
+  ];
+
+  test('reads its retention as missing rather than as a percentage of nothing', () => {
+    const trace = funnel(2, AFTER_EMPTY);
+
+    expect(announce(trace.state))
+      .toBe('Stage is c, People is 5, Retained is missing, Entered is 10, 50.0% of it');
+  });
+
+  test('the share of the population is unaffected', () => {
+    // The entry stage measured 10, so 5 is still half of what entered even
+    // though the stage before it kept nobody.
+    expect(nonEmptyState(funnel(2, AFTER_EMPTY)).text.stack?.share).toBeCloseTo(0.5);
+  });
+});
+
+describe('a funnel whose entry stage measured nothing', () => {
+  const EMPTY_ENTRY: BarPoint[] = [
+    { x: 'a', y: 0 },
+    { x: 'b', y: 3 },
+  ];
+
+  test('says nothing about a share of the population, since there is none', () => {
+    // "0, NaN% of it" claims a fraction of an empty population; the total is
+    // still worth announcing, the share is not.
+    const trace = funnel(1, EMPTY_ENTRY);
+
+    expect(announce(trace.state))
+      .toBe('Stage is b, People is 3, Retained is missing, Entered is 0');
+    expect(nonEmptyState(trace).text.stack?.share).toBeUndefined();
+  });
+
+  test('an absent entry stage is read the same way', () => {
+    // `null` is what a producer sends for a stage it did not measure; the
+    // count itself then has nothing to announce either.
+    const trace = funnel(1, [{ x: 'a', y: null as unknown as number }, { x: 'b', y: 3 }]);
+
+    expect(announce(trace.state))
+      .toBe('Stage is b, People is 3, Retained is missing, Entered is missing');
+  });
+});
+
+describe('a measured stage is unchanged', () => {
+  test('still reads its retention as a percentage', () => {
+    const trace = funnel(1, [{ x: 'a', y: 10 }, { x: 'b', y: 4 }]);
+
+    expect(announce(trace.state))
+      .toBe('Stage is b, People is 4, Retained is 40.0%, Entered is 10, 40.0% of it');
+  });
+});

--- a/test/model/lineGapIntersections.test.ts
+++ b/test/model/lineGapIntersections.test.ts
@@ -1,0 +1,92 @@
+import type { ExtremaTarget } from '@type/extrema';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { LineTrace } from '@model/line';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Intersections on a multiline chart where one series has a gap (#925).
+ *
+ * A gap is a sample with a position and no reading. The chart draws nothing
+ * through it, so no crossing can happen there: a segment into or out of a gap
+ * does not exist, and neither does a point at it. Coercing the gap to `0`
+ * puts a vertex on the x axis that the chart never drew, and every other line
+ * that passes between the gap's neighbours and that phantom vertex is then
+ * reported as crossing the series.
+ */
+
+function lineLayer(rows: LinePoint[][]): MaidrLayer {
+  return {
+    id: 'l',
+    type: TraceType.LINE,
+    title: 'Series',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data: rows,
+  };
+}
+
+function intersectionTargets(trace: LineTrace): ExtremaTarget[] {
+  return trace.getExtremaTargets().filter(target => target.type === 'intersection');
+}
+
+/** A series held at 10 with its middle sample unmeasured. */
+const GAPPED: LinePoint[] = [
+  { x: 0, y: 10 },
+  { x: 1, y: null },
+  { x: 2, y: 10 },
+];
+
+describe('a gap in the current line', () => {
+  test('does not create crossings with a line running below it', () => {
+    // Held at 5, the other line sits between the gap's measured neighbours
+    // at 10 and the phantom vertex a coerced gap would put at 0. It never
+    // meets the series the chart actually draws.
+    const trace = new LineTrace(lineLayer([
+      GAPPED,
+      [{ x: 0, y: 5 }, { x: 1, y: 5 }, { x: 2, y: 5 }],
+    ]));
+
+    expect(intersectionTargets(trace)).toEqual([]);
+  });
+
+  test('is not itself a point intersection with a line running at zero', () => {
+    // The worst case: the other line really is at 0, exactly where the
+    // coerced gap would land, so the two would match as a shared sampled
+    // point and the rotor would navigate onto a sample that reads "missing".
+    const trace = new LineTrace(lineLayer([
+      GAPPED,
+      [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }],
+    ]));
+    trace.col = 0;
+
+    expect(intersectionTargets(trace)).toEqual([]);
+    expect(trace.moveToNextIntersection()).toBe(false);
+    expect(trace.col).toBe(0);
+  });
+
+  test('leaves a real crossing elsewhere on the line intact', () => {
+    // The guard has to remove the segments that touch the gap, not the
+    // series: after the gap this line falls through the other one.
+    const trace = new LineTrace(lineLayer([
+      [...GAPPED, { x: 3, y: 0 }],
+      [{ x: 0, y: 5 }, { x: 1, y: 5 }, { x: 2, y: 5 }, { x: 3, y: 5 }],
+    ]));
+
+    const targets = intersectionTargets(trace);
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0].intersectionKind).toBe('slope');
+    expect(targets[0].value).toBeCloseTo(5);
+  });
+});
+
+describe('a gap in another line', () => {
+  test('does not create crossings with the current line either', () => {
+    const trace = new LineTrace(lineLayer([
+      [{ x: 0, y: 5 }, { x: 1, y: 5 }, { x: 2, y: 5 }],
+      GAPPED,
+    ]));
+
+    expect(intersectionTargets(trace)).toEqual([]);
+  });
+});

--- a/test/model/lineGaps.test.ts
+++ b/test/model/lineGaps.test.ts
@@ -182,3 +182,41 @@ describe('navigating between series across a gap', () => {
     expect(announce(trace.state)).toBe('X is b, Y is 9');
   });
 });
+
+describe('a gap shared with another line', () => {
+  /** Two lines that both have no reading at `b`. */
+  function bothGapped(): LineTrace {
+    return new LineTrace(lineLayer([
+      [{ x: 'a', y: 1, z: 'A' }, { x: 'b', y: null, z: 'A' }],
+      [{ x: 'a', y: 2, z: 'B' }, { x: 'b', y: null, z: 'B' }],
+    ]));
+  }
+
+  test('is not announced as an intersection', () => {
+    // A crossing is one point that several series share. Two series that
+    // have no reading at the same x share nothing there -- but `null ===
+    // null`, so an exact-match scan that does not exclude the gap finds
+    // every other gapped line and reports a crossing the chart never drew.
+    const trace = bothGapped();
+    trace.moveToIndex(1, 0);
+
+    trace.moveOnce('FORWARD');
+
+    expect(announce(trace.state)).toBe('X is b, Y is missing, Group is B');
+  });
+
+  test('is not sonified as a chord', () => {
+    // The intersections branch of the audio service runs before its
+    // empty-tone guard, so a gap reported as a crossing is played as a chord
+    // of non-finite frequencies rather than as the missing-value tone.
+    const trace = bothGapped();
+    trace.moveToIndex(1, 0);
+    const update = jest.fn();
+    trace.addObserver({ update });
+
+    trace.moveOnce('FORWARD');
+
+    const emitted = update.mock.calls[0][0] as { intersections?: unknown[] };
+    expect(emitted.intersections).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`Number(null)` is `0`, and several traces still coerced a gap (`y: null`) that way, so the text, audio and intersection logic fabricated readings the chart never drew. `LineTrace` already documents this trap and has `toBarValue` / `isMeasured` for it; this PR applies the same treatment to the remaining paths found in a codebase audit.

## Related Issues

Follows up on the gap handling from #925.

## Changes Made

- **line**: `findAllIntersectionsForCurrentLine` builds its numeric coordinates with `toBarValue`, and skips any segment pair with a non-finite endpoint. A gap no longer puts a phantom vertex at `y = 0`, so lines passing between a gap's neighbours are no longer reported as slope or point intersections, and the intersection rotor no longer lands on a gap.
- **line**: `findIntersections` returns no intersections when the cursor itself sits on a gap. `null === null` used to match every other line with a gap at the same x, announcing "intersection at (A, B)" and playing a chord with a NaN frequency. This also fixes the inherited announcement in area and bump charts.
- **area**: `computeColumnTotals` and `text` read gaps through `toBarValue`, so a column reached only by gaps has no total (as the existing guard intended) and a single gap is not announced as "0.0% of it".
- **bump**: a move into or out of an unranked period is `undefined` rather than `NaN`, so the text no longer says "Change is missing" for it and the rank rotor units are only offered when a real move exists.
- **funnel**: a stage with no ratio is announced as "missing" as its docstring promises, and the "N% of it" clause is dropped when the share is unmeasured, matching `AreaTrace`.

Each fix has a test that failed before the change and asserts the rendered announcement through `TextService` where practical.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint`, `npm run type-check`, `npm test` and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_