### PR TITLE
docs: add per-page SEO metadata to the API reference and unify the site's entity graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Full history, as in docs.yml: the site build reads git commit dates.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,23 @@ on:
       - 'examples/**'
       - 'media/**'
       - 'scripts/build-site.js'
+      - 'scripts/markdown.js'
+      - 'scripts/examplesGallery.js'
+      - 'scripts/typedoc-seo-plugin.mjs'
+      - 'scripts/add-navbar-to-typedoc.js'
+      - 'scripts/check-page-sizes.js'
       - '.github/workflows/docs.yml'
 
   workflow_dispatch:
+
+  # The semantic-release commit is "chore(release): X [skip ci]", which GitHub
+  # never runs `on: push` workflows for, so the site did not pick up a new
+  # version until the next push that touched a docs path. Rebuild when the
+  # Release workflow finishes instead; the job below skips a failed release.
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -30,9 +44,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history: scripts/build-site.js derives sitemap <lastmod> and
+          # TechArticle dates from git commit dates.
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -39,6 +39,9 @@ jobs:
           # Untrusted PR code is checked out only to be BUILT; don't leave the
           # job token in .git/config where a build script could read it.
           persist-credentials: false
+          # Full history: build-site.js dates each page from its last commit,
+          # so a shallow clone would stamp the preview with the build date.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@
 
 # MAIDR: Multimodal Access and Interactive Data Representation
 
-- **Note:** `maidr` package has been completely rewritten in TypeScript for better architecture and performance. The previous version is now archived at [xability/maidr-legacy](https://github.com/xability/maidr-legacy).
+MAIDR (Multimodal Access and Interactive Data Representation, pronounced "mader") is an open-source JavaScript/TypeScript library that makes statistical charts accessible to blind and low-vision people. It adds keyboard navigation, sonification, text descriptions, braille output and AI-generated descriptions to charts drawn with React, Recharts, Plotly, Vega-Lite, D3, Chart.js, Apache ECharts, Highcharts and other libraries, or described directly with its JSON data schema. MAIDR is developed by the [(x)Ability Design Lab](https://xabilitylab.ischool.illinois.edu/) at the University of Illinois Urbana-Champaign and is the engine behind [py-maidr](https://py.maidr.ai/) for Python and [maidr for R](https://r.maidr.ai/).
 
-`maidr` (pronounced as 'mader') is a system for non-visual access and control of statistical plots.
-It aims to provide an inclusive experience for users with visual impairments by offering multiple modes of interaction:
+- **Note:** The `maidr` package has been completely rewritten in TypeScript for better architecture and performance. The previous version is now archived at [xability/maidr-legacy](https://github.com/xability/maidr-legacy).
+
+`maidr` is the npm package that ships MAIDR. It aims to provide an inclusive experience for users with visual impairments by offering multiple modes of interaction:
 braille, text, and sonification (BTS).
 This comprehensive approach enhances the accessibility of data visualization
 and encourages a multi-modal exploration on visualization.
@@ -31,7 +32,7 @@ and encourages a multi-modal exploration on visualization.
 5. [Live & Streaming Data](#live--streaming-data)
 6. [Braille Generation](#braille-generation)
 7. [Examples](#examples)
-8. [Binders](#binders)
+8. [Related projects](#related-projects)
 9. [Papers](#papers)
 10. [License](#license)
 11. [Contact](#contact)
@@ -144,19 +145,23 @@ Example plots are demonstrated [here](examples.html).
 
 For more information, refer to the example HTML files provided in the directory examples/
 
-## Binders
+## Related projects
 
-We currently provide the following binders, all of which can be found at each repo:
+MAIDR is one of three sibling projects from the (x)Ability Design Lab. This repository is the JavaScript core; the two language bindings render their plots with it.
 
-- Python binder for matplotlib and seaborn: [Py maidr](https://py.maidr.ai/).
+- [MAIDR JavaScript core](https://maidr.ai/): this library, published on npm as [`maidr`](https://www.npmjs.com/package/maidr), with adapters for React, Recharts, Plotly, Vega-Lite, D3, Chart.js, Apache ECharts, Highcharts and other charting libraries. Source: [xability/maidr](https://github.com/xability/maidr).
 
-- R binder for ggplot2: [r maidr](https://r.maidr.ai/).
+- [py-maidr for Python](https://py.maidr.ai/): makes matplotlib, seaborn, Plotly and Altair charts accessible after `import maidr`; published on PyPI as `maidr`. Source: [xability/py-maidr](https://github.com/xability/py-maidr).
+
+- [maidr for R](https://r.maidr.ai/): makes ggplot2 and base graphics plots accessible; published on CRAN as `maidr`. Source: [xability/r-maidr](https://github.com/xability/r-maidr).
 
 ## Papers
 
 To learn more about the theoretical background and user study results, we recommend you read and cite the following papers.
 
 1. [MAIDR: Making Statistical Visualizations Accessible with Multimodal Data Representation](https://dl.acm.org/doi/10.1145/3613904.3642730):
+
+   Seo, J., Xia, Y., Lee, B., Mccurry, S., & Yam, Y. J. (2024). MAIDR: Making Statistical Visualizations Accessible with Multimodal Data Representation. In Proceedings of the CHI Conference on Human Factors in Computing Systems (CHI '24). ACM. https://doi.org/10.1145/3613904.3642730
 
 ```tex
 @inproceedings{seoMAIDRMakingStatistical2024,
@@ -179,6 +184,8 @@ To learn more about the theoretical background and user study results, we recomm
 ```
 
 2. [Designing Born-Accessible Courses in Data Science and Visualization: Challenges and Opportunities of a Remote Curriculum Taught by Blind Instructors to Blind Students](https://diglib.eg.org/items/5e71b594-3762-4604-a9c4-96623cda8bc3):
+
+   Seo, J., O'Modhrain, S., Xia, Y., Kamath, S., Lee, B., & Coughlan, J. M. (2024). Designing Born-Accessible Courses in Data Science and Visualization: Challenges and Opportunities of a Remote Curriculum Taught by Blind Instructors to Blind Students. In EuroVis 2024 - Education Papers. The Eurographics Association. https://doi.org/10.2312/eved.20241053
 
 ```tex
 @inproceedings{10.2312:eved.20241053,

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,21 +1,40 @@
 # MAIDR
 
-> MAIDR (Multimodal Access and Interactive Data Representation) is a TypeScript/React library that provides accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
+> MAIDR (Multimodal Access and Interactive Data Representation) is an open-source JavaScript/TypeScript library that makes statistical charts accessible to blind and low-vision people through keyboard navigation, audio sonification, text descriptions, braille output, and AI-generated descriptions. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign. It is the engine behind py-maidr (Python) and maidr for R.
 
-MAIDR converts data visualizations into interactive, multimodal formats navigable entirely by keyboard. It supports bar charts, stacked/dodged bar charts, histograms, line plots, multi-line plots, step plots, scatter plots, box plots, violin plots, heatmaps, candlestick charts, pie and doughnut charts, smooth curves, faceted plots, and multi-panel layouts. Available as an npm package and as a React component library.
+MAIDR converts data visualizations into interactive, multimodal formats navigable entirely by keyboard. It supports bar charts, stacked/dodged bar charts, histograms, line plots, multi-line plots, step plots, scatter plots, box plots, violin plots, heatmaps, candlestick charts, pie and doughnut charts, smooth curves, faceted plots, and multi-panel layouts. Available as an npm package (`maidr`), as a React component library, and through adapters for the charting libraries listed below.
 
 ## Docs
-- [Home](https://maidr.ai/): Overview and getting started guide
-- [React Integration](https://maidr.ai/react.html): How to use MAIDR with React
-- [Data Schema](https://maidr.ai/docs/SCHEMA.html): MAIDR data schema specification
-- [Keyboard Controls](https://maidr.ai/docs/CONTROLS.html): Keyboard controls reference
-- [Live & Streaming Data](https://maidr.ai/docs/LIVE_DATA.html): Realtime data updates, streaming, and monitor mode
-- [Braille Generation](https://maidr.ai/docs/BRAILLE.html): Braille output documentation
-- [API Documentation](https://maidr.ai/api/index.html): TypeDoc API reference
-- [Examples](https://maidr.ai/examples.html): Interactive examples gallery
+- [Home](https://maidr.ai/): Overview, usage, data schema summary, related projects, papers, and contact
+- [Data Schema](https://maidr.ai/docs/SCHEMA.html): The MAIDR JSON schema for figures, subplots, layers, axes and data points
+- [Keyboard Controls](https://maidr.ai/docs/CONTROLS.html): Keyboard shortcuts for navigating data and switching between braille, text and sonification
+- [Live & Streaming Data](https://maidr.ai/docs/LIVE_DATA.html): Realtime updates with setData and appendData, sliding windows, and monitor mode
+- [Braille Generation](https://maidr.ai/docs/BRAILLE.html): How each plot type is encoded for refreshable braille displays
+- [Tactile Graphics Display](https://maidr.ai/docs/TACTILE_DISPLAY.html): Rendering charts on the Dot Pad X tactile graphics display over Bluetooth or USB
+- [Violin Plot Specification](https://maidr.ai/docs/VIOLIN_PLOT_SPEC.html): Data structures and navigation for violin plots (KDE and box layers)
+- [API Reference](https://maidr.ai/api/index.html): TypeDoc reference for the MAIDR JavaScript API
+- [Examples](https://maidr.ai/examples.html): Interactive examples gallery for every supported chart type and integration
+
+## Integration guides
+- [React](https://maidr.ai/react.html): The `<Maidr>` component, TypeScript types, and data examples for React 18 and 19
+- [Recharts](https://maidr.ai/recharts.html): Accessible Recharts components for bar, line, scatter, stacked and histogram charts
+- [Plotly.js](https://maidr.ai/plotly.html): Zero-configuration accessibility for Plotly bar, scatter, line, box, violin, heatmap, histogram, candlestick and pie charts
+- [Google Charts](https://maidr.ai/google-charts.html): Bar, line, scatter, candlestick, stacked, dodged and pie charts
+- [D3.js](https://maidr.ai/d3.html): Binders for D3 bar, line, scatter, box, heatmap, histogram, candlestick, segmented, smooth and pie charts, plus a React wrapper
+- [Vega-Lite](https://maidr.ai/vegalite.html): Bar, stacked, dodged, normalized, histogram, line, scatter, heatmap, box plot and arc specs
+- [Chart.js](https://maidr.ai/chartjs.html): Bar, line, scatter, stacked, dodged, box plot, candlestick, heatmap (matrix) and pie or doughnut charts
+- [amCharts 5](https://maidr.ai/amcharts.html): Bar, dodged, stacked, normalized, line, histogram, heatmap and pie charts
+- [Observable Plot & Quarto](https://maidr.ai/observable.html): Bar, histogram, scatter, line, area and faceted plots, including Quarto OJS cells
+- [Apache ECharts](https://maidr.ai/echarts.html): Bar, stacked bar, dodged bar, line, area, step and scatter series
+- [Frappe Charts](https://maidr.ai/frappe.html): Bar, line, multi-line, scatter, mixed axis, pie and donut charts
+- [Victory](https://maidr.ai/victory.html): Bar, line, scatter, stacked, histogram, box plot, candlestick and pie charts for React
+- [AnyChart](https://maidr.ai/anychart.html): Bar, line, step, scatter, box, heatmap, candlestick and pie charts via a one-line binder
+- [Highcharts](https://maidr.ai/highcharts.html): Bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, normalized and pie charts
+- [Tableau](https://maidr.ai/tableau.html): Sonification, braille and screen-reader navigation for embedded Tableau dashboards
 
 ## Optional
 - [npm](https://www.npmjs.com/package/maidr): Install with `npm install maidr`
 - [GitHub](https://github.com/xability/maidr): Source code and issue tracker
-- [maidr for Python](https://py.maidr.ai/): Python binding (matplotlib, seaborn, plotly)
-- [maidr for R](https://r.maidr.ai/): R package (ggplot2, Base R)
+- [py-maidr for Python](https://py.maidr.ai/): Python binding for matplotlib, seaborn, Plotly and Altair (PyPI package `maidr`)
+- [maidr for R](https://r.maidr.ai/): R package for ggplot2 and base graphics (CRAN package `maidr`)
+- [(x)Ability Design Lab](https://xabilitylab.ischool.illinois.edu/): The lab at the University of Illinois Urbana-Champaign that develops MAIDR

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://maidr.ai/sitemap.xml
+Sitemap: https://maidr.ai/api/sitemap.xml

--- a/docs/template.html
+++ b/docs/template.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="{{DESCRIPTION}}" />
   <link rel="canonical" href="{{CANONICAL_URL}}" />
-  <meta property="og:title" content="{{TITLE}} - MAIDR" />
+  <meta property="og:title" content="{{SEO_TITLE}}" />
   <meta property="og:description" content="{{DESCRIPTION}}" />
   <meta property="og:type" content="{{OG_TYPE}}" />
   <meta property="og:url" content="{{CANONICAL_URL}}" />
@@ -17,11 +17,11 @@
   <meta property="og:site_name" content="MAIDR" />
   <meta property="og:locale" content="en_US" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="{{TITLE}} - MAIDR" />
+  <meta name="twitter:title" content="{{SEO_TITLE}}" />
   <meta name="twitter:description" content="{{DESCRIPTION}}" />
   <meta name="twitter:image" content="https://maidr.ai/media/logo.jpg" />
   <meta name="twitter:image:alt" content="MAIDR - Multimodal Access and Interactive Data Representation logo" />
-  <title>{{TITLE}} - MAIDR</title>
+  <title>{{SEO_TITLE}}</title>
   <link rel="icon" type="image/svg+xml" href="{{BASE_PATH}}media/logo.svg" />
   <script type="application/ld+json">
   {
@@ -31,37 +31,59 @@
         "@type": "Organization",
         "@id": "https://maidr.ai/#organization",
         "name": "(x)Ability Design Lab",
-        "url": "https://xability.github.io/",
+        "url": "https://xabilitylab.ischool.illinois.edu/",
         "sameAs": [
           "https://github.com/xability",
-          "https://www.npmjs.com/package/maidr"
+          "https://xability.github.io/"
+        ],
+        "parentOrganization": {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Illinois Urbana-Champaign",
+          "url": "https://illinois.edu/"
+        }
+      },
+      {
+        "@type": "Person",
+        "@id": "https://maidr.ai/#jooyoung-seo",
+        "name": "JooYoung Seo",
+        "url": "https://ischool.illinois.edu/people/jooyoung-seo",
+        "affiliation": { "@id": "https://maidr.ai/#organization" },
+        "sameAs": [
+          "https://github.com/jooyoungseo",
+          "https://scholar.google.com/citations?user=c0x8E5YAAAAJ",
+          "https://www.linkedin.com/in/jooyoungseo"
         ]
       },
       {
         "@type": "WebSite",
         "@id": "https://maidr.ai/#website",
-        "url": "https://maidr.ai/",
         "name": "MAIDR",
+        "url": "https://maidr.ai/",
+        "inLanguage": "en",
         "description": "Accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions.",
-        "publisher": { "@id": "https://maidr.ai/#organization" }
+        "publisher": { "@id": "https://maidr.ai/#organization" },
+        "about": { "@id": "https://maidr.ai/#software" }
       },
       {
-        "@type": "SoftwareApplication",
+        "@type": ["SoftwareSourceCode", "SoftwareApplication"],
         "@id": "https://maidr.ai/#software",
         "name": "MAIDR",
-        "alternateName": "Multimodal Access and Interactive Data Representation",
-        "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "Web",
+        "alternateName": ["maidr", "Multimodal Access and Interactive Data Representation"],
         "description": "Accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions.",
-        "url": "https://maidr.ai",
-        "softwareVersion": "{{SOFTWARE_VERSION}}",
-        "downloadUrl": "https://www.npmjs.com/package/maidr",
+        "url": "https://maidr.ai/",
         "codeRepository": "https://github.com/xability/maidr",
+        "downloadUrl": "https://www.npmjs.com/package/maidr",
         "programmingLanguage": ["TypeScript", "JavaScript"],
-        "license": "https://opensource.org/license/gpl-3-0",
+        "runtimePlatform": "Web browser",
+        "operatingSystem": "Web",
+        "applicationCategory": "DeveloperApplication",
+        "softwareVersion": "{{SOFTWARE_VERSION}}",
+        "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+        "isAccessibleForFree": true,
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
         "author": { "@id": "https://maidr.ai/#organization" },
-        "featureList": [
+        "maintainer": { "@id": "https://maidr.ai/#jooyoung-seo" },
+        {{SOFTWARE_CITATION}}"featureList": [
           "Audio sonification of chart data",
           "Text descriptions for screen readers",
           "Braille output for tactile displays",
@@ -73,7 +95,7 @@
           "https://github.com/xability/maidr",
           "https://www.npmjs.com/package/maidr"
         ]
-      }
+      }{{HOME_GRAPH_NODES}}
     ]
   }
   </script>
@@ -287,6 +309,46 @@
       left: 0;
     }
 
+    /* Breadcrumb trail on pages below the home page. */
+    .breadcrumb {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem 2rem 0;
+      font-size: 0.95rem;
+    }
+
+    .breadcrumb ol {
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+    }
+
+    .breadcrumb li + li::before {
+      content: "/";
+      margin-right: 0.5rem;
+      color: #888;
+    }
+
+    .breadcrumb a {
+      /* 5.9:1 on white; the lighter #667eea used elsewhere is only 3.7:1. */
+      color: #4a5bc4;
+    }
+
+    .breadcrumb [aria-current="page"] {
+      color: #555;
+    }
+
+    .page-meta {
+      max-width: 1200px;
+      margin: 0.5rem auto 0;
+      padding: 0 2rem;
+      font-size: 0.9rem;
+      color: #555;
+    }
+
     main {
       max-width: 1200px;
       margin: 0 auto;
@@ -429,7 +491,7 @@
 
 <body>
   <a class="skip-link" href="#main-content">Skip to content</a>
-  <nav>
+  <nav aria-label="Main">
     <div class="container">
       <a href="{{BASE_PATH}}index.html" class="logo">
         <img src="{{BASE_PATH}}media/logo.jpg" alt="MAIDR Logo" />
@@ -480,12 +542,15 @@
     </div>
   </nav>
 
+  {{BREADCRUMB}}
+
   <main id="main-content" tabindex="-1">
     {{CONTENT}}
   </main>
 
   <footer>
     <p>MAIDR - Multimodal Access and Interactive Data Representation</p>
+    <p>Developed by the <a href="https://xabilitylab.ischool.illinois.edu/">(x)Ability Design Lab</a> at the University of Illinois Urbana-Champaign. Principal investigator: JooYoung Seo.</p>
     <p><a href="https://github.com/xability/maidr">GitHub</a> | Licensed under GPL-3.0</p>
   </footer>
   <script>

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "test:coverage": "node scripts/test.js --coverage",
     "type-check": "tsc --noEmit && tsc -p tsconfig.ci.json",
     "build:recharts-example": "vite build --config examples/recharts/vite.config.ts",
-    "docs": "npm run build:recharts-example && npm run build:victory-example && node scripts/build-site.js && typedoc && node scripts/add-navbar-to-typedoc.js",
+    "docs": "npm run build:recharts-example && npm run build:victory-example && node scripts/build-site.js && typedoc && node scripts/add-navbar-to-typedoc.js && node scripts/check-page-sizes.js",
     "docs:watch": "typedoc --watch",
     "docs:serve": "npm run docs && npx http-server _site -o",
     "e2e": "npx playwright test --config=e2e_tests/config/test-config.ts",

--- a/scripts/add-navbar-to-typedoc.js
+++ b/scripts/add-navbar-to-typedoc.js
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
 
 /**
- * Adds the site navbar to TypeDoc generated pages
+ * Adds the site navbar to TypeDoc generated pages, and removes the generic
+ * `<meta name="description">` TypeDoc hard-codes ("Documentation for <project
+ * name>") so the per-page one from scripts/typedoc-seo-plugin.mjs is the only
+ * description left. A renderer hook can add to <head> but not take from it,
+ * which is why the removal lives here, in the pass that already rewrites
+ * every page.
+ *
+ * Also rewrites the api/sitemap.xml TypeDoc writes from `hostedBaseUrl`: its
+ * first entry is `api/index.html` while the canonical TypeDoc puts on that
+ * page is `api/`, and every entry carries the build time as <lastmod>, which
+ * Google learns to ignore. The entry becomes the canonical and the lastmod
+ * the date of the last commit touching src/, which is what the API pages are
+ * generated from.
  */
 
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -120,11 +133,41 @@ function processHTMLFile(filePath) {
     .replace(/\.\.\/api\/index\.html/g, `${prefix}api/index.html`)
     .replace(/\.\.\/media\//g, `${prefix}media/`);
 
+  // Drop TypeDoc's generic description; the SEO plugin emitted a per-page one.
+  content = content.replace(/<meta name="description" content="Documentation for [^"]*"\s*\/?>\n?/, '');
+
   // Insert navbar after <body> tag
   content = content.replace(/<body[^>]*>/, match => `${match}\n${adjustedNavbar}`);
 
   fs.writeFileSync(filePath, content, 'utf-8');
   console.log(`Added navbar to ${path.relative(SITE_DIR, filePath)}`);
+}
+
+/**
+ * Rewrite the TypeDoc sitemap so its index entry matches the canonical and
+ * its lastmod is a real content date rather than the build time.
+ */
+function fixSitemap() {
+  const sitemapPath = path.join(API_DIR, 'sitemap.xml');
+  if (!fs.existsSync(sitemapPath)) {
+    console.warn('No api/sitemap.xml found; is hostedBaseUrl set in typedoc.json?');
+    return;
+  }
+  let lastmod = new Date().toISOString().split('T')[0];
+  try {
+    lastmod = execFileSync('git', ['log', '-1', '--format=%cs', '--', 'src'], {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || lastmod;
+  } catch {
+    // No git history (a tarball or a shallow checkout): today is the fallback.
+  }
+  const sitemap = fs.readFileSync(sitemapPath, 'utf-8')
+    .replace('<loc>https://maidr.ai/api/index.html</loc>', '<loc>https://maidr.ai/api/</loc>')
+    .replace(/<lastmod>[^<]*<\/lastmod>/g, `<lastmod>${lastmod}</lastmod>`);
+  fs.writeFileSync(sitemapPath, sitemap, 'utf-8');
+  console.log(`Rewrote api/sitemap.xml (lastmod ${lastmod})`);
 }
 
 // Main
@@ -133,5 +176,6 @@ const htmlFiles = findHTMLFiles(API_DIR);
 console.log(`Found ${htmlFiles.length} HTML files`);
 
 htmlFiles.forEach(processHTMLFile);
+fixSitemap();
 
 console.log('Done!');

--- a/scripts/add-navbar-to-typedoc.js
+++ b/scripts/add-navbar-to-typedoc.js
@@ -16,10 +16,10 @@
  * generated from.
  */
 
-import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { lastCommitDate } from './gitDates.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SITE_DIR = path.join(__dirname, '..', '_site');
@@ -153,16 +153,9 @@ function fixSitemap() {
     console.warn('No api/sitemap.xml found; is hostedBaseUrl set in typedoc.json?');
     return;
   }
-  let lastmod = new Date().toISOString().split('T')[0];
-  try {
-    lastmod = execFileSync('git', ['log', '-1', '--format=%cs', '--', 'src'], {
-      cwd: path.join(__dirname, '..'),
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim() || lastmod;
-  } catch {
-    // No git history (a tarball or a shallow checkout): today is the fallback.
-  }
+  // The API pages are generated from `src/`, so that is what dates them.
+  const today = new Date().toISOString().split('T')[0];
+  const lastmod = lastCommitDate(path.join(__dirname, '..'), 'src', today);
   const sitemap = fs.readFileSync(sitemapPath, 'utf-8')
     .replace('<loc>https://maidr.ai/api/index.html</loc>', '<loc>https://maidr.ai/api/</loc>')
     .replace(/<lastmod>[^<]*<\/lastmod>/g, `<lastmod>${lastmod}</lastmod>`);

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -3,12 +3,13 @@
 /**
  * Build script to generate the documentation site
  * - Creates index.html from README.md
+ * - Creates one root page per integration guide (react.html, plotly.html, ...)
  * - Creates examples.html that embeds the examples
  * - Copies media and examples folders
  * - TypeDoc generates API docs separately
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,6 +22,7 @@ const ROOT = path.join(__dirname, '..');
 const SITE_DIR = path.join(ROOT, '_site');
 const TEMPLATE_PATH = path.join(ROOT, 'docs', 'template.html');
 const PKG = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+const SITE_URL = 'https://maidr.ai/';
 
 // Ensure _site directory exists
 if (!fs.existsSync(SITE_DIR)) {
@@ -44,40 +46,124 @@ function markdownToHtml(md) {
   return renderMarkdown(content);
 }
 
+/**
+ * The integration guides built as root-level pages.
+ *
+ * One list drives everything that used to be spelled out per integration:
+ * the page build, the exclusion from the generic `docs/` loop (so a guide is
+ * not built a second time under `docs/`), and the sitemap. Adding a guide is
+ * one line here; the nav link in `docs/template.html` is still by hand.
+ *
+ * `slug` is the output filename without `.html` and the `activePage` key the
+ * template's nav uses; `title` is the nav-facing title; `source` is the
+ * markdown file under `docs/`.
+ */
+const INTEGRATION_PAGES = [
+  { slug: 'react', title: 'React', source: 'react.md' },
+  { slug: 'recharts', title: 'Recharts', source: 'recharts.md' },
+  { slug: 'plotly', title: 'Plotly', source: 'plotly.md' },
+  { slug: 'google-charts', title: 'Google Charts', source: 'google-charts.md' },
+  { slug: 'd3', title: 'D3.js', source: 'd3.md' },
+  { slug: 'vegalite', title: 'Vega-Lite', source: 'vegalite.md' },
+  { slug: 'chartjs', title: 'Chart.js', source: 'chartjs.md' },
+  { slug: 'amcharts', title: 'amCharts', source: 'amcharts.md' },
+  { slug: 'observable', title: 'Observable Plot', source: 'observable.md' },
+  { slug: 'echarts', title: 'Apache ECharts', source: 'echarts.md' },
+  { slug: 'frappe', title: 'Frappe Charts', source: 'frappe.md' },
+  { slug: 'victory', title: 'Victory', source: 'victory.md' },
+  { slug: 'anychart', title: 'AnyChart', source: 'anychart.md' },
+  { slug: 'highcharts', title: 'Highcharts', source: 'highcharts.md' },
+  { slug: 'tableau', title: 'Tableau', source: 'tableau.md' },
+];
+
+const INTEGRATION_SOURCES = new Set(INTEGRATION_PAGES.map(page => page.source));
+
+/** Page titles for the `docs/*.md` files whose filename is not a title. */
+const DOC_TITLES = {
+  SCHEMA: 'Data Schema',
+  BRAILLE: 'Braille Generation',
+  CONTROLS: 'Keyboard Controls',
+  LIVE_DATA: 'Live & Streaming Data',
+  TACTILE_DISPLAY: 'Tactile Graphics Display',
+  VIOLIN_PLOT_SPEC: 'Violin Plot Specification',
+};
+
 // Per-page SEO descriptions.
 // Keys are either activePage slugs ('home', 'react', 'examples') or page titles
 // ('Data Schema', etc.) for doc pages where activePage is '' and lookup falls back to title.
+// Keep each one unique and roughly 70-160 characters; generatePage warns outside
+// that range and fails the build when a page has no entry at all.
 const PAGE_DESCRIPTIONS = {
   'home': 'MAIDR provides accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions.',
   'react': 'How to integrate MAIDR accessible data visualizations into React applications with TypeScript support.',
   'recharts': 'How to integrate MAIDR accessibility features with Recharts React components for accessible data visualizations.',
-  'plotly': 'How to make Plotly.js charts accessible with MAIDR — zero configuration auto-detection for bar, scatter, line, box, violin, heatmap, histogram, candlestick, and pie charts.',
-  'google-charts': 'How to make Google Charts accessible with MAIDR — support for bar, line, scatter, candlestick, stacked, dodged, and pie charts.',
-  'd3': 'How to make D3.js charts accessible with MAIDR — binders for bar, line, scatter, box, heatmap, histogram, candlestick, segmented, smooth, and pie charts plus a React wrapper.',
-  'vegalite': 'How to make Vega-Lite charts accessible with MAIDR — support for bar, stacked, dodged, normalized, histogram, line, scatter, heatmap, box plot, and arc (pie) specs.',
-  'chartjs': 'How to make Chart.js charts accessible with MAIDR — support for bar, line, scatter, stacked, dodged, box plot, candlestick, heatmap (matrix), and pie / doughnut chart types.',
-  'amcharts': 'How to make amCharts 5 charts accessible with MAIDR — support for bar, dodged, stacked, normalized, line, histogram, heatmap, and pie chart types.',
-  'observable': 'How to make Observable Plot charts accessible with MAIDR — zero-configuration binding for bar, stacked bar, histogram, scatter, dot, line, area, and faceted plots, including the {ojs} cells of a Quarto document.',
-  'echarts': 'How to make Apache ECharts accessible with MAIDR — support for bar, stacked bar, dodged bar, line, area, step, and scatter series.',
-  'frappe': 'How to make Frappe Charts accessible with MAIDR — support for bar, line, multi-line, scatter, mixed axis (bar + line), pie, and donut chart types.',
-  'victory': 'How to make Victory charts accessible with MAIDR — support for bar, line, scatter, stacked, histogram, box plot, candlestick, and pie chart types.',
-  'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, step, scatter, box, heatmap, candlestick, and pie chart types via a one-line binder.',
-  'highcharts': 'How to make Highcharts charts accessible with MAIDR — support for bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, normalized, and pie chart types.',
-  'tableau': 'How to make embedded Tableau dashboards accessible with MAIDR — sonification, braille and screen-reader navigation for bar, line, scatter and pie worksheets via a one-line binder.',
+  'plotly': 'How to make Plotly.js charts accessible with MAIDR: automatic support for bar, scatter, line, box, violin, heatmap, histogram, candlestick and pie charts.',
+  'google-charts': 'How to make Google Charts accessible with MAIDR: support for bar, line, scatter, candlestick, stacked, dodged, and pie charts.',
+  'd3': 'How to make D3.js charts accessible with MAIDR: binders for bar, line, scatter, box, heatmap, histogram, candlestick and pie charts, plus a React wrapper.',
+  'vegalite': 'How to make Vega-Lite charts accessible with MAIDR: support for bar, stacked, dodged, normalized, histogram, line, scatter, heatmap, box and arc (pie) specs.',
+  'chartjs': 'How to make Chart.js charts accessible with MAIDR: support for bar, line, scatter, stacked, dodged, box, candlestick, heatmap (matrix), pie and doughnut charts.',
+  'amcharts': 'How to make amCharts 5 charts accessible with MAIDR: support for bar, dodged, stacked, normalized, line, histogram, heatmap, and pie chart types.',
+  'observable': 'How to make Observable Plot charts accessible with MAIDR: one binding for bar, histogram, scatter, line, area and faceted plots, and for Quarto OJS cells.',
+  'echarts': 'How to make Apache ECharts accessible with MAIDR: support for bar, stacked bar, dodged bar, line, area, step, and scatter series.',
+  'frappe': 'How to make Frappe Charts accessible with MAIDR: support for bar, line, multi-line, scatter, mixed axis (bar + line), pie, and donut chart types.',
+  'victory': 'How to make Victory charts accessible with MAIDR: support for bar, line, scatter, stacked, histogram, box plot, candlestick, and pie chart types.',
+  'anychart': 'How to make AnyChart charts accessible with MAIDR: support for bar, line, step, scatter, box, heatmap, candlestick, and pie chart types via a one-line binder.',
+  'highcharts': 'How to make Highcharts accessible with MAIDR: support for bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, normalized and pie charts.',
+  'tableau': 'How to make embedded Tableau dashboards accessible with MAIDR: sonification, braille and screen-reader navigation for bar, line, scatter and pie worksheets.',
   'examples': 'Interactive examples of accessible bar plots, line charts, heatmaps, scatter plots, box plots, and more using MAIDR.',
-  'Data Schema': 'MAIDR data schema specification for defining accessible chart data structures.',
-  'Braille Generation': 'Documentation for MAIDR braille output generation for tactile data exploration.',
-  'Keyboard Controls': 'Keyboard controls reference for navigating MAIDR accessible data visualizations.',
-  'Live & Streaming Data': 'How to update MAIDR charts in realtime — setData, appendData streaming, sliding windows, and monitor mode for auto-sonifying live data.',
-  'Violin Plot Specification': 'Technical specification for MAIDR violin plot data structures and rendering.',
+  'Data Schema': 'The MAIDR JSON data schema: how to describe figures, subplots, layers, axes and data points for bar, box, heatmap, scatter, line and other chart types.',
+  'Braille Generation': 'How MAIDR encodes bar, box, heatmap, line, scatter and other plots as braille characters for refreshable braille displays, with the rules for each plot type.',
+  'Keyboard Controls': 'Keyboard controls reference for MAIDR: moving through data points, switching between braille, text and sonification modes, and opening the help and chat menus.',
+  'Live & Streaming Data': 'How to update MAIDR charts in realtime: setData, appendData streaming, sliding windows, and monitor mode for auto-sonifying live data.',
+  'Tactile Graphics Display': 'How MAIDR renders charts on the Dot Pad X tactile graphics display over Bluetooth or USB, with the keyboard controls and setup steps the tactile mode needs.',
+  'Violin Plot Specification': 'Technical specification for MAIDR violin plots: the KDE and box layer data structures, how each layer is navigated and sonified, and a backend checklist.',
 };
+
+const today = new Date().toISOString().split('T')[0];
+
+/**
+ * Run a git command in the repository and return its trimmed stdout, or an
+ * empty string when git is unavailable or the command fails (no history, a
+ * tarball checkout, a path git has never seen).
+ */
+function git(args) {
+  try {
+    return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Date (YYYY-MM-DD) of the last commit touching `relPath`, or today when git
+ * history is unavailable.
+ *
+ * File mtimes are useless for this: `actions/checkout` stamps every file with
+ * the checkout time, so a sitemap built from them said "changed today" for
+ * every page on every deploy, and Google ignores a lastmod that is never
+ * accurate. `.github/workflows/docs.yml` checks out with `fetch-depth: 0` so
+ * the history is there in CI.
+ */
+function lastCommitDate(relPath) {
+  return git(['log', '-1', '--format=%cs', '--', relPath]) || today;
+}
+
+/**
+ * Date of the commit that added `relPath`, falling back to its last commit
+ * date. On a shallow clone the earliest visible commit stands in for the real
+ * first one.
+ */
+function firstCommitDate(relPath) {
+  const dates = git(['log', '--diff-filter=A', '--format=%cs', '--', relPath]).split('\n').filter(Boolean);
+  return dates.at(-1) || lastCommitDate(relPath);
+}
 
 /**
  * Build a BreadcrumbList JSON-LD block for the given page.
  */
 function buildBreadcrumbSchema(title, canonicalUrl) {
-  const crumbs = [{ name: 'Home', url: 'https://maidr.ai/' }];
-  if (canonicalUrl !== 'https://maidr.ai/') {
+  const crumbs = [{ name: 'Home', url: SITE_URL }];
+  if (canonicalUrl !== SITE_URL) {
     crumbs.push({ name: title, url: canonicalUrl });
   }
   return JSON.stringify({
@@ -93,17 +179,37 @@ function buildBreadcrumbSchema(title, canonicalUrl) {
 }
 
 /**
+ * The visible breadcrumb trail the BreadcrumbList above describes. Google
+ * asks that structured data mirror what the page shows, so the markup and
+ * the trail come from the same two crumbs.
+ */
+function buildBreadcrumbNav(title, dateModified = '') {
+  // The TechArticle's dateModified needs a visible counterpart; the date is
+  // the last commit touching the page's source, the same one the sitemap uses.
+  const pageMeta = dateModified
+    ? `\n  <p class="page-meta">Last updated <time datetime="${dateModified}">${dateModified}</time></p>`
+    : '';
+  return `<nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="{{BASE_PATH}}index.html">Home</a></li>
+      <li aria-current="page">${title}</li>
+    </ol>
+  </nav>${pageMeta}`;
+}
+
+/**
  * Build a TechArticle JSON-LD block for documentation pages.
  */
-function buildTechArticleSchema(title, description, canonicalUrl, dateModified) {
+function buildTechArticleSchema(title, description, canonicalUrl, datePublished, dateModified) {
   return JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
     'headline': title,
     'description': description,
     'url': canonicalUrl,
-    'datePublished': '2024-01-15', // project launch date; per-page dates not tracked
+    'datePublished': datePublished,
     'dateModified': dateModified,
+    'author': { '@id': 'https://maidr.ai/#organization' },
     'publisher': { '@id': 'https://maidr.ai/#organization' },
     'isPartOf': { '@id': 'https://maidr.ai/#website' },
     'about': { '@id': 'https://maidr.ai/#software' },
@@ -111,37 +217,120 @@ function buildTechArticleSchema(title, description, canonicalUrl, dateModified) 
 }
 
 /**
+ * The papers the README's "Papers" section lists, as ScholarlyArticle nodes
+ * keyed by DOI. Emitted on the home page only, where the citations are
+ * visible; the software node there references them via `citation`.
+ */
+const PAPERS = [
+  {
+    '@type': 'ScholarlyArticle',
+    '@id': 'https://doi.org/10.1145/3613904.3642730',
+    'name': 'MAIDR: Making Statistical Visualizations Accessible with Multimodal Data Representation',
+    'author': [
+      { '@id': 'https://maidr.ai/#jooyoung-seo' },
+      { '@type': 'Person', 'name': 'Yilin Xia' },
+      { '@type': 'Person', 'name': 'Bongshin Lee' },
+      { '@type': 'Person', 'name': 'Sean Mccurry' },
+      { '@type': 'Person', 'name': 'Yu Jun Yam' },
+    ],
+    'datePublished': '2024-05',
+    'isPartOf': {
+      '@type': 'Book',
+      'name': 'Proceedings of the CHI Conference on Human Factors in Computing Systems (CHI \'24)',
+      'isbn': '9798400703300',
+    },
+    'publisher': { '@type': 'Organization', 'name': 'Association for Computing Machinery' },
+    'identifier': '10.1145/3613904.3642730',
+    'url': 'https://doi.org/10.1145/3613904.3642730',
+  },
+  {
+    '@type': 'ScholarlyArticle',
+    '@id': 'https://doi.org/10.2312/eved.20241053',
+    'name': 'Designing Born-Accessible Courses in Data Science and Visualization: Challenges and Opportunities of a Remote Curriculum Taught by Blind Instructors to Blind Students',
+    'author': [
+      { '@id': 'https://maidr.ai/#jooyoung-seo' },
+      { '@type': 'Person', 'name': 'Sile O\'Modhrain' },
+      { '@type': 'Person', 'name': 'Yilin Xia' },
+      { '@type': 'Person', 'name': 'Sanchita Kamath' },
+      { '@type': 'Person', 'name': 'Bongshin Lee' },
+      { '@type': 'Person', 'name': 'James M. Coughlan' },
+    ],
+    'datePublished': '2024',
+    'isPartOf': {
+      '@type': 'Book',
+      'name': 'EuroVis 2024 - Education Papers',
+      'isbn': '978-3-03868-257-8',
+    },
+    'publisher': { '@type': 'Organization', 'name': 'The Eurographics Association' },
+    'identifier': '10.2312/eved.20241053',
+    'url': 'https://doi.org/10.2312/eved.20241053',
+  },
+];
+
+/** The home page's own node, cross-linking the Python and R sites. */
+const HOME_WEBPAGE = {
+  '@type': 'WebPage',
+  '@id': 'https://maidr.ai/#webpage',
+  'url': SITE_URL,
+  'isPartOf': { '@id': 'https://maidr.ai/#website' },
+  'mainEntity': { '@id': 'https://maidr.ai/#software' },
+  'relatedLink': ['https://py.maidr.ai/', 'https://r.maidr.ai/'],
+};
+
+/** Indent every line but the first so a node sits inside the template's @graph. */
+function graphNode(node) {
+  return JSON.stringify(node, null, 2).replace(/\n/g, '\n      ');
+}
+
+/**
  * Generate a page from template.
  * @param {object} opts
- * @param {string} opts.title
- * @param {string} opts.content       - inner HTML
- * @param {string} opts.activePage     - 'home' | 'react' | 'examples' | 'api' | ''
+ * @param {string} opts.title            - nav-facing title; also the breadcrumb text
+ * @param {string} opts.content          - inner HTML
+ * @param {string} opts.activePage       - 'home' | 'react' | 'examples' | 'api' | ''
  * @param {string} [opts.basePath]
- * @param {string} [opts.slug]         - path portion after domain (e.g. 'react.html')
+ * @param {string} [opts.slug]           - path portion after domain (e.g. 'react.html')
  * @param {string} [opts.ogType]
- * @param {string} [opts.pageSchema]   - extra JSON-LD script tags
+ * @param {string} [opts.pageSchema]     - extra JSON-LD script tags
+ * @param {string} [opts.seoTitle]       - full <title>; defaults to "<title> - MAIDR"
+ * @param {string} [opts.dateModified]   - ISO date shown as "Last updated" under the breadcrumb
  */
-function generatePage({ title, content, activePage, basePath = '', slug = '', ogType = 'website', pageSchema = '' }) {
+function generatePage({ title, content, activePage, basePath = '', slug = '', ogType = 'website', pageSchema = '', seoTitle = `${title} - MAIDR`, dateModified = '' }) {
   const description = PAGE_DESCRIPTIONS[activePage] || PAGE_DESCRIPTIONS[title];
   if (!description) {
-    console.warn(`[SEO] No description for page "${title}" (activePage: "${activePage}") — falling back to homepage description`);
+    throw new Error(`[SEO] No description for page "${title}" (activePage: "${activePage}"). Add one to PAGE_DESCRIPTIONS in scripts/build-site.js.`);
   }
-  const finalDescription = description || PAGE_DESCRIPTIONS.home;
-  const canonicalUrl = slug ? `https://maidr.ai/${slug}` : 'https://maidr.ai/';
+  if (description.length < 70 || description.length > 160) {
+    console.warn(`[SEO] Description for "${title}" is ${description.length} characters; aim for 70-160.`);
+  }
+  const canonicalUrl = slug ? `${SITE_URL}${slug}` : SITE_URL;
+  const isHome = canonicalUrl === SITE_URL;
 
-  // Generate breadcrumb schema (skip for home page — single-item lists are unusual)
-  const breadcrumbTag = canonicalUrl !== 'https://maidr.ai/'
-    ? `<script type="application/ld+json">\n  ${buildBreadcrumbSchema(title, canonicalUrl)}\n  </script>`
-    : '';
+  // Breadcrumbs are for pages below the home page: a single-item list is unusual.
+  const breadcrumbTag = isHome
+    ? ''
+    : `<script type="application/ld+json">\n  ${buildBreadcrumbSchema(title, canonicalUrl)}\n  </script>`;
   const allPageSchemas = [breadcrumbTag, pageSchema].filter(Boolean).join('\n  ');
+
+  // The papers and the WebPage node are visible on the home page only.
+  const softwareCitation = isHome
+    ? `"citation": ${graphNode(PAPERS.map(paper => ({ '@id': paper['@id'] })))},\n        `
+    : '';
+  const homeGraphNodes = isHome
+    ? [HOME_WEBPAGE, ...PAPERS].map(node => `,\n      ${graphNode(node)}`).join('')
+    : '';
 
   const page = template
     .replace(/\{\{TITLE\}\}/g, () => title)
-    .replace(/\{\{DESCRIPTION\}\}/g, () => finalDescription)
+    .replace(/\{\{SEO_TITLE\}\}/g, () => seoTitle)
+    .replace(/\{\{DESCRIPTION\}\}/g, () => description)
     .replace(/\{\{CANONICAL_URL\}\}/g, () => canonicalUrl)
     .replace(/\{\{SOFTWARE_VERSION\}\}/g, () => PKG.version)
+    .replace(/\{\{SOFTWARE_CITATION\}\}/g, () => softwareCitation)
+    .replace(/\{\{HOME_GRAPH_NODES\}\}/g, () => homeGraphNodes)
     .replace(/\{\{OG_TYPE\}\}/g, () => ogType)
     .replace(/\{\{PAGE_SCHEMA\}\}/g, () => allPageSchemas)
+    .replace(/\{\{BREADCRUMB\}\}/g, () => isHome ? '' : buildBreadcrumbNav(title, dateModified))
     .replace(/\{\{CONTENT\}\}/g, () => content)
     .replace(/\{\{HOME_ACTIVE\}\}/g, () => activePage === 'home' ? 'active' : '')
     .replace(/\{\{REACT_ACTIVE\}\}/g, () => activePage === 'react' ? 'active' : '')
@@ -182,217 +371,40 @@ const readmeHtml = `
   ${readmeContentHtml}
 </div>
 `;
-const indexPage = generatePage({ title: 'Home', content: readmeHtml, activePage: 'home', slug: '' });
+const indexPage = generatePage({
+  title: 'Home',
+  seoTitle: 'MAIDR: Accessible Data Visualization with Sonification, Braille and Text',
+  content: readmeHtml,
+  activePage: 'home',
+  slug: '',
+});
 fs.writeFileSync(path.join(SITE_DIR, 'index.html'), indexPage);
 
-// Build react.html from docs/react.md
-console.log('Building react.html from docs/react.md...');
-const reactMdPath = path.join(ROOT, 'docs', 'react.md');
-if (fs.existsSync(reactMdPath)) {
-  const reactMd = fs.readFileSync(reactMdPath, 'utf-8');
-  const reactHtml = `
+// Build one root page per integration guide
+const builtIntegrations = [];
+for (const { slug, title, source } of INTEGRATION_PAGES) {
+  const mdPath = path.join(ROOT, 'docs', source);
+  if (!fs.existsSync(mdPath)) {
+    console.warn(`Warning: docs/${source} not found; skipping ${slug}.html`);
+    continue;
+  }
+  console.log(`Building ${slug}.html from docs/${source}...`);
+  const md = fs.readFileSync(mdPath, 'utf-8');
+  const html = `
 <div class="content">
-  ${renderMarkdown(reactMd)}
+  ${renderMarkdown(md)}
 </div>
 `;
-  const reactPage = generatePage({ title: 'React', content: reactHtml, activePage: 'react', slug: 'react.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'react.html'), reactPage);
-}
-
-// Build recharts.html from docs/recharts.md
-console.log('Building recharts.html from docs/recharts.md...');
-const rechartsMdPath = path.join(ROOT, 'docs', 'recharts.md');
-if (fs.existsSync(rechartsMdPath)) {
-  const rechartsMd = fs.readFileSync(rechartsMdPath, 'utf-8');
-  const rechartsHtml = `
-<div class="content">
-  ${renderMarkdown(rechartsMd)}
-</div>
-`;
-  const rechartsPage = generatePage({ title: 'Recharts', content: rechartsHtml, activePage: 'recharts', slug: 'recharts.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'recharts.html'), rechartsPage);
-}
-
-// Build plotly.html from docs/plotly.md
-console.log('Building plotly.html from docs/plotly.md...');
-const plotlyMdPath = path.join(ROOT, 'docs', 'plotly.md');
-if (fs.existsSync(plotlyMdPath)) {
-  const plotlyMd = fs.readFileSync(plotlyMdPath, 'utf-8');
-  const plotlyHtml = `
-<div class="content">
-  ${renderMarkdown(plotlyMd)}
-</div>
-`;
-  const plotlyPage = generatePage({ title: 'Plotly', content: plotlyHtml, activePage: 'plotly', slug: 'plotly.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'plotly.html'), plotlyPage);
-}
-
-// Build google-charts.html from docs/google-charts.md
-console.log('Building google-charts.html from docs/google-charts.md...');
-const googleChartsMdPath = path.join(ROOT, 'docs', 'google-charts.md');
-if (fs.existsSync(googleChartsMdPath)) {
-  const googleChartsMd = fs.readFileSync(googleChartsMdPath, 'utf-8');
-  const googleChartsHtml = `
-<div class="content">
-  ${renderMarkdown(googleChartsMd)}
-</div>
-`;
-  const googleChartsPage = generatePage({ title: 'Google Charts', content: googleChartsHtml, activePage: 'google-charts', slug: 'google-charts.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'google-charts.html'), googleChartsPage);
-}
-
-// Build d3.html from docs/d3.md
-console.log('Building d3.html from docs/d3.md...');
-const d3MdPath = path.join(ROOT, 'docs', 'd3.md');
-if (fs.existsSync(d3MdPath)) {
-  const d3Md = fs.readFileSync(d3MdPath, 'utf-8');
-  const d3Html = `
-<div class="content">
-  ${renderMarkdown(d3Md)}
-</div>
-`;
-  const d3Page = generatePage({ title: 'D3.js', content: d3Html, activePage: 'd3', slug: 'd3.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'd3.html'), d3Page);
-}
-
-// Build vegalite.html from docs/vegalite.md
-console.log('Building vegalite.html from docs/vegalite.md...');
-const vegaliteMdPath = path.join(ROOT, 'docs', 'vegalite.md');
-if (fs.existsSync(vegaliteMdPath)) {
-  const vegaliteMd = fs.readFileSync(vegaliteMdPath, 'utf-8');
-  const vegaliteHtml = `
-<div class="content">
-  ${renderMarkdown(vegaliteMd)}
-</div>
-`;
-  const vegalitePage = generatePage({ title: 'Vega-Lite', content: vegaliteHtml, activePage: 'vegalite', slug: 'vegalite.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'vegalite.html'), vegalitePage);
-}
-
-// Build chartjs.html from docs/chartjs.md
-console.log('Building chartjs.html from docs/chartjs.md...');
-const chartjsMdPath = path.join(ROOT, 'docs', 'chartjs.md');
-if (fs.existsSync(chartjsMdPath)) {
-  const chartjsMd = fs.readFileSync(chartjsMdPath, 'utf-8');
-  const chartjsHtml = `
-<div class="content">
-  ${renderMarkdown(chartjsMd)}
-</div>
-`;
-  const chartjsPage = generatePage({ title: 'Chart.js', content: chartjsHtml, activePage: 'chartjs', slug: 'chartjs.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'chartjs.html'), chartjsPage);
-}
-
-// Build amcharts.html from docs/amcharts.md
-console.log('Building amcharts.html from docs/amcharts.md...');
-const amchartsMdPath = path.join(ROOT, 'docs', 'amcharts.md');
-if (fs.existsSync(amchartsMdPath)) {
-  const amchartsMd = fs.readFileSync(amchartsMdPath, 'utf-8');
-  const amchartsHtml = `
-<div class="content">
-  ${renderMarkdown(amchartsMd)}
-</div>
-`;
-  const amchartsPage = generatePage({ title: 'amCharts', content: amchartsHtml, activePage: 'amcharts', slug: 'amcharts.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'amcharts.html'), amchartsPage);
-}
-
-// Build observable.html from docs/observable.md
-console.log('Building observable.html from docs/observable.md...');
-const observableMdPath = path.join(ROOT, 'docs', 'observable.md');
-if (fs.existsSync(observableMdPath)) {
-  const observableMd = fs.readFileSync(observableMdPath, 'utf-8');
-  const observableHtml = `
-<div class="content">
-  ${renderMarkdown(observableMd)}
-</div>
-`;
-  const observablePage = generatePage({ title: 'Observable Plot', content: observableHtml, activePage: 'observable', slug: 'observable.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'observable.html'), observablePage);
-}
-
-// Build echarts.html from docs/echarts.md
-console.log('Building echarts.html from docs/echarts.md...');
-const echartsMdPath = path.join(ROOT, 'docs', 'echarts.md');
-if (fs.existsSync(echartsMdPath)) {
-  const echartsMd = fs.readFileSync(echartsMdPath, 'utf-8');
-  const echartsHtml = `
-<div class="content">
-  ${renderMarkdown(echartsMd)}
-</div>
-`;
-  const echartsPage = generatePage({ title: 'Apache ECharts', content: echartsHtml, activePage: 'echarts', slug: 'echarts.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'echarts.html'), echartsPage);
-}
-
-// Build frappe.html from docs/frappe.md
-console.log('Building frappe.html from docs/frappe.md...');
-const frappeMdPath = path.join(ROOT, 'docs', 'frappe.md');
-if (fs.existsSync(frappeMdPath)) {
-  const frappeMd = fs.readFileSync(frappeMdPath, 'utf-8');
-  const frappeHtml = `
-<div class="content">
-  ${renderMarkdown(frappeMd)}
-</div>
-`;
-  const frappePage = generatePage({ title: 'Frappe Charts', content: frappeHtml, activePage: 'frappe', slug: 'frappe.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'frappe.html'), frappePage);
-}
-
-// Build victory.html from docs/victory.md
-console.log('Building victory.html from docs/victory.md...');
-const victoryMdPath = path.join(ROOT, 'docs', 'victory.md');
-if (fs.existsSync(victoryMdPath)) {
-  const victoryMd = fs.readFileSync(victoryMdPath, 'utf-8');
-  const victoryHtml = `
-<div class="content">
-  ${renderMarkdown(victoryMd)}
-</div>
-`;
-  const victoryPage = generatePage({ title: 'Victory', content: victoryHtml, activePage: 'victory', slug: 'victory.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'victory.html'), victoryPage);
-}
-
-// Build anychart.html from docs/anychart.md
-console.log('Building anychart.html from docs/anychart.md...');
-const anychartMdPath = path.join(ROOT, 'docs', 'anychart.md');
-if (fs.existsSync(anychartMdPath)) {
-  const anychartMd = fs.readFileSync(anychartMdPath, 'utf-8');
-  const anychartHtml = `
-<div class="content">
-  ${renderMarkdown(anychartMd)}
-</div>
-`;
-  const anychartPage = generatePage({ title: 'AnyChart', content: anychartHtml, activePage: 'anychart', slug: 'anychart.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'anychart.html'), anychartPage);
-}
-
-// Build highcharts.html from docs/highcharts.md
-console.log('Building highcharts.html from docs/highcharts.md...');
-const highchartsMdPath = path.join(ROOT, 'docs', 'highcharts.md');
-if (fs.existsSync(highchartsMdPath)) {
-  const highchartsMd = fs.readFileSync(highchartsMdPath, 'utf-8');
-  const highchartsHtml = `
-<div class="content">
-  ${renderMarkdown(highchartsMd)}
-</div>
-`;
-  const highchartsPage = generatePage({ title: 'Highcharts', content: highchartsHtml, activePage: 'highcharts', slug: 'highcharts.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'highcharts.html'), highchartsPage);
-}
-
-// Build tableau.html from docs/tableau.md
-console.log('Building tableau.html from docs/tableau.md...');
-const tableauMdPath = path.join(ROOT, 'docs', 'tableau.md');
-if (fs.existsSync(tableauMdPath)) {
-  const tableauMd = fs.readFileSync(tableauMdPath, 'utf-8');
-  const tableauHtml = `
-<div class="content">
-  ${renderMarkdown(tableauMd)}
-</div>
-`;
-  const tableauPage = generatePage({ title: 'Tableau', content: tableauHtml, activePage: 'tableau', slug: 'tableau.html', ogType: 'article' });
-  fs.writeFileSync(path.join(SITE_DIR, 'tableau.html'), tableauPage);
+  const page = generatePage({
+    title,
+    seoTitle: `${title} Accessibility Integration - MAIDR`,
+    content: html,
+    activePage: slug,
+    slug: `${slug}.html`,
+    ogType: 'article',
+  });
+  fs.writeFileSync(path.join(SITE_DIR, `${slug}.html`), page);
+  builtIntegrations.push({ slug, source });
 }
 
 // Build examples.html (inline gallery content — no middle iframe)
@@ -588,24 +600,52 @@ if (fs.existsSync(victoryBuilt)) {
   console.warn('Warning: Built Victory example not found. Run "npm run build:victory-example" first.');
 }
 
-const today = new Date().toISOString().split('T')[0];
-
-/** Return file mtime as YYYY-MM-DD, or today if the file does not exist. */
-function fileMod(filePath) {
-  try {
-    return fs.statSync(filePath).mtime.toISOString().split('T')[0];
-  } catch {
-    return today;
+/**
+ * Keep the example pages out of the search index.
+ *
+ * They are demo files: no title worth indexing, no description, often no
+ * heading, and the Recharts bundle sits at Googlebot's 2 MB cut-off. The
+ * gallery on examples.html links them with real hrefs so they are crawlable
+ * (and so the links work for assistive technology), and this tag keeps that
+ * from filling the index with 250-odd thin pages. examples.html itself is
+ * not touched; it has unique text and stays indexable.
+ */
+function noindexExamplePages(dir) {
+  let count = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += noindexExamplePages(full);
+      continue;
+    }
+    if (!entry.name.endsWith('.html')) {
+      continue;
+    }
+    const html = fs.readFileSync(full, 'utf-8');
+    if (/<meta\s+name="robots"/i.test(html)) {
+      continue;
+    }
+    const tag = '<meta name="robots" content="noindex">';
+    const tagged = /<head[^>]*>/i.test(html)
+      ? html.replace(/<head[^>]*>/i, match => `${match}\n${tag}`)
+      : `${tag}\n${html}`;
+    fs.writeFileSync(full, tagged);
+    count += 1;
   }
+  return count;
+}
+if (fs.existsSync(examplesDest)) {
+  console.log(`Marked ${noindexExamplePages(examplesDest)} example pages noindex`);
 }
 
 // Process docs folder: convert .md to HTML pages, copy other static assets
 const docsSource = path.join(ROOT, 'docs');
 const docsSiteDest = path.join(SITE_DIR, 'docs');
+const builtDocs = [];
 if (fs.existsSync(docsSource)) {
   const files = fs.readdirSync(docsSource);
   for (const file of files) {
-    if (file === 'template.html' || file === 'examples' || file === 'react.md' || file === 'recharts.md' || file === 'plotly.md' || file === 'google-charts.md' || file === 'd3.md' || file === 'vegalite.md' || file === 'chartjs.md' || file === 'amcharts.md' || file === 'frappe.md' || file === 'observable.md' || file === 'victory.md' || file === 'anychart.md' || file === 'highcharts.md' || file === 'tableau.md')
+    if (file === 'template.html' || file === 'examples' || INTEGRATION_SOURCES.has(file))
       continue;
 
     const src = path.join(docsSource, file);
@@ -620,19 +660,17 @@ if (fs.existsSync(docsSource)) {
       const md = fs.readFileSync(src, 'utf-8');
       const htmlContent = `<div class="content">${markdownToHtml(md)}</div>`;
       const baseName = path.basename(file, path.extname(file));
-      const titleMap = {
-        SCHEMA: 'Data Schema',
-        BRAILLE: 'Braille Generation',
-        CONTROLS: 'Keyboard Controls',
-        LIVE_DATA: 'Live & Streaming Data',
-        VIOLIN_PLOT_SPEC: 'Violin Plot Specification',
-      };
-      const title = titleMap[baseName] ?? baseName;
+      const title = DOC_TITLES[baseName] ?? baseName;
       const docSlug = `docs/${baseName}.html`;
-      const docCanonical = `https://maidr.ai/${docSlug}`;
-      const fileMtime = fileMod(src);
-      const description = PAGE_DESCRIPTIONS[title] || PAGE_DESCRIPTIONS.home;
-      const techArticleTag = `<script type="application/ld+json">\n  ${buildTechArticleSchema(title, description, docCanonical, fileMtime)}\n  </script>`;
+      const docCanonical = `${SITE_URL}${docSlug}`;
+      const relSource = `docs/${file}`;
+      const dateModified = lastCommitDate(relSource);
+      const datePublished = firstCommitDate(relSource);
+      const description = PAGE_DESCRIPTIONS[title];
+      if (!description) {
+        throw new Error(`[SEO] No description for docs page "${title}" (docs/${file}). Add one to PAGE_DESCRIPTIONS in scripts/build-site.js.`);
+      }
+      const techArticleTag = `<script type="application/ld+json">\n  ${buildTechArticleSchema(title, description, docCanonical, datePublished, dateModified)}\n  </script>`;
       const docPage = generatePage({
         title,
         content: htmlContent,
@@ -641,8 +679,10 @@ if (fs.existsSync(docsSource)) {
         slug: docSlug,
         ogType: 'article',
         pageSchema: techArticleTag,
+        dateModified,
       });
       fs.writeFileSync(path.join(docsSiteDest, `${baseName}.html`), docPage);
+      builtDocs.push({ slug: docSlug, lastmod: dateModified });
     } else if (fs.statSync(src).isDirectory()) {
       // Copy directories to _site/ root
       fs.cpSync(src, path.join(SITE_DIR, file), { recursive: true });
@@ -653,50 +693,27 @@ if (fs.existsSync(docsSource)) {
   }
 }
 
-// Generate sitemap.xml — built dynamically from the docs/ folder so new pages
-// are included automatically without maintaining a hardcoded list.
+// Generate sitemap.xml from the pages built above, so a new page cannot be
+// left out of it. Only <loc> and <lastmod>: Google ignores <changefreq> and
+// <priority>. The API reference has its own sitemap, written by TypeDoc from
+// `hostedBaseUrl` to _site/api/sitemap.xml and listed in docs/robots.txt.
 console.log('Generating sitemap.xml...');
 
 const sitemapUrls = [
-  { loc: 'https://maidr.ai/', priority: '1.0', lastmod: fileMod(path.join(ROOT, 'README.md')) },
-  { loc: 'https://maidr.ai/react.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'react.md')) },
-  { loc: 'https://maidr.ai/recharts.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'recharts.md')) },
-  { loc: 'https://maidr.ai/plotly.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'plotly.md')) },
-  { loc: 'https://maidr.ai/google-charts.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'google-charts.md')) },
-  { loc: 'https://maidr.ai/d3.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'd3.md')) },
-  { loc: 'https://maidr.ai/vegalite.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'vegalite.md')) },
-  { loc: 'https://maidr.ai/chartjs.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'chartjs.md')) },
-  { loc: 'https://maidr.ai/amcharts.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'amcharts.md')) },
-  { loc: 'https://maidr.ai/frappe.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'frappe.md')) },
-  { loc: 'https://maidr.ai/observable.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'observable.md')) },
-  { loc: 'https://maidr.ai/victory.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'victory.md')) },
-  { loc: 'https://maidr.ai/anychart.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'anychart.md')) },
-  { loc: 'https://maidr.ai/highcharts.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'highcharts.md')) },
-  { loc: 'https://maidr.ai/tableau.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'tableau.md')) },
-  { loc: 'https://maidr.ai/examples.html', priority: '0.8', lastmod: today },
-  { loc: 'https://maidr.ai/api/index.html', priority: '0.7', lastmod: today },
+  { loc: SITE_URL, lastmod: lastCommitDate('README.md') },
+  ...builtIntegrations.map(({ slug, source }) => ({
+    loc: `${SITE_URL}${slug}.html`,
+    lastmod: lastCommitDate(`docs/${source}`),
+  })),
+  { loc: `${SITE_URL}examples.html`, lastmod: lastCommitDate('examples') },
+  ...builtDocs.map(({ slug, lastmod }) => ({ loc: `${SITE_URL}${slug}`, lastmod })),
 ];
-
-// Add all doc .md files that were built into _site/docs/
-if (fs.existsSync(docsSource)) {
-  for (const f of fs.readdirSync(docsSource)) {
-    if (f === 'template.html' || f === 'react.md' || f === 'recharts.md' || f === 'plotly.md' || f === 'google-charts.md' || f === 'd3.md' || f === 'vegalite.md' || f === 'chartjs.md' || f === 'amcharts.md' || f === 'frappe.md' || f === 'observable.md' || f === 'victory.md' || f === 'anychart.md' || f === 'highcharts.md' || f === 'tableau.md' || !f.endsWith('.md'))
-      continue;
-    const base = path.basename(f, '.md');
-    sitemapUrls.push({
-      loc: `https://maidr.ai/docs/${base}.html`,
-      priority: '0.6',
-      lastmod: fileMod(path.join(docsSource, f)),
-    });
-  }
-}
 
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${sitemapUrls.map(u => `  <url>
-    <loc>${u.loc}</loc>${u.lastmod ? `\n    <lastmod>${u.lastmod}</lastmod>` : ''}
-    <changefreq>monthly</changefreq>
-    <priority>${u.priority}</priority>
+    <loc>${u.loc}</loc>
+    <lastmod>${u.lastmod}</lastmod>
   </url>`).join('\n')}
 </urlset>
 `;

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -9,11 +9,12 @@
  * - TypeDoc generates API docs separately
  */
 
-import { execFileSync, execSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildGallery, listExamplePages, renderGallery } from './examplesGallery.js';
+import { firstCommitDate as firstCommit, lastCommitDate as lastCommit } from './gitDates.js';
 import { renderMarkdown } from './markdown.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -121,41 +122,14 @@ const PAGE_DESCRIPTIONS = {
 
 const today = new Date().toISOString().split('T')[0];
 
-/**
- * Run a git command in the repository and return its trimmed stdout, or an
- * empty string when git is unavailable or the command fails (no history, a
- * tarball checkout, a path git has never seen).
- */
-function git(args) {
-  try {
-    return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Date (YYYY-MM-DD) of the last commit touching `relPath`, or today when git
- * history is unavailable.
- *
- * File mtimes are useless for this: `actions/checkout` stamps every file with
- * the checkout time, so a sitemap built from them said "changed today" for
- * every page on every deploy, and Google ignores a lastmod that is never
- * accurate. `.github/workflows/docs.yml` checks out with `fetch-depth: 0` so
- * the history is there in CI.
- */
+/** Date of the last commit touching `relPath`, or today outside a git checkout. */
 function lastCommitDate(relPath) {
-  return git(['log', '-1', '--format=%cs', '--', relPath]) || today;
+  return lastCommit(ROOT, relPath, today);
 }
 
-/**
- * Date of the commit that added `relPath`, falling back to its last commit
- * date. On a shallow clone the earliest visible commit stands in for the real
- * first one.
- */
+/** Date of the commit that added `relPath`, followed across renames. */
 function firstCommitDate(relPath) {
-  const dates = git(['log', '--diff-filter=A', '--format=%cs', '--', relPath]).split('\n').filter(Boolean);
-  return dates.at(-1) || lastCommitDate(relPath);
+  return firstCommit(ROOT, relPath, today);
 }
 
 /**
@@ -395,6 +369,14 @@ for (const { slug, title, source } of INTEGRATION_PAGES) {
   ${renderMarkdown(md)}
 </div>
 `;
+  const description = PAGE_DESCRIPTIONS[slug];
+  if (!description) {
+    throw new Error(`[SEO] No description for integration page "${slug}" (docs/${source}). Add one to PAGE_DESCRIPTIONS in scripts/build-site.js.`);
+  }
+  const relSource = `docs/${source}`;
+  const dateModified = lastCommitDate(relSource);
+  const canonical = `${SITE_URL}${slug}.html`;
+  const techArticleTag = `<script type="application/ld+json">\n  ${buildTechArticleSchema(title, description, canonical, firstCommitDate(relSource), dateModified)}\n  </script>`;
   const page = generatePage({
     title,
     seoTitle: `${title} Accessibility Integration - MAIDR`,
@@ -402,6 +384,8 @@ for (const { slug, title, source } of INTEGRATION_PAGES) {
     activePage: slug,
     slug: `${slug}.html`,
     ogType: 'article',
+    pageSchema: techArticleTag,
+    dateModified,
   });
   fs.writeFileSync(path.join(SITE_DIR, `${slug}.html`), page);
   builtIntegrations.push({ slug, source });

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildGallery, listExamplePages, renderGallery } from './examplesGallery.js';
 import { firstCommitDate as firstCommit, lastCommitDate as lastCommit } from './gitDates.js';
+import { inlineJson } from './jsonLd.js';
 import { renderMarkdown } from './markdown.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -140,7 +141,7 @@ function buildBreadcrumbSchema(title, canonicalUrl) {
   if (canonicalUrl !== SITE_URL) {
     crumbs.push({ name: title, url: canonicalUrl });
   }
-  return JSON.stringify({
+  return inlineJson({
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     'itemListElement': crumbs.map((c, i) => ({
@@ -149,7 +150,7 @@ function buildBreadcrumbSchema(title, canonicalUrl) {
       'name': c.name,
       'item': c.url,
     })),
-  }, null, 2);
+  }, 2);
 }
 
 /**
@@ -175,7 +176,7 @@ function buildBreadcrumbNav(title, dateModified = '') {
  * Build a TechArticle JSON-LD block for documentation pages.
  */
 function buildTechArticleSchema(title, description, canonicalUrl, datePublished, dateModified) {
-  return JSON.stringify({
+  return inlineJson({
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
     'headline': title,
@@ -187,7 +188,7 @@ function buildTechArticleSchema(title, description, canonicalUrl, datePublished,
     'publisher': { '@id': 'https://maidr.ai/#organization' },
     'isPartOf': { '@id': 'https://maidr.ai/#website' },
     'about': { '@id': 'https://maidr.ai/#software' },
-  }, null, 2);
+  }, 2);
 }
 
 /**
@@ -253,7 +254,7 @@ const HOME_WEBPAGE = {
 
 /** Indent every line but the first so a node sits inside the template's @graph. */
 function graphNode(node) {
-  return JSON.stringify(node, null, 2).replace(/\n/g, '\n      ');
+  return inlineJson(node, 2).replace(/\n/g, '\n      ');
 }
 
 /**

--- a/scripts/check-page-sizes.js
+++ b/scripts/check-page-sizes.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * Fails the docs build when a page grows past what Googlebot will read.
+ *
+ * Googlebot fetches the first 2 MB (2,097,152 bytes, uncompressed) of an HTML
+ * file and discards the rest, so anything after that point is invisible to
+ * search and to the AI features built on it. The cap here is 1,900,000 bytes
+ * to leave headroom.
+ *
+ * `_site/examples/` and `_site/api/` are exempt: the examples are demo files
+ * marked noindex (the single-file Recharts bundle sits right at the limit),
+ * and the TypeDoc pages top out around 860 KB because the hierarchy theme
+ * inlines the navigation tree into each one. The five largest files overall
+ * are still printed so growth in either stays visible.
+ *
+ * Runs last in `npm run docs`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SITE_DIR = path.join(__dirname, '..', '_site');
+const LIMIT = 1_900_000;
+const EXEMPT_DIRS = new Set(['examples', 'api']);
+
+/** Every .html file under `dir`, recursively. */
+function findHtmlFiles(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findHtmlFiles(full, files);
+    } else if (entry.name.endsWith('.html')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/** The path relative to `_site/`, with forward slashes. */
+function siteRelative(file) {
+  return path.relative(SITE_DIR, file).split(path.sep).join('/');
+}
+
+function formatBytes(size) {
+  return `${size.toLocaleString('en-US')} B`;
+}
+
+if (!fs.existsSync(SITE_DIR)) {
+  console.error(`check-page-sizes: ${SITE_DIR} does not exist; run the docs build first.`);
+  process.exit(1);
+}
+
+const pages = findHtmlFiles(SITE_DIR)
+  .map(file => ({ file: siteRelative(file), size: fs.statSync(file).size }))
+  .sort((a, b) => b.size - a.size);
+
+console.log('Largest HTML files in _site/:');
+for (const { file, size } of pages.slice(0, 5)) {
+  console.log(`  ${formatBytes(size).padStart(14)}  ${file}`);
+}
+
+const offenders = pages.filter(({ file, size }) => !EXEMPT_DIRS.has(file.split('/')[0]) && size > LIMIT);
+
+if (offenders.length > 0) {
+  console.error(`\ncheck-page-sizes: ${offenders.length} page(s) exceed ${formatBytes(LIMIT)}, the Googlebot-safe limit:`);
+  for (const { file, size } of offenders) {
+    console.error(`  ${formatBytes(size).padStart(14)}  ${file}`);
+  }
+  process.exit(1);
+}
+
+console.log(`\nAll indexable pages are under ${formatBytes(LIMIT)}.`);

--- a/scripts/check-page-sizes.js
+++ b/scripts/check-page-sizes.js
@@ -3,29 +3,19 @@
 /**
  * Fails the docs build when a page grows past what Googlebot will read.
  *
- * Googlebot fetches the first 2 MB (2,097,152 bytes, uncompressed) of an HTML
- * file and discards the rest, so anything after that point is invisible to
- * search and to the AI features built on it. The cap here is 1,900,000 bytes
- * to leave headroom.
- *
- * `_site/examples/` and `_site/api/` are exempt: the examples are demo files
- * marked noindex (the single-file Recharts bundle sits right at the limit),
- * and the TypeDoc pages top out around 860 KB because the hierarchy theme
- * inlines the navigation tree into each one. The five largest files overall
- * are still printed so growth in either stays visible.
- *
- * Runs last in `npm run docs`.
+ * The limits and exemptions live in `scripts/pageSizes.js`; this is the CLI
+ * that runs last in `npm run docs`, prints the five largest files so growth
+ * anywhere stays visible, and exits non-zero on an offender.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import { findOffenders, HARD_LIMIT, SOFT_LIMIT } from './pageSizes.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SITE_DIR = path.join(__dirname, '..', '_site');
-const LIMIT = 1_900_000;
-const EXEMPT_DIRS = new Set(['examples', 'api']);
 
 /** Every .html file under `dir`, recursively. */
 function findHtmlFiles(dir, files = []) {
@@ -63,14 +53,14 @@ for (const { file, size } of pages.slice(0, 5)) {
   console.log(`  ${formatBytes(size).padStart(14)}  ${file}`);
 }
 
-const offenders = pages.filter(({ file, size }) => !EXEMPT_DIRS.has(file.split('/')[0]) && size > LIMIT);
+const offenders = findOffenders(pages);
 
 if (offenders.length > 0) {
-  console.error(`\ncheck-page-sizes: ${offenders.length} page(s) exceed ${formatBytes(LIMIT)}, the Googlebot-safe limit:`);
-  for (const { file, size } of offenders) {
-    console.error(`  ${formatBytes(size).padStart(14)}  ${file}`);
+  console.error(`\ncheck-page-sizes: ${offenders.length} page(s) exceed their Googlebot-safe limit:`);
+  for (const { file, size, limit } of offenders) {
+    console.error(`  ${formatBytes(size).padStart(14)}  ${file} (limit ${formatBytes(limit)})`);
   }
   process.exit(1);
 }
 
-console.log(`\nAll indexable pages are under ${formatBytes(LIMIT)}.`);
+console.log(`\nAll indexable pages are within ${formatBytes(SOFT_LIMIT)} (${formatBytes(HARD_LIMIT)} for api/).`);

--- a/scripts/examplesGallery.d.ts
+++ b/scripts/examplesGallery.d.ts
@@ -18,6 +18,8 @@ export interface ExcludedExample {
 export interface GalleryItem {
   /** Path relative to `examples/`; absent on a hand-written entry. */
   page?: string;
+  /** A hand-written entry's link target, in place of `examples/<page>`. */
+  href?: string;
   /** A hand-written entry's click handler, in place of `loadHTML(...)`. */
   onclick?: string;
   /** The link text. */
@@ -52,7 +54,7 @@ export interface GalleryGroup {
   /** Prepended to the link text to form the announced heading. */
   headingPrefix?: string;
   /** Entries that are not pages, such as the bundled React example. */
-  statics?: { onclick: string; label: string }[];
+  statics?: { href: string; onclick: string; label: string }[];
   /** Whether an unprefixed top-level page lands here. At most one group. */
   fallback?: boolean;
 }

--- a/scripts/examplesGallery.js
+++ b/scripts/examplesGallery.js
@@ -245,7 +245,7 @@ export const GROUPS = [
     id: 'react',
     heading: 'React',
     headingId: 'react-examples',
-    statics: [{ onclick: 'loadReact()', label: 'React Examples (Bar, Line, Smooth, D3 Bar, D3 Scatter)' }],
+    statics: [{ href: 'examples/react/index.html', onclick: 'loadReact()', label: 'React Examples (Bar, Line, Smooth, D3 Bar, D3 Scatter)' }],
     note: 'See the <a href="react.html">React Integration Guide</a> for setup instructions, TypeScript types, and code examples for all plot types. The D3 examples show how to use <a href="d3.html">the D3 adapter</a> with the <code>&lt;MaidrD3&gt;</code> wrapper.',
   },
   {
@@ -265,7 +265,7 @@ export const GROUPS = [
   {
     id: 'recharts',
     heading: 'Recharts',
-    statics: [{ onclick: 'loadRecharts()', label: 'Recharts Examples (Bar, Line, Scatter, Stacked, Histogram)' }],
+    statics: [{ href: 'examples/recharts/index.html', onclick: 'loadRecharts()', label: 'Recharts Examples (Bar, Line, Scatter, Stacked, Histogram)' }],
     note: 'See the <a href="recharts.html">Recharts Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.',
   },
   {
@@ -326,7 +326,7 @@ export const GROUPS = [
   {
     id: 'victory',
     heading: 'Victory',
-    statics: [{ onclick: 'loadVictory()', label: 'Victory Examples (Bar, Line, Scatter, Stacked, Histogram, Box, Candlestick)' }],
+    statics: [{ href: 'examples/victory/index.html', onclick: 'loadVictory()', label: 'Victory Examples (Bar, Line, Scatter, Stacked, Histogram, Box, Candlestick)' }],
     note: 'See the <a href="victory.html">Victory Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.',
   },
   {
@@ -553,10 +553,21 @@ function js(value) {
   return value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
 }
 
-/** One `<li>`: the same markup and the same `loadHTML` call as before. */
+/**
+ * One `<li>`: a real link to the example page, with the same `loadHTML` call
+ * as before on click.
+ *
+ * The `href` used to be `#`, which made every entry a link in name only: no
+ * crawler could reach a page under `examples/` from the gallery, and a
+ * screen reader announced a link that went nowhere. The handler still
+ * `return false`s, so a click (or Enter on the focused link) opens the
+ * example in the iframe below rather than navigating, and the href is what a
+ * middle-click, a crawler, or a user without JavaScript follows.
+ */
 function renderItem(item) {
+  const href = item.href ?? `examples/${item.page}`;
   const onclick = item.onclick ?? `loadHTML('${js(item.page)}', '${js(item.heading)}')`;
-  return `    <li><a href="#" onclick="${attr(onclick)}; return false;">${item.label}</a></li>`;
+  return `    <li><a href="${attr(href)}" onclick="${attr(onclick)}; return false;">${item.label}</a></li>`;
 }
 
 /** The gallery's markup, for `scripts/build-site.js` to drop into the page. */

--- a/scripts/gitDates.d.ts
+++ b/scripts/gitDates.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Hand-written declarations for `gitDates.js`.
+ *
+ * The module is plain JS so `scripts/build-site.js` (run directly by node) can
+ * import it; `tsconfig.json` sets `allowJs: false`, so a TypeScript test needs
+ * these to import it too. Keep both files in sync.
+ */
+
+/** Trimmed stdout of `git <args>` run in `cwd`, or `''` when it fails. */
+export function git(cwd: string, args: string[]): string;
+
+/** Date (YYYY-MM-DD) of the last commit touching `relPath`, else `fallback`. */
+export function lastCommitDate(cwd: string, relPath: string, fallback: string): string;
+
+/**
+ * Date of the commit that added `relPath`, followed across renames, else its
+ * last commit date, else `fallback`.
+ */
+export function firstCommitDate(cwd: string, relPath: string, fallback: string): string;

--- a/scripts/gitDates.js
+++ b/scripts/gitDates.js
@@ -1,0 +1,38 @@
+/**
+ * Commit dates for the site's sitemap `<lastmod>` and TechArticle dates.
+ *
+ * `actions/checkout` gives every file the checkout time as its mtime, so file
+ * stats would stamp the build date on every URL; Google ignores a `lastmod`
+ * that changes on every build. The dates here come from git instead, and the
+ * docs workflows check out full history so they are the real ones.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Run a git command in `cwd` and return its trimmed stdout, or an empty
+ * string when git is unavailable or the command fails (no history, a tarball
+ * checkout, a path git has never seen).
+ */
+export function git(cwd, args) {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Date (YYYY-MM-DD) of the last commit touching `relPath`, else `fallback`. */
+export function lastCommitDate(cwd, relPath, fallback) {
+  return git(cwd, ['log', '-1', '--format=%cs', '--', relPath]) || fallback;
+}
+
+/**
+ * Date of the commit that added `relPath`, followed across renames, falling
+ * back to its last commit date. On a shallow clone the earliest visible
+ * commit stands in for the real first one.
+ */
+export function firstCommitDate(cwd, relPath, fallback) {
+  const dates = git(cwd, ['log', '--follow', '--diff-filter=A', '--format=%cs', '--', relPath]).split('\n').filter(Boolean);
+  return dates.at(-1) || lastCommitDate(cwd, relPath, fallback);
+}

--- a/scripts/jsonLd.d.ts
+++ b/scripts/jsonLd.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Hand-written declarations for `jsonLd.js`.
+ *
+ * The module is plain JS so `scripts/build-site.js` (run directly by node) and
+ * `scripts/typedoc-seo-plugin.mjs` (loaded by TypeDoc) can import it;
+ * `tsconfig.json` sets `allowJs: false`, so a TypeScript test needs these to
+ * import it too. Keep both files in sync.
+ */
+
+/** `value` as JSON safe to inline in a script tag, indented by `space`. */
+export function inlineJson(value: unknown, space?: number | string): string;

--- a/scripts/jsonLd.js
+++ b/scripts/jsonLd.js
@@ -1,0 +1,14 @@
+/**
+ * JSON for an inline `<script type="application/ld+json">`.
+ *
+ * A `<` inside a string value would let `</script>` end the block early, so
+ * it is escaped. Every value the site puts in structured data is authored in
+ * this repository today, but the two emitters (`build-site.js` and
+ * `typedoc-seo-plugin.mjs`, the latter reading TypeDoc doc comments) should
+ * not disagree on that.
+ */
+
+/** `value` as JSON safe to inline in a script tag, indented by `space`. */
+export function inlineJson(value, space) {
+  return JSON.stringify(value, null, space).replace(/</g, '\\u003c');
+}

--- a/scripts/pageSizes.d.ts
+++ b/scripts/pageSizes.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Hand-written declarations for `pageSizes.js`.
+ *
+ * The module is plain JS so `scripts/check-page-sizes.js` (run directly by
+ * node) can import it; `tsconfig.json` sets `allowJs: false`, so a TypeScript
+ * test needs these to import it too. Keep both files in sync.
+ */
+
+/** Limit for ordinary pages: Googlebot's 2 MB cutoff with headroom. */
+export const SOFT_LIMIT: number;
+
+/** Googlebot's cutoff itself, applied to `api/` pages. */
+export const HARD_LIMIT: number;
+
+/** A built page: path relative to `_site/` and size in bytes. */
+export interface PageSize {
+  file: string;
+  size: number;
+}
+
+/** A page over its limit. */
+export interface Offender extends PageSize {
+  limit: number;
+}
+
+/** The byte limit for a page path, or null when the page is exempt. */
+export function limitFor(file: string): number | null;
+
+/** The pages over their limit, each with the limit it broke. */
+export function findOffenders(pages: PageSize[]): Offender[];

--- a/scripts/pageSizes.js
+++ b/scripts/pageSizes.js
@@ -1,0 +1,43 @@
+/**
+ * Which built pages are too large for Googlebot, and by which limit.
+ *
+ * Googlebot fetches the first 2 MB (2,097,152 bytes, uncompressed) of an HTML
+ * file and discards the rest, so anything past that point is invisible to
+ * search and to the AI features built on it.
+ *
+ * - Ordinary pages are held to 1,900,000 bytes, leaving headroom.
+ * - `api/` pages are indexable too, but the hierarchy theme inlines the whole
+ *   navigation tree (about 600 KB) into each of them, so they are held to the
+ *   hard cutoff itself rather than the headroom.
+ * - `examples/` pages are demos marked noindex, and the single-file Recharts
+ *   bundle sits right at the limit, so they are exempt.
+ */
+
+export const SOFT_LIMIT = 1_900_000;
+export const HARD_LIMIT = 2_097_152;
+
+/** The byte limit for a page path relative to `_site/`, or null if exempt. */
+export function limitFor(file) {
+  const top = file.split('/')[0];
+  if (top === 'examples') {
+    return null;
+  }
+  return top === 'api' ? HARD_LIMIT : SOFT_LIMIT;
+}
+
+/**
+ * The pages over their limit, each with the limit it broke.
+ *
+ * @param {Array<{file: string, size: number}>} pages
+ * @returns {Array<{file: string, size: number, limit: number}>} the offenders, in the order given
+ */
+export function findOffenders(pages) {
+  const offenders = [];
+  for (const { file, size } of pages) {
+    const limit = limitFor(file);
+    if (limit !== null && size > limit) {
+      offenders.push({ file, size, limit });
+    }
+  }
+  return offenders;
+}

--- a/scripts/typedoc-seo-plugin.mjs
+++ b/scripts/typedoc-seo-plugin.mjs
@@ -29,6 +29,7 @@
  */
 
 import { Comment, JSX, ReflectionKind } from 'typedoc';
+import { inlineJson } from './jsonLd.js';
 import { fallbackDescription, PROJECT_PAGES, truncate } from './typedocSeo.js';
 
 const SITE_URL = 'https://maidr.ai/';
@@ -105,11 +106,6 @@ function trailOf(model, router) {
     }
   }
   return trail;
-}
-
-/** JSON for an inline `<script>`: `<` escaped so `</script>` cannot end it early. */
-function inlineJson(value) {
-  return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 
 function ldScript(value) {

--- a/scripts/typedoc-seo-plugin.mjs
+++ b/scripts/typedoc-seo-plugin.mjs
@@ -29,10 +29,10 @@
  */
 
 import { Comment, JSX, ReflectionKind } from 'typedoc';
+import { fallbackDescription, PROJECT_PAGES, truncate } from './typedocSeo.js';
 
 const SITE_URL = 'https://maidr.ai/';
 const API_URL = 'https://maidr.ai/api/';
-const MAX_DESCRIPTION = 155;
 
 /** Minimal stubs of the nodes docs/template.html declares in full. */
 const SITE_NODES = [
@@ -56,18 +56,6 @@ const SITE_NODES = [
   },
 ];
 
-/** Pages TypeDoc renders for the project itself rather than for a symbol. */
-const PROJECT_PAGES = {
-  'index.html': {
-    title: null,
-    description: 'API reference for the MAIDR JavaScript library: classes, interfaces, functions and types for building accessible data visualizations.',
-  },
-  'hierarchy.html': {
-    title: 'Class Hierarchy',
-    description: 'Inheritance hierarchy of the classes and interfaces in the MAIDR JavaScript API reference.',
-  },
-};
-
 /**
  * The reflection's summary as one line of plain text, or an empty string
  * when it has none.
@@ -86,16 +74,6 @@ function summaryOf(model) {
   return Comment.combineDisplayParts(parts).replace(/`/g, '').replace(/\s+/g, ' ').trim();
 }
 
-/** Cut a description at a word boundary so it fits a search snippet. */
-function truncate(text) {
-  if (text.length <= MAX_DESCRIPTION) {
-    return text;
-  }
-  const cut = text.slice(0, MAX_DESCRIPTION - 3);
-  const lastSpace = cut.lastIndexOf(' ');
-  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).replace(/[\s,;:]+$/, '')}...`;
-}
-
 /**
  * The meta description for a page: its summary, or a fallback naming the
  * kind, the symbol and its module, so that identically named exports (every
@@ -112,8 +90,7 @@ function describe(model, page) {
   }
   const kind = model.kind === undefined ? 'Symbol' : ReflectionKind.singularString(model.kind);
   const moduleName = model.parent?.isProject() ? '' : model.parent?.getFullName();
-  const location = moduleName ? ` in module ${moduleName}` : '';
-  return `${kind} ${model.name}${location} of the MAIDR JavaScript API reference.`;
+  return fallbackDescription(kind, model.name, moduleName);
 }
 
 /**

--- a/scripts/typedoc-seo-plugin.mjs
+++ b/scripts/typedoc-seo-plugin.mjs
@@ -1,0 +1,209 @@
+/**
+ * TypeDoc plugin: per-page SEO tags for the API reference at maidr.ai/api/.
+ *
+ * TypeDoc 0.28 hard-codes one `<meta name="description">` ("Documentation for
+ * <project name>") for every page, emits a canonical link only on index.html
+ * (from `hostedBaseUrl`), and has no option for either. Its renderer hooks
+ * can add to `<head>` but not remove from it, so this plugin adds the
+ * per-page tags and `scripts/add-navbar-to-typedoc.js` strips the generic
+ * description afterwards, leaving exactly one.
+ *
+ * Emitted on every page, from the reflection being rendered:
+ * - `<link rel="canonical">` (skipped on index.html, which TypeDoc handles)
+ * - `<meta name="description">` from the doc comment's summary
+ * - Open Graph title, description, url and type
+ * - JSON-LD: a TechArticle for the page, in a @graph with minimal stubs of
+ *   the site-wide nodes it references (#website, #software, #organization),
+ *   so every @id resolves on the page itself. `docs/template.html` carries
+ *   the full nodes; Google parses each page on its own, so the stubs cannot
+ *   be left out here.
+ * - JSON-LD: a BreadcrumbList on pages that show TypeDoc's own breadcrumb
+ *   trail, built from the same parent chain (Home > API Reference > module
+ *   > symbol). index.html and hierarchy.html show no trail and get none.
+ *
+ * The description is the same text the page shows in its comment block, so
+ * the structured data mirrors visible content, as Google asks.
+ *
+ * Registered in `typedoc.json` under `plugin` with a `./`-relative path,
+ * which TypeDoc resolves against the config file.
+ */
+
+import { Comment, JSX, ReflectionKind } from 'typedoc';
+
+const SITE_URL = 'https://maidr.ai/';
+const API_URL = 'https://maidr.ai/api/';
+const MAX_DESCRIPTION = 155;
+
+/** Minimal stubs of the nodes docs/template.html declares in full. */
+const SITE_NODES = [
+  {
+    '@type': 'Organization',
+    '@id': `${SITE_URL}#organization`,
+    'name': '(x)Ability Design Lab',
+    'url': 'https://xabilitylab.ischool.illinois.edu/',
+  },
+  {
+    '@type': 'WebSite',
+    '@id': `${SITE_URL}#website`,
+    'name': 'MAIDR',
+    'url': SITE_URL,
+  },
+  {
+    '@type': ['SoftwareSourceCode', 'SoftwareApplication'],
+    '@id': `${SITE_URL}#software`,
+    'name': 'MAIDR',
+    'url': SITE_URL,
+  },
+];
+
+/** Pages TypeDoc renders for the project itself rather than for a symbol. */
+const PROJECT_PAGES = {
+  'index.html': {
+    title: null,
+    description: 'API reference for the MAIDR JavaScript library: classes, interfaces, functions and types for building accessible data visualizations.',
+  },
+  'hierarchy.html': {
+    title: 'Class Hierarchy',
+    description: 'Inheritance hierarchy of the classes and interfaces in the MAIDR JavaScript API reference.',
+  },
+};
+
+/**
+ * The reflection's summary as one line of plain text, or an empty string
+ * when it has none.
+ *
+ * A function or method keeps its comment on the signature rather than on the
+ * declaration, so that is the second place to look. Inline tags are reduced
+ * to their text (`{@link AmRoot}` reads "AmRoot") and code spans lose their
+ * backticks, since the result goes into a meta attribute, not a page.
+ */
+function summaryOf(model) {
+  const comment = model.comment ?? model.signatures?.find(signature => signature.comment)?.comment;
+  if (!comment) {
+    return '';
+  }
+  const parts = comment.summary.map(part => part.kind === 'inline-tag' ? { kind: 'text', text: part.text } : part);
+  return Comment.combineDisplayParts(parts).replace(/`/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/** Cut a description at a word boundary so it fits a search snippet. */
+function truncate(text) {
+  if (text.length <= MAX_DESCRIPTION) {
+    return text;
+  }
+  const cut = text.slice(0, MAX_DESCRIPTION - 3);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).replace(/[\s,;:]+$/, '')}...`;
+}
+
+/**
+ * The meta description for a page: its summary, or a fallback naming the
+ * kind, the symbol and its module, so that identically named exports (every
+ * `default`, say) do not all describe themselves the same way.
+ */
+function describe(model, page) {
+  const projectPage = PROJECT_PAGES[page.url];
+  if (projectPage) {
+    return projectPage.description;
+  }
+  const summary = summaryOf(model);
+  if (summary) {
+    return truncate(summary);
+  }
+  const kind = model.kind === undefined ? 'Symbol' : ReflectionKind.singularString(model.kind);
+  const moduleName = model.parent?.isProject() ? '' : model.parent?.getFullName();
+  const location = moduleName ? ` in module ${moduleName}` : '';
+  return `${kind} ${model.name}${location} of the MAIDR JavaScript API reference.`;
+}
+
+/**
+ * The reflections TypeDoc's own breadcrumb lists for `model`: its ancestors
+ * below the project that have a page of their own, then the model itself.
+ */
+function trailOf(model, router) {
+  const trail = [];
+  for (let current = model; current && !current.isProject(); current = current.parent) {
+    if (router.hasOwnDocument(current)) {
+      trail.unshift(current);
+    }
+  }
+  return trail;
+}
+
+/** JSON for an inline `<script>`: `<` escaped so `</script>` cannot end it early. */
+function inlineJson(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function ldScript(value) {
+  return JSX.createElement('script', { type: 'application/ld+json' }, JSX.createElement(JSX.Raw, { html: inlineJson(value) }));
+}
+
+export function load(app) {
+  app.renderer.hooks.on('head.end', (context) => {
+    const { page, router } = context;
+    const project = page.project;
+    const model = page.model ?? project;
+    const projectPage = PROJECT_PAGES[page.url];
+    const isIndex = page.url === 'index.html';
+    const canonical = isIndex ? API_URL : new URL(page.url, API_URL).toString();
+    const pageName = projectPage ? projectPage.title : model.name;
+    const headline = pageName ? `${pageName} | ${project.name}` : project.name;
+    const description = describe(model, page);
+
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        ...SITE_NODES,
+        {
+          '@type': 'TechArticle',
+          'headline': headline,
+          'description': description,
+          'url': canonical,
+          'isPartOf': { '@id': `${SITE_URL}#website` },
+          'about': { '@id': `${SITE_URL}#software` },
+          'publisher': { '@id': `${SITE_URL}#organization` },
+          'author': { '@id': `${SITE_URL}#organization` },
+        },
+      ],
+    };
+
+    // The trail mirrors the tsd-breadcrumb the page shows; project pages
+    // have none, so they get no BreadcrumbList either.
+    let breadcrumb = null;
+    if (!projectPage) {
+      const crumbs = [
+        { name: 'Home', item: SITE_URL },
+        { name: 'API Reference', item: API_URL },
+        ...trailOf(model, router).map(reflection => ({
+          name: reflection.name,
+          item: new URL(router.getFullUrl(reflection), API_URL).toString(),
+        })),
+      ];
+      breadcrumb = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        'itemListElement': crumbs.map((crumb, index) => ({
+          '@type': 'ListItem',
+          'position': index + 1,
+          'name': crumb.name,
+          'item': crumb.item,
+        })),
+      };
+    }
+
+    return JSX.createElement(
+      JSX.Fragment,
+      null,
+      isIndex ? null : JSX.createElement('link', { rel: 'canonical', href: canonical }),
+      JSX.createElement('meta', { name: 'description', content: description }),
+      JSX.createElement('meta', { property: 'og:title', content: headline }),
+      JSX.createElement('meta', { property: 'og:description', content: description }),
+      JSX.createElement('meta', { property: 'og:url', content: canonical }),
+      JSX.createElement('meta', { property: 'og:type', content: 'article' }),
+      JSX.createElement('meta', { property: 'og:site_name', content: 'MAIDR' }),
+      ldScript(graph),
+      breadcrumb ? ldScript(breadcrumb) : null,
+    );
+  });
+}

--- a/scripts/typedocSeo.d.ts
+++ b/scripts/typedocSeo.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Hand-written declarations for `typedocSeo.js`.
+ *
+ * The module is plain JS so `scripts/typedoc-seo-plugin.mjs` (loaded by
+ * TypeDoc) can import it; `tsconfig.json` sets `allowJs: false`, so a
+ * TypeScript test needs these to import it too. Keep both files in sync.
+ */
+
+/** Longest description that still fits a search snippet. */
+export const MAX_DESCRIPTION: number;
+
+/** A page TypeDoc renders for the project itself rather than for a symbol. */
+export interface ProjectPage {
+  /** Its heading, or null to keep TypeDoc's own for the index. */
+  title: string | null;
+  description: string;
+}
+
+/** Project pages keyed by their TypeDoc output path. */
+export const PROJECT_PAGES: Record<string, ProjectPage>;
+
+/** Cut a description at a word boundary so it fits a search snippet. */
+export function truncate(text: string): string;
+
+/** The description for a symbol with no doc comment. */
+export function fallbackDescription(kind: string, name: string, moduleName?: string): string;

--- a/scripts/typedocSeo.js
+++ b/scripts/typedocSeo.js
@@ -1,0 +1,39 @@
+/**
+ * The text decisions behind `scripts/typedoc-seo-plugin.mjs`, kept free of
+ * TypeDoc so they can be tested without a TypeDoc project.
+ */
+
+/** Longest description that still fits a search snippet. */
+export const MAX_DESCRIPTION = 155;
+
+/** Pages TypeDoc renders for the project itself rather than for a symbol. */
+export const PROJECT_PAGES = {
+  'index.html': {
+    title: null,
+    description: 'API reference for the MAIDR JavaScript library: classes, interfaces, functions and types for building accessible data visualizations.',
+  },
+  'hierarchy.html': {
+    title: 'Class Hierarchy',
+    description: 'Inheritance hierarchy of the classes and interfaces in the MAIDR JavaScript API reference.',
+  },
+};
+
+/** Cut a description at a word boundary so it fits a search snippet. */
+export function truncate(text) {
+  if (text.length <= MAX_DESCRIPTION) {
+    return text;
+  }
+  const cut = text.slice(0, MAX_DESCRIPTION - 3);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).replace(/[\s,;:]+$/, '')}...`;
+}
+
+/**
+ * The description for a symbol with no doc comment: its kind, name and
+ * module, so that identically named exports (every `default`, say) do not
+ * all describe themselves the same way.
+ */
+export function fallbackDescription(kind, name, moduleName = '') {
+  const location = moduleName ? ` in module ${moduleName}` : '';
+  return `${kind} ${name}${location} of the MAIDR JavaScript API reference.`;
+}

--- a/test/scripts/examplesGallery.esm-test.ts
+++ b/test/scripts/examplesGallery.esm-test.ts
@@ -159,19 +159,29 @@ describe('the gallery\'s labels', () => {
 describe('the gallery\'s markup', () => {
   const html = renderGallery(sections);
 
-  it('should call loadHTML with the page and its heading', () => {
+  it('should link the page and call loadHTML with it and its heading', () => {
+    // A real href, not `#`: the gallery is the only path a crawler has to
+    // the pages under `examples/`, and a link to `#` is not a link to
+    // anyone who cannot see the iframe it fills.
     expect(html).toContain(
-      '<li><a href="#" onclick="loadHTML(\'barplot.html\', \'Barplot\'); return false;">Barplot</a></li>',
+      '<li><a href="examples/barplot.html" onclick="loadHTML(\'barplot.html\', \'Barplot\'); return false;">Barplot</a></li>',
     );
     expect(html).toContain(
-      '<li><a href="#" onclick="loadHTML(\'plotly-bar.html\', \'Plotly Bar Chart\'); return false;">Bar Chart</a></li>',
+      '<li><a href="examples/plotly-bar.html" onclick="loadHTML(\'plotly-bar.html\', \'Plotly Bar Chart\'); return false;">Bar Chart</a></li>',
+    );
+  });
+
+  it('should give every entry a real href', () => {
+    expect(html).not.toContain('href="#"');
+    expect(html.match(/<a href="examples\//g)).toHaveLength(
+      sections.reduce((n, section) => n + section.items.length, 0),
     );
   });
 
   it('should keep the hand-written entries that are not pages', () => {
-    expect(html).toContain('onclick="loadReact(); return false;"');
-    expect(html).toContain('onclick="loadRecharts(); return false;"');
-    expect(html).toContain('onclick="loadVictory(); return false;"');
+    expect(html).toContain('href="examples/react/index.html" onclick="loadReact(); return false;"');
+    expect(html).toContain('href="examples/recharts/index.html" onclick="loadRecharts(); return false;"');
+    expect(html).toContain('href="examples/victory/index.html" onclick="loadVictory(); return false;"');
   });
 
   it('should be what build-site.js drops into the page', () => {

--- a/test/scripts/siteAnchors.esm-test.ts
+++ b/test/scripts/siteAnchors.esm-test.ts
@@ -62,8 +62,7 @@ function deadAnchors(source: string): string[] {
   const document = buildPage(source);
   return [...document.querySelectorAll('a[href^="#"]')]
     .map(anchor => anchor.getAttribute('href') ?? '')
-    // `href="#"` is the top of the page and always resolves; the examples
-    // gallery uses it for its onclick handlers.
+    // `href="#"` is the top of the page and always resolves.
     .filter(href => href.length > 1)
     .map(href => decodeURIComponent(href.slice(1)))
     .filter(id => document.getElementById(id) === null)

--- a/test/scripts/siteSeo.esm-test.ts
+++ b/test/scripts/siteSeo.esm-test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import process from 'node:process';
 import { describe, expect, it } from '@jest/globals';
 import { firstCommitDate, lastCommitDate } from '../../scripts/gitDates';
+import { inlineJson } from '../../scripts/jsonLd';
 import { findOffenders, HARD_LIMIT, limitFor, SOFT_LIMIT } from '../../scripts/pageSizes';
 import { fallbackDescription, MAX_DESCRIPTION, PROJECT_PAGES, truncate } from '../../scripts/typedocSeo';
 
@@ -133,5 +134,20 @@ describe('typedocSeo', () => {
     for (const { description } of Object.values(PROJECT_PAGES)) {
       expect(description.length).toBeLessThanOrEqual(MAX_DESCRIPTION);
     }
+  });
+});
+
+describe('jsonLd', () => {
+  it('should escape a less-than sign so a value cannot close the script tag', () => {
+    const json = inlineJson({ description: 'Closes early? </script><img src=x>' });
+    expect(json).not.toContain('</script>');
+    expect(json).toContain('\\u003c/script');
+    expect(JSON.parse(json)).toEqual({ description: 'Closes early? </script><img src=x>' });
+  });
+
+  it('should indent when asked, for a node spliced into the template graph', () => {
+    expect(inlineJson({ '@id': 'https://maidr.ai/#software' }, 2)).toBe(
+      '{\n  "@id": "https://maidr.ai/#software"\n}',
+    );
   });
 });

--- a/test/scripts/siteSeo.esm-test.ts
+++ b/test/scripts/siteSeo.esm-test.ts
@@ -1,0 +1,137 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { describe, expect, it } from '@jest/globals';
+import { firstCommitDate, lastCommitDate } from '../../scripts/gitDates';
+import { findOffenders, HARD_LIMIT, limitFor, SOFT_LIMIT } from '../../scripts/pageSizes';
+import { fallbackDescription, MAX_DESCRIPTION, PROJECT_PAGES, truncate } from '../../scripts/typedocSeo';
+
+/**
+ * Tests for the pieces of the site build that decide what search engines see:
+ * the git-derived dates behind sitemap `<lastmod>` and TechArticle
+ * `datePublished`/`dateModified` (`scripts/gitDates.js`), the Googlebot page
+ * budget (`scripts/pageSizes.js`), and the description text on TypeDoc pages
+ * (`scripts/typedocSeo.js`).
+ *
+ * `scripts/build-site.js` itself writes `_site/` and shells out on import, so
+ * these modules hold the logic it delegates to, and are tested here directly.
+ *
+ * It runs in the `esm` project because the modules under test are ESM — the
+ * repo is `"type": "module"` — and the CommonJS project cannot require them,
+ * the same arrangement as `testArgs.esm-test.ts`.
+ */
+
+/** A throwaway repository with one file, renamed once, committed on known dates. */
+function repoWithRename(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'maidr-gitdates-'));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 'test@example.com',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 'test@example.com',
+  };
+  const git = (args: string[], date: string): void => {
+    execFileSync('git', args, {
+      cwd,
+      env: { ...env, GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date },
+      stdio: 'ignore',
+    });
+  };
+  git(['init', '-q'], '2024-01-15T12:00:00Z');
+  writeFileSync(join(cwd, 'guide.md'), '# Guide\n');
+  git(['add', 'guide.md'], '2024-01-15T12:00:00Z');
+  git(['commit', '-q', '-m', 'add guide'], '2024-01-15T12:00:00Z');
+  git(['mv', 'guide.md', 'renamed.md'], '2024-02-20T12:00:00Z');
+  git(['commit', '-q', '-m', 'rename guide'], '2024-02-20T12:00:00Z');
+  writeFileSync(join(cwd, 'renamed.md'), '# Guide\n\nMore.\n');
+  git(['add', 'renamed.md'], '2024-03-05T12:00:00Z');
+  git(['commit', '-q', '-m', 'extend guide'], '2024-03-05T12:00:00Z');
+  return cwd;
+}
+
+describe('gitDates', () => {
+  const cwd = repoWithRename();
+
+  it('should date a page by the last commit that touched it', () => {
+    expect(lastCommitDate(cwd, 'renamed.md', 'fallback')).toBe('2024-03-05');
+  });
+
+  it('should find the commit that first added a page even across a rename', () => {
+    expect(firstCommitDate(cwd, 'renamed.md', 'fallback')).toBe('2024-01-15');
+  });
+
+  it('should fall back for a path git has never seen', () => {
+    expect(lastCommitDate(cwd, 'missing.md', 'fallback')).toBe('fallback');
+    expect(firstCommitDate(cwd, 'missing.md', 'fallback')).toBe('fallback');
+  });
+
+  it('should fall back outside a git checkout', () => {
+    const bare = mkdtempSync(join(tmpdir(), 'maidr-nogit-'));
+    expect(lastCommitDate(bare, 'anything.md', '2026-01-01')).toBe('2026-01-01');
+    expect(firstCommitDate(bare, 'anything.md', '2026-01-01')).toBe('2026-01-01');
+  });
+});
+
+describe('pageSizes', () => {
+  it('should hold ordinary pages to the limit with headroom', () => {
+    expect(limitFor('index.html')).toBe(SOFT_LIMIT);
+    expect(limitFor('docs/SCHEMA.html')).toBe(SOFT_LIMIT);
+  });
+
+  it('should hold API pages to the Googlebot cutoff itself', () => {
+    expect(limitFor('api/classes/Controller.html')).toBe(HARD_LIMIT);
+    expect(HARD_LIMIT).toBe(2_097_152);
+  });
+
+  it('should exempt the noindex example demos', () => {
+    expect(limitFor('examples/recharts/index.html')).toBeNull();
+  });
+
+  it('should report each offender with the limit it broke', () => {
+    const offenders = findOffenders([
+      { file: 'index.html', size: SOFT_LIMIT },
+      { file: 'react.html', size: SOFT_LIMIT + 1 },
+      { file: 'api/classes/Big.html', size: HARD_LIMIT - 1 },
+      { file: 'api/classes/Bigger.html', size: HARD_LIMIT + 1 },
+      { file: 'examples/recharts/index.html', size: HARD_LIMIT * 2 },
+    ]);
+    expect(offenders).toEqual([
+      { file: 'react.html', size: SOFT_LIMIT + 1, limit: SOFT_LIMIT },
+      { file: 'api/classes/Bigger.html', size: HARD_LIMIT + 1, limit: HARD_LIMIT },
+    ]);
+  });
+});
+
+describe('typedocSeo', () => {
+  it('should leave a short summary alone', () => {
+    expect(truncate('Main controller class.')).toBe('Main controller class.');
+  });
+
+  it('should cut a long summary at a word boundary with an ellipsis', () => {
+    const words = Array.from({ length: 60 }, (_, i) => `word${i}`).join(' ');
+    const cut = truncate(words);
+    expect(cut.length).toBeLessThanOrEqual(MAX_DESCRIPTION);
+    expect(cut.endsWith('...')).toBe(true);
+    // The kept text is a prefix that stops on a word boundary, not mid-word.
+    expect(words.startsWith(cut.slice(0, -3))).toBe(true);
+    expect(words[cut.length - 3]).toBe(' ');
+  });
+
+  it('should name the kind, symbol and module when there is no doc comment', () => {
+    expect(fallbackDescription('Variable', 'default', 'adapters/amcharts')).toBe(
+      'Variable default in module adapters/amcharts of the MAIDR JavaScript API reference.',
+    );
+    expect(fallbackDescription('Module', 'controller')).toBe(
+      'Module controller of the MAIDR JavaScript API reference.',
+    );
+  });
+
+  it('should keep every project page description within a snippet', () => {
+    for (const { description } of Object.values(PROJECT_PAGES)) {
+      expect(description.length).toBeLessThanOrEqual(MAX_DESCRIPTION);
+    }
+  });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,8 +12,10 @@
     "examples/**",
     "_site/**"
   ],
-  "name": "MAIDR Documentation",
-  "includeVersion": true,
+  "name": "MAIDR JavaScript API",
+  "includeVersion": false,
+  "titleLink": "https://maidr.ai/",
+  "hostedBaseUrl": "https://maidr.ai/api/",
   "categorizeByGroup": false,
   "navigation": {
     "includeCategories": false,
@@ -27,7 +29,8 @@
     "source-order"
   ],
   "plugin": [
-    "typedoc-theme-hierarchy"
+    "typedoc-theme-hierarchy",
+    "./scripts/typedoc-seo-plugin.mjs"
   ],
   "theme": "hierarchy"
 }


### PR DESCRIPTION
# Pull Request

## Description

SEO and generative-engine (Google AI Overviews / AI Mode) optimization of https://maidr.ai, following Google's guide [Optimizing your website for generative AI features on Google Search](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide). Google's position is that AI features need nothing beyond standard SEO: indexed, snippet-eligible pages, structured data that mirrors visible text, and no special AI files (llms.txt neither helps nor hurts). The same pass is applied to py.maidr.ai (xability/py-maidr#768) and r.maidr.ai (xability/r-maidr#299) so the three sites describe one set of entities.

maidr.ai was already in decent shape (canonicals, descriptions, JSON-LD). The gaps were the 1,587 TypeDoc pages (no canonical, a generic "Documentation for MAIDR Documentation" description, version-suffixed titles that churn every release, no structured data), a home page titled "Home - MAIDR", `docs/echarts.md` built twice with the sitemap pointing at the copy nothing links to, sitemap `lastmod` values that were just the build date, an Organization node that disagreed with the sibling sites, and a BreadcrumbList with no visible breadcrumb.

## Related Issues

None filed; companion PRs xability/py-maidr#768 and xability/r-maidr#299.

## Changes Made

- **TypeDoc (`typedoc.json`, `scripts/typedoc-seo-plugin.mjs`, `scripts/add-navbar-to-typedoc.js`):** `hostedBaseUrl` gives an `api/sitemap.xml` and the index canonical; the project is named "MAIDR JavaScript API" without the version so titles stay stable across releases. A small local plugin (`head.end` hook) adds to every API page a self-referential canonical, a description taken from the symbol's doc comment (so it matches the visible text), Open Graph tags, and TechArticle plus BreadcrumbList JSON-LD with stubs of the site-wide nodes so every `@id` resolves on-page. The post-processor strips TypeDoc's hard-coded description so exactly one remains, and rewrites the API sitemap's index URL and `lastmod` (last commit touching `src/`). `docs/robots.txt` lists both sitemaps.
- **`scripts/build-site.js`:** one `INTEGRATION_PAGES` list drives building, exclusion from the generic docs loop and the sitemap (ECharts is built once and listed once); an optional SEO title per page (home: "MAIDR: Accessible Data Visualization with Sonification, Braille and Text"; integrations: "<Library> Accessibility Integration - MAIDR"); a missing description is now a build failure; `<lastmod>` and TechArticle dates come from git commit dates (both docs workflows check out full history); `changefreq`/`priority` dropped because Google ignores them; a visible "Last updated" line on docs pages mirrors the TechArticle date.
- **`docs/template.html`:** JSON-LD rewritten to the entity graph shared with the sibling sites (the (x)Ability Design Lab with its illinois.edu URL and parent university, JooYoung Seo, a dual-typed software node with license, runtime, `alternateName`, `maintainer` and, on the home page, `citation` to the two MAIDR papers by DOI, plus a WebPage with `relatedLink` to py.maidr.ai and r.maidr.ai). A visible breadcrumb nav (`aria-label="Breadcrumb"`, AA contrast) now backs the BreadcrumbList, the primary nav is labelled "Main", and a footer line names the lab and PI so the site-wide nodes have visible text on every page.
- **Examples gallery (`scripts/examplesGallery.js`):** links are real `href="examples/..."` anchors (keyboard and crawler friendly) with the same click handler; the 260 demo pages under `examples/` get `<meta name="robots" content="noindex">` at build time since they have no titles or descriptions. `examples.html` itself stays indexable.
- **README.md:** a definition paragraph under the H1 (what MAIDR is, which libraries it works with, who builds it, its relation to py-maidr and maidr for R), "Binders" renamed to "Related projects" with descriptive cross-links, and plain-text citations with DOI links before each BibTeX block. `docs/llms.txt` now lists every integration guide.
- **Workflows:** `docs.yml` also runs after the "Release" workflow (its commit carries `[skip ci]`, so the site never rebuilt at release time) and both docs jobs use `fetch-depth: 0`. `scripts/check-page-sizes.js` runs last in `npm run docs` and fails if any indexable page exceeds 1,900,000 bytes (Googlebot reads only the first 2 MB of an HTML file); the largest indexable page is 861 KB.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- Verified locally: `npm run lint`, `npm run type-check`, `npm run build`, `npm run docs` (all 1,587 API pages carry exactly one description and a canonical; every JSON-LD `@id` on the home, docs and API pages resolves on the same page), and the `test/scripts` suites (gallery and site-anchor tests updated).
- The TypeDoc hierarchy theme inlines the whole navigation tree (~600 KB) into every API page. That stays under the 2 MB limit but dilutes each page's unique text; switching to the default theme would cut API pages to a few KB each. Left for a separate decision.
- The `api/index.html` entry was removed from the root sitemap because the generated `api/sitemap.xml` lists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqUywJzoCqyMGLFp8De1mn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqUywJzoCqyMGLFp8De1mn)_