### PR TITLE
fix(model): tolerate empty and degenerate data without throwing or hanging

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -173,8 +173,14 @@ export abstract class AbstractPlot<State> implements Movable, Observable<State>,
 
   public notifyRotorBounds(): void {
     this.isWarning = true;
-    this.notifyStateUpdate();
-    this.isWarning = false;
+    try {
+      this.notifyStateUpdate();
+    } finally {
+      // Restore on every path, as `getStateAt` does: `CommandExecutor` swallows
+      // a throw from an observer, and a flag left raised turns every later
+      // `state` read into the warning variant.
+      this.isWarning = false;
+    }
   }
 
   public get isInitialEntry(): boolean {

--- a/src/model/bump.ts
+++ b/src/model/bump.ts
@@ -2,6 +2,7 @@ import type { RotorFilterUnit } from '@model/abstract';
 import type { MaidrLayer } from '@type/grammar';
 import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
 import { MathUtil } from '@util/math';
+import { isMeasured } from './bar';
 import { LineTrace } from './line';
 
 /**
@@ -78,9 +79,13 @@ export class BumpTrace extends LineTrace {
 
     // `MathUtil` rather than a spread into `Math.min`: the same helpers
     // `LineTrace` uses per row, without the call-stack limit a spread carries
-    // on a large table and with one answer for an empty chart.
-    this.bestRank = MathUtil.minFrom2D(this.lineValues);
-    this.worstRank = MathUtil.maxFrom2D(this.lineValues);
+    // on a large table and with one answer for an empty chart. Over the
+    // measured ranks only, as `LineTrace` filters its per-row range: a gap is
+    // NaN, and one NaN in the spread made both bounds NaN and every point in
+    // the chart, gap or not, unplayable.
+    const measured = this.lineValues.flat().filter(isMeasured);
+    this.bestRank = MathUtil.safeMin(measured);
+    this.worstRank = MathUtil.safeMax(measured);
 
     // The longest competitor, not row 0's. A table where one competitor
     // joined late is ragged, and reading row 0's length would take some other

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -351,8 +351,10 @@ export class Candlestick extends AbstractTrace {
    * Updates visual position for segment highlighting using dynamic value-sorted order
    */
   private updateVisualSegmentPosition(): void {
-    // Use the sorted navigation order (with volatility first)
-    const navOrder = this.sortedSegmentsByPoint[this.currentPointIndex];
+    // Use the sorted navigation order (with volatility first). A layer with
+    // no candles has no order to read; the cursor then sits at -1, which the
+    // state getter reads as nothing at the cursor.
+    const navOrder = this.sortedSegmentsByPoint[this.currentPointIndex] ?? [];
     const dynamicSegmentPosition = navOrder.indexOf(
       this.currentSegmentType ?? this.sections[0],
     );
@@ -396,6 +398,14 @@ export class Candlestick extends AbstractTrace {
    * @param direction - Direction to move (UPWARD, DOWNWARD, FORWARD, BACKWARD)
    */
   public override moveOnce(direction: MovableDirection): boolean {
+    // The guard `MovableGrid.moveOnce` has and this override bypassed: with
+    // no candles there is nothing to enter, so the move is out of bounds like
+    // every other trace's rather than a throw out of the keybinding handler.
+    if (this.candles.length === 0) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
     if (this.isInitialEntry) {
       this.handleInitialEntry();
       this.notifyStateUpdate();
@@ -458,6 +468,11 @@ export class Candlestick extends AbstractTrace {
   }
 
   public override moveToExtreme(direction: MovableDirection): boolean {
+    if (this.candles.length === 0) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -184,7 +184,13 @@ export class Heatmap extends AbstractTrace {
     }
 
     const numRows = this.heatmapValues.length;
-    const numCols = this.heatmapValues[0].length;
+    const numCols = this.heatmapValues[0]?.length ?? 0;
+    // Nothing to pair a selector with. A producer with no cells to draw still
+    // emits the selector its template always emits, and a throw here left
+    // the constructor and the figure with it.
+    if (numRows === 0 || numCols === 0) {
+      return null;
+    }
 
     // Per-cell selector grid: `selector[r][c]` resolves to the SVG element for
     // logical row `r`, column `c`. Used by adapters (e.g. Highcharts) that

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -17,16 +17,22 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
   public override get description(): DescriptionState {
     const isVertical = this.orientation === Orientation.VERTICAL;
     const points = this.points[0] as HistogramPoint[];
-    const firstPoint = points[0];
-    const lastPoint = points[points.length - 1];
+    const firstPoint: HistogramPoint | undefined = points[0];
+    const lastPoint: HistogramPoint | undefined = points[points.length - 1];
 
-    const binRangeMin = isVertical ? firstPoint.xMin : firstPoint.yMin;
-    const binRangeMax = isVertical ? lastPoint.xMax : lastPoint.yMax;
+    // A producer can emit a histogram with no bins; the range is then
+    // 'missing', as `rangeStats` already reports the min and max.
+    const binRange = firstPoint && lastPoint
+      ? MathUtil.spanned(
+          isVertical ? firstPoint.xMin : firstPoint.yMin,
+          isVertical ? lastPoint.xMax : lastPoint.yMax,
+        )
+      : 'missing';
 
     const stats: DescriptionState['stats'] = [
       { label: 'Number of bins', value: points.length },
       ...this.rangeStats(),
-      { label: 'Bin range', value: MathUtil.spanned(binRangeMin, binRangeMax) },
+      { label: 'Bin range', value: binRange },
     ];
 
     const headers = isVertical

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -325,9 +325,15 @@ export class LineTrace extends AbstractTrace {
     const isMultiline = this.points.length > 1;
     const labels = this.seriesLabels;
 
+    // The widest series, not the first: a ragged layer's first series can be
+    // the empty one, and a layer can have no series at all.
+    const perSeries = this.points.reduce(
+      (widest, line) => Math.max(widest, line.length),
+      0,
+    );
     const stats: DescriptionState['stats'] = [
       { label: labels.count, value: this.points.length },
-      { label: labels.perSeries, value: this.points[0].length },
+      { label: labels.perSeries, value: perSeries },
       { label: 'Min value', value: MathUtil.safeMin(this.min) },
       { label: 'Max value', value: MathUtil.safeMax(this.max) },
     ];
@@ -368,7 +374,7 @@ export class LineTrace extends AbstractTrace {
       });
     } else {
       headers = [this.xAxis, this.yAxis];
-      rows = this.points[0].map(p => [p.x, p.y ?? '']);
+      rows = (this.points[0] ?? []).map(p => [p.x, p.y ?? '']);
     }
 
     return {

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -574,9 +574,30 @@ export class LineTrace extends AbstractTrace {
     };
   }
 
+  /**
+   * Establishes the cursor on the first move into the trace.
+   *
+   * `MovableGraph.handleInitialEntry` tries `(0, 0)` and otherwise parks the
+   * cursor at `(-1, -1)`. A ragged layer whose *first* series is empty -- a
+   * hue level with no data in the range, emitted before the ones that have
+   * some -- has points to land on all the same, so the cursor is moved to the
+   * first series that has any rather than left off the data.
+   */
+  protected enterTrace(): void {
+    this.movable.handleInitialEntry();
+    if (this.row !== -1) {
+      return;
+    }
+    const populated = this.points.findIndex(line => line.length > 0);
+    if (populated !== -1) {
+      this.row = populated;
+      this.col = 0;
+    }
+  }
+
   public override moveOnce(direction: MovableDirection): boolean {
     if (this.isInitialEntry) {
-      this.movable.handleInitialEntry();
+      this.enterTrace();
       this.previousRow = null;
       this.notifyStateUpdate();
       return true;
@@ -721,17 +742,22 @@ export class LineTrace extends AbstractTrace {
     switch (target) {
       case 'UPWARD':
       case 'DOWNWARD': {
+        // Nothing at the cursor -- an empty series, or an entry that found
+        // no series at all -- has no x to match, so there is nowhere to go.
+        const current = this.points[this.row]?.[this.col];
+        if (current === undefined) {
+          return false;
+        }
         // For y-value-based navigation, check if there's a valid target line with same X value
         const targetRow = this.findLineByXAndYDirection(target);
         if (targetRow === null) {
           return false;
         }
         // Also check if the target line has a point with the same X value
-        const currentX = this.points[this.row][this.col].x;
-        return this.findColumnByXValue(targetRow, currentX) !== -1;
+        return this.findColumnByXValue(targetRow, current.x) !== -1;
       }
       case 'FORWARD':
-        return this.col < this.values[this.row].length - 1;
+        return this.col < (this.values[this.row]?.length ?? 0) - 1;
       case 'BACKWARD':
         return this.col > 0;
     }
@@ -746,7 +772,11 @@ export class LineTrace extends AbstractTrace {
   private findLineByXAndYDirection(
     direction: 'UPWARD' | 'DOWNWARD',
   ): number | null {
-    const currentX = this.points[this.row][this.col].x;
+    const current = this.points[this.row]?.[this.col];
+    if (current === undefined) {
+      return null;
+    }
+    const currentX = current.x;
 
     let bestRow: number | null = null;
     let bestDistance = Number.POSITIVE_INFINITY;
@@ -1803,7 +1833,7 @@ export class LineTrace extends AbstractTrace {
    * @returns Array of X values
    */
   public getAvailableXValues(): XValue[] {
-    return this.points[this.row].map(val => val.x);
+    return (this.points[this.row] ?? []).map(val => val.x);
   }
 
   /**
@@ -1814,7 +1844,7 @@ export class LineTrace extends AbstractTrace {
   public override moveToXValue(xValue: XValue): boolean {
     // Handle initial entry properly
     if (this.isInitialEntry) {
-      this.movable.handleInitialEntry();
+      this.enterTrace();
     }
     return super.moveToXValue(xValue);
   }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -2150,7 +2150,28 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       return null;
     }
 
+    // ...and describe a grid. A zero step over a positive range asks
+    // `computeGridSteps` for `Infinity` bins, which it pushes until the tab
+    // runs out of memory -- inside the constructor, so nothing can catch it.
+    // A negative step or an inverted range yields the opposite, a grid with
+    // no cell to enter. Neither is a grid, so neither advertises one.
+    if (!this.isGridAxis(xMin, xMax, xTickStep) || !this.isGridAxis(yMin, yMax, yTickStep)) {
+      return null;
+    }
+
     return { xMin, xMax, xTickStep, yMin, yMax, yTickStep };
+  }
+
+  /**
+   * Whether one axis's range and step can be cut into at least one bin.
+   * @param min - The axis minimum
+   * @param max - The axis maximum
+   * @param tick - The bin width
+   * @returns True when the values yield a finite, positive number of bins
+   */
+  private isGridAxis(min: number, max: number, tick: number): boolean {
+    return Number.isFinite(min) && Number.isFinite(max) && Number.isFinite(tick)
+      && tick > 0 && max > min;
   }
 
   /**

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -2163,15 +2163,26 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
   }
 
   /**
+   * The most bins one axis may be cut into.
+   *
+   * A positive but tiny step is the same hang as a zero step, only slower:
+   * `computeGridSteps` would build billions of finite bins in the
+   * constructor. No reader navigates a grid that fine, so a step that asks
+   * for more than this is read as not describing a grid at all.
+   */
+  private static readonly MAX_GRID_BINS = 10_000;
+
+  /**
    * Whether one axis's range and step can be cut into at least one bin.
    * @param min - The axis minimum
    * @param max - The axis maximum
    * @param tick - The bin width
-   * @returns True when the values yield a finite, positive number of bins
+   * @returns True when the values yield a finite, positive, bounded number of bins
    */
   private isGridAxis(min: number, max: number, tick: number): boolean {
     return Number.isFinite(min) && Number.isFinite(max) && Number.isFinite(tick)
-      && tick > 0 && max > min;
+      && tick > 0 && max > min
+      && (max - min) / tick <= ScatterTrace.MAX_GRID_BINS;
   }
 
   /**

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -2159,6 +2159,16 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       return null;
     }
 
+    // ...and a grid a reader can hold. `buildGridCells` allocates one cell
+    // object with six arrays per row-column pair up front, so two axes that
+    // each pass the per-axis bound on their own still multiply into a grid
+    // whose construction is the same tab-freezing allocation, only reached
+    // by their product rather than by either one.
+    const cells = ((xMax - xMin) / xTickStep) * ((yMax - yMin) / yTickStep);
+    if (cells > ScatterTrace.MAX_GRID_CELLS) {
+      return null;
+    }
+
     return { xMin, xMax, xTickStep, yMin, yMax, yTickStep };
   }
 
@@ -2171,6 +2181,15 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
    * for more than this is read as not describing a grid at all.
    */
   private static readonly MAX_GRID_BINS = 10_000;
+
+  /**
+   * The most cells a grid may hold across both axes.
+   *
+   * Bounding each axis on its own is not enough: two bounds that each look
+   * reasonable multiply, and it is the product that `buildGridCells`
+   * allocates in one synchronous pass in the constructor.
+   */
+  private static readonly MAX_GRID_CELLS = 100_000;
 
   /**
    * Whether one axis's range and step can be cut into at least one bin.

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -34,7 +34,11 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
   private createSummaryLevel(): void {
     const summaryValues = new Array<number>();
     const summaryPoints = new Array<SegmentedPoint>();
-    for (let i = 0; i < this.barValues[0].length; i++) {
+    // A producer can emit `[]` rather than `[[]]` for a chart with nothing to
+    // stack. There is then no row to read the categories off, and the summary
+    // is an empty row like every other.
+    const categories = this.barValues[0]?.length ?? 0;
+    for (let i = 0; i < categories; i++) {
       // Sum the measured segments only. Adding a gap in would make the total
       // NaN, and NaN spreads: it would seed MathUtil.minMax below and, through
       // safeMin/safeMax over every row, hand the whole chart a NaN pitch range.

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -105,9 +105,21 @@ export class ViolinKdeTrace extends AbstractTrace {
     // points array. mapToSvgElements pairs selectors[i] with this.points[i],
     // so both must be in the same order. No separate highlightValues.reverse()
     // is needed since the selectors are pre-aligned.
-    const kdeSelectors = this.orientation === Orientation.HORIZONTAL
-      ? [...(layer.selectors as string[])].reverse()
-      : (layer.selectors as string[]);
+    //
+    // `selectors` is optional in the grammar and the Chart.js extractor emits
+    // none, so there may be nothing to reverse; spreading `undefined` threw
+    // out of the constructor and took the figure with it. A single string is
+    // the grammar's "one pattern for every violin", which `mapToSvgElements`
+    // reads off a one-element array; spread, it would fall apart into
+    // characters.
+    const selectors = typeof layer.selectors === 'string'
+      ? [layer.selectors]
+      : Array.isArray(layer.selectors) && layer.selectors.every(one => typeof one === 'string')
+        ? (layer.selectors as string[])
+        : undefined;
+    const kdeSelectors = selectors && this.orientation === Orientation.HORIZONTAL
+      ? [...selectors].reverse()
+      : selectors;
     this.highlightValues = this.mapToSvgElements(kdeSelectors);
     this.highlightCenters = this.mapSvgElementsToCenters();
     this.movable = new MovableGrid<ViolinKdePoint>(this.points, { row: 0 });

--- a/src/model/waterfall.ts
+++ b/src/model/waterfall.ts
@@ -6,6 +6,7 @@ import type { Dimension, NearestPoint } from './abstract';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
+import { isMeasured } from './bar';
 import { MovableGrid } from './movable';
 
 /**
@@ -68,7 +69,10 @@ export class WaterfallTrace extends AbstractTrace {
     this.points = layer.data as WaterfallPoint[];
     this.deltaValues = [this.points.map(point => Number(point.delta))];
 
-    const { min, max } = MathUtil.minMax(this.deltaValues[0]);
+    // A missing contribution is not a measurement, so it must not set the
+    // range: `minMax` seeds from the first value, and a NaN there never loses
+    // a comparison, so it would hand every step a NaN pitch.
+    const { min, max } = MathUtil.minMax(this.deltaValues[0].filter(isMeasured));
     this.min = min;
     this.max = max;
 
@@ -185,11 +189,14 @@ export class WaterfallTrace extends AbstractTrace {
       );
     }
 
-    if (steps.length > 0) {
+    // Ranked over the measured steps only, as `getExtremaTargets` ranks
+    // them: a NaN would win `Math.max` and name no step at all.
+    const measured = steps.filter(point => isMeasured(Number(point.delta)));
+    if (measured.length > 0) {
       // The largest mover is what a waterfall is read to find, and scanning
       // for it by ear means walking every step.
-      const magnitudes = steps.map(point => Math.abs(Number(point.delta)));
-      const largest = steps[magnitudes.indexOf(Math.max(...magnitudes))];
+      const magnitudes = measured.map(point => Math.abs(Number(point.delta)));
+      const largest = measured[magnitudes.indexOf(Math.max(...magnitudes))];
       stats.push({
         label: 'Largest contribution',
         value: `${largest.x} (${Number(largest.delta)})`,

--- a/test/model/bump.test.ts
+++ b/test/model/bump.test.ts
@@ -289,6 +289,42 @@ describe('a table where a competitor joined late or dropped out', () => {
   });
 });
 
+describe('a table with a gap in one competitor\'s run', () => {
+  /**
+   * Birch has no rank for R2. A gap is a fact about one period of one
+   * competitor; it must not cost the fully measured competitors their pitch.
+   */
+  const GAPPED: LinePoint[][] = [
+    [
+      { x: 'R1', y: 1, z: 'Ash' },
+      { x: 'R2', y: 2, z: 'Ash' },
+      { x: 'R3', y: 3, z: 'Ash' },
+    ],
+    [
+      { x: 'R1', y: 2, z: 'Birch' },
+      { x: 'R2', y: null, z: 'Birch' },
+      { x: 'R3', y: 1, z: 'Birch' },
+    ],
+  ];
+
+  test('the measured competitor keeps a finite pitch range', () => {
+    // Chart-wide bounds over a spread that held a NaN were NaN, so every
+    // point in the chart -- the gap and the leader alike -- lost its pitch.
+    const { freq } = nonEmptyState(bump(0, 0, GAPPED)).audio;
+
+    expect(freq.min).toBe(3);
+    expect(freq.max).toBe(1);
+  });
+
+  test('the competitor with the gap keeps its range on its measured rounds', () => {
+    const { freq } = nonEmptyState(bump(1, 2, GAPPED)).audio;
+
+    expect(freq.min).toBe(3);
+    expect(freq.max).toBe(1);
+    expect(freq.raw).toBe(1);
+  });
+});
+
 describe('the description says who moved', () => {
   const read = (label: string): unknown =>
     bump().description.stats.find(stat => stat.label === label)?.value;

--- a/test/model/candlestickEmpty.test.ts
+++ b/test/model/candlestickEmpty.test.ts
@@ -1,0 +1,81 @@
+import type { MaidrLayer } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A candlestick layer with no candles threw on the first keypress.
+ *
+ * `Subplot` constructs every layer without an empty-data filter and
+ * `AbstractTrace.state` tolerates an empty series (#905), so the layer
+ * renders. But `Candlestick` overrides `moveOnce` and `moveToExtreme` without
+ * the `elements.length === 0` guard `MovableGrid` has, and its initial entry
+ * clamps the candle index to 0 and reads `sortedSegmentsByPoint[0]` -- which
+ * does not exist. The `TypeError` escaped the keybinding handler, so where
+ * every other trace reports out of bounds, this one went silent.
+ */
+function emptyLayer(): MaidrLayer {
+  return {
+    id: 'no-candles',
+    type: TraceType.CANDLESTICK,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: [],
+  };
+}
+
+describe('a candlestick layer with no candles', () => {
+  test('constructs and reports empty', () => {
+    const trace = new Candlestick(emptyLayer());
+
+    expect(trace.state.empty).toBe(true);
+  });
+
+  test.each(['FORWARD', 'BACKWARD', 'UPWARD', 'DOWNWARD'] as const)(
+    'the first %s arrow reports out of bounds rather than throwing',
+    (direction) => {
+      const trace = new Candlestick(emptyLayer());
+      const update = jest.fn();
+      trace.addObserver({ update });
+
+      expect(() => trace.moveOnce(direction)).not.toThrow();
+      expect(trace.moveOnce(direction)).toBe(false);
+      expect(update).toHaveBeenCalledWith(expect.objectContaining({ empty: true }));
+    },
+  );
+
+  test.each(['FORWARD', 'BACKWARD', 'UPWARD', 'DOWNWARD'] as const)(
+    'jumping to the %s extreme reports out of bounds rather than throwing',
+    (direction) => {
+      const trace = new Candlestick(emptyLayer());
+      const update = jest.fn();
+      trace.addObserver({ update });
+
+      expect(() => trace.moveToExtreme(direction)).not.toThrow();
+      expect(trace.moveToExtreme(direction)).toBe(false);
+      expect(update).toHaveBeenCalledWith(expect.objectContaining({ empty: true }));
+    },
+  );
+
+  test('a compare jump finds nothing rather than throwing', () => {
+    const trace = new Candlestick(emptyLayer());
+
+    expect(() => trace.moveToNextCompareValue('right', 'higher')).not.toThrow();
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(false);
+  });
+
+  test('a trend filter jump finds nothing rather than throwing', () => {
+    const trace = new Candlestick(emptyLayer());
+
+    expect(() => trace.moveToRotorFilter('Bull', 'right')).not.toThrow();
+    expect(trace.moveToRotorFilter('Bull', 'right')).toBe(false);
+  });
+
+  test('the state after an attempted move is still empty', () => {
+    const trace = new Candlestick(emptyLayer());
+
+    trace.moveOnce('FORWARD');
+    trace.moveToNextCompareValue('left', 'lower');
+
+    expect(trace.state.empty).toBe(true);
+  });
+});

--- a/test/model/emptySeriesState.test.ts
+++ b/test/model/emptySeriesState.test.ts
@@ -73,6 +73,25 @@ describe('a trace with nothing at the cursor', () => {
   });
 });
 
+describe('a segmented layer with no series at all', () => {
+  // A producer emits `[]` rather than `[[]]` for a stacked chart with nothing
+  // to stack. The summary row is built off `barValues[0]`, which does not
+  // exist, and the throw left trace construction and the figure with it.
+  test.each([
+    ['stacked', TraceType.STACKED],
+    ['dodged', TraceType.DODGED],
+    ['normalized', TraceType.NORMALIZED],
+    ['diverging', TraceType.DIVERGING],
+    ['mosaic', TraceType.MOSAIC],
+  ])('a %s layer with no series constructs and reports empty', (_name, type) => {
+    const build = (): ReturnType<typeof TraceFactory.create> =>
+      TraceFactory.create(layer(type, []));
+
+    expect(build).not.toThrow();
+    expect(build().state.empty).toBe(true);
+  });
+});
+
 describe('an empty histogram', () => {
   test('is described without a bin range rather than throwing', () => {
     // The bin range is read off the first and last bin. With no bins there is

--- a/test/model/emptySeriesState.test.ts
+++ b/test/model/emptySeriesState.test.ts
@@ -20,6 +20,7 @@
 import type { Maidr, MaidrLayer } from '@type/grammar';
 import { describe, expect, jest, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
+import { Histogram } from '@model/histogram';
 import { Figure } from '@model/plot';
 import { TraceType } from '@type/grammar';
 
@@ -69,6 +70,21 @@ describe('a trace with nothing at the cursor', () => {
 
     expect(() => trace.state).not.toThrow();
     expect(trace.state.empty).toBe(true);
+  });
+});
+
+describe('an empty histogram', () => {
+  test('is described without a bin range rather than throwing', () => {
+    // The bin range is read off the first and last bin. With no bins there is
+    // no range to report, and the rest of the description still stands.
+    const trace = new Histogram(layer(TraceType.HISTOGRAM, []));
+
+    expect(() => trace.description).not.toThrow();
+    expect(trace.description.stats).toEqual(expect.arrayContaining([
+      { label: 'Number of bins', value: 0 },
+      { label: 'Bin range', value: 'missing' },
+    ]));
+    expect(trace.description.dataTable.rows).toEqual([]);
   });
 });
 

--- a/test/model/emptySeriesState.test.ts
+++ b/test/model/emptySeriesState.test.ts
@@ -1,3 +1,4 @@
+import type { LineTrace } from '@model/line';
 /**
  * A layer with an empty series threw as soon as its state was read (#905).
  *
@@ -142,6 +143,59 @@ describe('a ragged layer', () => {
 
     trace.row = 0;
     expect(trace.state.empty).toBe(false);
+  });
+});
+
+describe('a ragged layer whose first series is empty', () => {
+  /**
+   * The empty series comes first -- a hue level with nothing in the range,
+   * emitted before the ones that have data. `handleInitialEntry` parks the
+   * cursor at (-1, -1) because `graph[0][0]` does not exist, and every
+   * accessor that indexes `points[row]` from there threw.
+   * @returns The trace
+   */
+  function firstEmptyTrace(): ReturnType<typeof TraceFactory.create> {
+    return TraceFactory.create(layer(TraceType.LINE, [[], POINTS]));
+  }
+
+  test('the first keypress lands on the series that has points', () => {
+    const trace = firstEmptyTrace();
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.row).toBe(1);
+    expect(trace.state.empty).toBe(false);
+  });
+
+  test.each(['FORWARD', 'BACKWARD', 'UPWARD', 'DOWNWARD'] as const)(
+    'moving %s from the empty series reports out of bounds rather than throwing',
+    (direction) => {
+      const trace = firstEmptyTrace();
+      trace.isInitialEntry = false;
+      trace.row = 0;
+      const update = jest.fn();
+      trace.addObserver({ update });
+
+      expect(() => trace.moveOnce(direction)).not.toThrow();
+      expect(trace.moveOnce(direction)).toBe(false);
+      expect(update).toHaveBeenCalledWith(expect.objectContaining({ empty: true }));
+    },
+  );
+
+  test('an entry that finds no series at all still answers every move', () => {
+    const trace = TraceFactory.create(layer(TraceType.LINE, [[]]));
+    trace.moveOnce('FORWARD');
+
+    expect(trace.state.empty).toBe(true);
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+  });
+
+  test('the x values on offer from the empty series are none', () => {
+    const trace = firstEmptyTrace() as LineTrace;
+    trace.isInitialEntry = false;
+    trace.row = 0;
+
+    expect(trace.getAvailableXValues()).toEqual([]);
   });
 });
 

--- a/test/model/emptySeriesState.test.ts
+++ b/test/model/emptySeriesState.test.ts
@@ -1,4 +1,3 @@
-import type { LineTrace } from '@model/line';
 /**
  * A layer with an empty series threw as soon as its state was read (#905).
  *
@@ -22,6 +21,7 @@ import type { Maidr, MaidrLayer } from '@type/grammar';
 import { describe, expect, jest, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
 import { Histogram } from '@model/histogram';
+import { LineTrace } from '@model/line';
 import { Figure } from '@model/plot';
 import { TraceType } from '@type/grammar';
 
@@ -196,6 +196,29 @@ describe('a ragged layer whose first series is empty', () => {
     trace.row = 0;
 
     expect(trace.getAvailableXValues()).toEqual([]);
+  });
+});
+
+describe('describing a layer with an empty series', () => {
+  test('a layer with no series at all is described rather than throwing', () => {
+    // The description read the points per line off series 0, and the
+    // single-line table off it too; with no series there was no series 0.
+    const trace = new LineTrace(layer(TraceType.LINE, []));
+
+    expect(() => trace.description).not.toThrow();
+    expect(trace.description.stats).toEqual(expect.arrayContaining([
+      { label: 'Number of lines', value: 0 },
+      { label: 'Points per line', value: 0 },
+    ]));
+    expect(trace.description.dataTable.rows).toEqual([]);
+  });
+
+  test('the points per line are the widest series, not the first', () => {
+    // Series 0 being the empty one should not read as "Points per line: 0"
+    // for a chart whose other series draw two.
+    const trace = new LineTrace(layer(TraceType.LINE, [[], POINTS]));
+
+    expect(trace.description.stats).toContainEqual({ label: 'Points per line', value: 2 });
   });
 });
 

--- a/test/model/heatmapEmptyGrid.test.ts
+++ b/test/model/heatmapEmptyGrid.test.ts
@@ -1,0 +1,45 @@
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { Heatmap } from '@model/heatmap';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A heatmap with no rows threw in the constructor as soon as it carried a
+ * selector. `mapToSvgElements` read the column count off `heatmapValues[0]`
+ * before it had checked there was a row to read it from, so the same layer
+ * that constructs and reports empty without a selector took the whole figure
+ * down with one -- and a producer with nothing to draw still emits the
+ * selector its template always emits.
+ */
+function heatmapLayer(selectors?: MaidrLayer['selectors']): MaidrLayer {
+  const data: HeatmapData = { x: [], y: [], points: [] };
+  return {
+    id: 'empty-heatmap',
+    type: TraceType.HEATMAP,
+    axes: { x: { label: 'Day' }, y: { label: 'Hour' } },
+    data,
+    ...(selectors === undefined ? {} : { selectors }),
+  };
+}
+
+describe('a heatmap with no cells', () => {
+  test('constructs without a selector and reports empty', () => {
+    const trace = new Heatmap(heatmapLayer());
+
+    expect(trace.state.empty).toBe(true);
+  });
+
+  test('constructs with a pattern selector and reports empty', () => {
+    const build = (): Heatmap => new Heatmap(heatmapLayer('rect'));
+
+    expect(build).not.toThrow();
+    expect(build().state.empty).toBe(true);
+  });
+
+  test('constructs with a per-cell selector grid and reports empty', () => {
+    const build = (): Heatmap => new Heatmap(heatmapLayer([]));
+
+    expect(build).not.toThrow();
+    expect(build().state.empty).toBe(true);
+  });
+});

--- a/test/model/rotorBoundsWarning.test.ts
+++ b/test/model/rotorBoundsWarning.test.ts
@@ -1,0 +1,49 @@
+import type { MaidrLayer } from '@type/grammar';
+import { describe, expect, it, jest } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { TraceType } from '@type/grammar';
+
+/**
+ * `notifyRotorBounds` raises the warning flag around one notification. The
+ * flag is transient: it exists so the audio service plays the boundary cue
+ * once, not so the trace stays in the warning state.
+ *
+ * `CommandExecutor` swallows an exception thrown by a command, so an observer
+ * that throws during that one notification leaves the page running. If the
+ * flag is not restored on that path, every later `state` read answers with
+ * the warning variant and navigation goes silent for the rest of the session.
+ */
+function barLayer(): MaidrLayer {
+  return {
+    id: 'bars',
+    type: TraceType.BAR,
+    axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+    data: [{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }],
+  };
+}
+
+describe('rotor bounds warning', () => {
+  it('flags the state as a warning for the notification only', () => {
+    const trace = new BarTrace(barLayer());
+    const seen: boolean[] = [];
+    trace.addObserver({ update: state => seen.push(state.empty && state.warning === true) });
+
+    trace.notifyRotorBounds();
+
+    expect(seen).toEqual([true]);
+    expect(trace.state.empty).toBe(false);
+  });
+
+  it('clears the warning flag when an observer throws', () => {
+    const trace = new BarTrace(barLayer());
+    trace.addObserver({
+      update: jest.fn(() => {
+        throw new Error('observer failed');
+      }),
+    });
+
+    expect(() => trace.notifyRotorBounds()).toThrow('observer failed');
+
+    expect(trace.state.empty).toBe(false);
+  });
+});

--- a/test/model/scatterGridTickStep.test.ts
+++ b/test/model/scatterGridTickStep.test.ts
@@ -32,6 +32,7 @@ describe('a scatter grid config that does not describe a grid', () => {
     ['a negative tick step', { min: 0, max: 4, tickStep: -2 }, { min: 0, max: 4, tickStep: 2 }],
     ['a non-finite tick step', { min: 0, max: 4, tickStep: Number.POSITIVE_INFINITY }, { min: 0, max: 4, tickStep: 2 }],
     ['a NaN tick step', { min: 0, max: 4, tickStep: Number.NaN }, { min: 0, max: 4, tickStep: 2 }],
+    ['a tick step asking for billions of bins', { min: 0, max: 4, tickStep: 1e-9 }, { min: 0, max: 4, tickStep: 2 }],
     ['an inverted range', { min: 4, max: 0, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
     ['a collapsed range', { min: 2, max: 2, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
   ])('%s constructs without a grid', (_name, x, y) => {

--- a/test/model/scatterGridTickStep.test.ts
+++ b/test/model/scatterGridTickStep.test.ts
@@ -1,0 +1,54 @@
+import type { AxisConfig, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * `resolveGridConfig` only checked that the six grid values were present,
+ * never that they described a grid. A `tickStep` of `0` over a positive range
+ * made `computeGridSteps` compute `Infinity` bins and push bin objects until
+ * the tab ran out of memory -- inside the constructor, so `new Figure(...)`
+ * never returned and there was nothing to catch. A negative step or an
+ * inverted range produced the opposite: zero bins, and a grid mode that was
+ * advertised but had no cell to enter.
+ *
+ * The Plotly extractor rejects a non-positive step before it reaches here,
+ * but hand-authored JSON and other producers construct the trace directly.
+ */
+function scatterLayer(x: AxisConfig, y: AxisConfig): MaidrLayer {
+  return {
+    id: 'grid-tick-step-layer',
+    type: TraceType.SCATTER,
+    title: 'Grid tick step',
+    axes: { x, y },
+    data: [{ x: 1, y: 1 }, { x: 3, y: 3 }],
+  };
+}
+
+describe('a scatter grid config that does not describe a grid', () => {
+  test.each([
+    ['a zero x tick step', { min: 0, max: 4, tickStep: 0 }, { min: 0, max: 4, tickStep: 2 }],
+    ['a zero y tick step', { min: 0, max: 4, tickStep: 2 }, { min: 0, max: 4, tickStep: 0 }],
+    ['a negative tick step', { min: 0, max: 4, tickStep: -2 }, { min: 0, max: 4, tickStep: 2 }],
+    ['a non-finite tick step', { min: 0, max: 4, tickStep: Number.POSITIVE_INFINITY }, { min: 0, max: 4, tickStep: 2 }],
+    ['a NaN tick step', { min: 0, max: 4, tickStep: Number.NaN }, { min: 0, max: 4, tickStep: 2 }],
+    ['an inverted range', { min: 4, max: 0, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
+    ['a collapsed range', { min: 2, max: 2, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
+  ])('%s constructs without a grid', (_name, x, y) => {
+    const trace = new ScatterTrace(scatterLayer({ label: 'X', ...x }, { label: 'Y', ...y }));
+
+    expect(trace.supportsGridMode()).toBe(false);
+    expect(trace.getGridDimensions()).toBeNull();
+    expect(trace.state.empty).toBe(false);
+  });
+
+  test('a well-formed config still builds the grid', () => {
+    const trace = new ScatterTrace(scatterLayer(
+      { label: 'X', min: 0, max: 4, tickStep: 2 },
+      { label: 'Y', min: 0, max: 4, tickStep: 2 },
+    ));
+
+    expect(trace.supportsGridMode()).toBe(true);
+    expect(trace.getGridDimensions()).toEqual({ rows: 2, cols: 2 });
+  });
+});

--- a/test/model/scatterGridTickStep.test.ts
+++ b/test/model/scatterGridTickStep.test.ts
@@ -36,6 +36,9 @@ describe('a scatter grid config that does not describe a grid', () => {
     // Each axis is inside the per-axis bound; their product is not, and the
     // product is what the grid allocates.
     ['two axes that multiply into a grid too large to build', { min: 0, max: 10_000, tickStep: 1 }, { min: 0, max: 10_000, tickStep: 1 }],
+    // One cell over the cap, so the comparison itself is pinned rather than
+    // bracketed: 1000 x 101 against the 1000 x 100 accepted below.
+    ['a grid one row past the cap', { min: 0, max: 1000, tickStep: 1 }, { min: 0, max: 101, tickStep: 1 }],
     ['an inverted range', { min: 4, max: 0, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
     ['a collapsed range', { min: 2, max: 2, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
   ])('%s constructs without a grid', (_name, x, y) => {
@@ -46,16 +49,18 @@ describe('a scatter grid config that does not describe a grid', () => {
     expect(trace.state.empty).toBe(false);
   });
 
-  test('a large grid that is still within reach is built', () => {
-    // 300 x 300 = 90,000 cells: far more than a reader would walk, and
-    // still built, so the cap rejects only what would freeze the tab.
+  test('a grid at exactly the cap is built', () => {
+    // 1000 x 100 = 100,000 cells, the largest grid the cap admits: far more
+    // than a reader would walk, and still built, so the cap turns away only
+    // what would freeze the tab. Paired with the one-row-larger rejection
+    // above, this pins the comparison rather than bracketing it.
     const trace = new ScatterTrace(scatterLayer(
-      { label: 'X', min: 0, max: 300, tickStep: 1 },
-      { label: 'Y', min: 0, max: 300, tickStep: 1 },
+      { label: 'X', min: 0, max: 1000, tickStep: 1 },
+      { label: 'Y', min: 0, max: 100, tickStep: 1 },
     ));
 
     expect(trace.supportsGridMode()).toBe(true);
-    expect(trace.getGridDimensions()).toEqual({ rows: 300, cols: 300 });
+    expect(trace.getGridDimensions()).toEqual({ rows: 100, cols: 1000 });
   });
 
   test('a well-formed config still builds the grid', () => {

--- a/test/model/scatterGridTickStep.test.ts
+++ b/test/model/scatterGridTickStep.test.ts
@@ -33,6 +33,9 @@ describe('a scatter grid config that does not describe a grid', () => {
     ['a non-finite tick step', { min: 0, max: 4, tickStep: Number.POSITIVE_INFINITY }, { min: 0, max: 4, tickStep: 2 }],
     ['a NaN tick step', { min: 0, max: 4, tickStep: Number.NaN }, { min: 0, max: 4, tickStep: 2 }],
     ['a tick step asking for billions of bins', { min: 0, max: 4, tickStep: 1e-9 }, { min: 0, max: 4, tickStep: 2 }],
+    // Each axis is inside the per-axis bound; their product is not, and the
+    // product is what the grid allocates.
+    ['two axes that multiply into a grid too large to build', { min: 0, max: 10_000, tickStep: 1 }, { min: 0, max: 10_000, tickStep: 1 }],
     ['an inverted range', { min: 4, max: 0, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
     ['a collapsed range', { min: 2, max: 2, tickStep: 2 }, { min: 0, max: 4, tickStep: 2 }],
   ])('%s constructs without a grid', (_name, x, y) => {
@@ -41,6 +44,18 @@ describe('a scatter grid config that does not describe a grid', () => {
     expect(trace.supportsGridMode()).toBe(false);
     expect(trace.getGridDimensions()).toBeNull();
     expect(trace.state.empty).toBe(false);
+  });
+
+  test('a large grid that is still within reach is built', () => {
+    // 300 x 300 = 90,000 cells: far more than a reader would walk, and
+    // still built, so the cap rejects only what would freeze the tab.
+    const trace = new ScatterTrace(scatterLayer(
+      { label: 'X', min: 0, max: 300, tickStep: 1 },
+      { label: 'Y', min: 0, max: 300, tickStep: 1 },
+    ));
+
+    expect(trace.supportsGridMode()).toBe(true);
+    expect(trace.getGridDimensions()).toEqual({ rows: 300, cols: 300 });
   });
 
   test('a well-formed config still builds the grid', () => {

--- a/test/model/violinKdeSelectors.test.ts
+++ b/test/model/violinKdeSelectors.test.ts
@@ -1,0 +1,63 @@
+import type { MaidrLayer, ViolinKdePoint } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { ViolinKdeTrace } from '@model/violin';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A horizontal violin-KDE layer with no `selectors` threw in the constructor.
+ *
+ * The horizontal branch reversed the selectors to match the reversed points
+ * by spreading them -- `[...layer.selectors]` -- and `selectors` is optional
+ * in the grammar, so spreading `undefined` threw `layer.selectors is not
+ * iterable`. The vertical branch never spread and reached the guard in
+ * `mapToSvgElements`, so the same layer the other way up was fine.
+ *
+ * The Chart.js extractor emits exactly this shape -- a VIOLIN_KDE layer with
+ * an orientation and no selectors -- so a sideways Chart.js violin took the
+ * whole figure down with it.
+ */
+const CURVES: ViolinKdePoint[][] = [
+  [
+    { x: 'setosa', y: 1, density: 0.2 },
+    { x: 'setosa', y: 2, density: 0.8 },
+  ],
+  [
+    { x: 'versicolor', y: 3, density: 0.5 },
+    { x: 'versicolor', y: 4, density: 0.3 },
+  ],
+];
+
+/**
+ * Build a violin-KDE layer without any selectors.
+ * @param orientation - Which way the violins lie
+ * @param selectors - Selectors to carry, when the layer carries any
+ * @returns A layer definition
+ */
+function kdeLayer(orientation: Orientation, selectors?: MaidrLayer['selectors']): MaidrLayer {
+  return {
+    id: 'kde',
+    type: TraceType.VIOLIN_KDE,
+    orientation,
+    axes: { x: { label: 'Species' }, y: { label: 'Petal length' } },
+    data: CURVES,
+    ...(selectors === undefined ? {} : { selectors }),
+  };
+}
+
+describe('a violin-KDE layer without selectors', () => {
+  test('constructs when the violins lie horizontally', () => {
+    expect(() => new ViolinKdeTrace(kdeLayer(Orientation.HORIZONTAL))).not.toThrow();
+  });
+
+  test('still reads its first violin', () => {
+    const trace = new ViolinKdeTrace(kdeLayer(Orientation.HORIZONTAL));
+
+    trace.moveOnce('FORWARD');
+
+    expect(trace.state.empty).toBe(false);
+  });
+
+  test('constructs when the violins stand vertically', () => {
+    expect(() => new ViolinKdeTrace(kdeLayer(Orientation.VERTICAL))).not.toThrow();
+  });
+});

--- a/test/model/waterfall.test.ts
+++ b/test/model/waterfall.test.ts
@@ -131,6 +131,17 @@ describe('audio', () => {
     expect(Number(decrease.freq.raw)).toBeLessThan(Number(increase.freq.raw));
   });
 
+  test('keeps the pitch range over the measured steps when the first is missing', () => {
+    // `MathUtil.minMax` seeds its range from the first value, and a NaN there
+    // never loses a comparison, so one unmeasured opening step handed every
+    // other step a NaN range and a silent chart.
+    const unmeasured = { x: 'Opening', start: 0, end: 1200, kind: 'total' } as WaterfallPoint;
+    const { audio } = nonEmptyState(at(2, [unmeasured, ...STEPS.slice(1)]));
+
+    expect(audio.freq.min).toBe(-250);
+    expect(audio.freq.max).toBe(1360);
+  });
+
   test('pans across the steps', () => {
     const { audio } = nonEmptyState(at(3));
 
@@ -252,6 +263,26 @@ describe('description', () => {
       { x: 'Close', start: 0, end: 500, delta: 500, kind: 'total' },
     ];
     const labels = at(0, totalsOnly).description.stats.map(stat => stat.label);
+
+    expect(labels).not.toContain('Largest contribution');
+  });
+
+  test('names the largest mover among the measured steps when one is missing', () => {
+    // A producer can leave a step's contribution out. Ranking it as NaN made
+    // `Math.max` NaN, the lookup `steps[-1]`, and the describe command throw.
+    const [opening, marketing, sales, support, closing] = STEPS;
+    const unmeasured = { x: 'Legal', start: 950, end: 950, kind: 'decrease' } as WaterfallPoint;
+    const stat = at(0, [opening, marketing, sales, unmeasured, support, closing])
+      .description
+      .stats
+      .find(s => s.label === 'Largest contribution');
+
+    expect(stat).toEqual({ label: 'Largest contribution', value: 'Sales (480)' });
+  });
+
+  test('stays silent about a largest mover when no step is measured', () => {
+    const unmeasured = { x: 'Legal', start: 950, end: 950, kind: 'decrease' } as WaterfallPoint;
+    const labels = at(0, [STEPS[0], unmeasured, STEPS[4]]).description.stats.map(stat => stat.label);
 
     expect(labels).not.toContain('Largest contribution');
   });


### PR DESCRIPTION
# Pull Request

## Description

A throw inside a trace propagates out of `new Figure(...)` and takes the whole chart down (the blast radius #905 was fixed to avoid), and an unbounded loop inside a constructor freezes the tab with nothing to catch. A codebase audit found eleven places where a producer emitting empty, ragged or non-numeric data still reaches one of those outcomes. Each is fixed with the smallest guard that keeps the documented "nothing at the cursor" behaviour, and each has a test that failed before the change.

## Related Issues

Follows up on the empty-series handling from #905.

## Changes Made

- **scatter**: `resolveGridConfig` rejects a non-finite or non-positive `tickStep` and an inverted or collapsed range. `tickStep: 0` over a positive range used to make `computeGridSteps` push `Infinity` bins until the tab ran out of memory.
- **violin (KDE)**: a horizontal layer without `selectors` no longer throws `layer.selectors is not iterable` (the Chart.js extractor emits exactly that shape); a single-string selector is read as one pattern instead of being spread into characters.
- **heatmap**: a layer with a selector but no cells constructs and reports empty instead of throwing on `heatmapValues[0].length`.
- **segmented (stacked/dodged/normalized/diverging/mosaic)**: `data: []` constructs with an empty summary row instead of throwing in `createSummaryLevel`.
- **histogram**: `description` on an empty layer reports the bin range as "missing" instead of throwing.
- **line**: a ragged layer whose first series is empty lands the cursor on the first populated series, and the movement accessors report out of bounds rather than throwing on `points[-1]`; `description` reads points-per-series from the widest series and tolerates an empty layer.
- **candlestick**: an empty layer reports out of bounds on the first arrow key or Ctrl+arrow instead of throwing out of the keybinding handler.
- **bump**: a single null rank no longer makes every pitch bound NaN (the whole chart went silent).
- **waterfall**: a missing or non-numeric delta is kept out of the pitch range and out of the "Largest contribution" ranking, which used to throw.
- **model**: `notifyRotorBounds` restores the warning flag in a `finally`, so an observer that throws cannot leave every later state read in the warning variant.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint`, `npm run type-check`, `npm test` and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_