### PR TITLE
fix(model): remove every hidden highlight clone on dispose and stop truncating caller data

### DIFF
--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -76,7 +76,10 @@ export class BoxTrace extends AbstractTrace {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.points = [...(layer.data as BoxPoint[])].reverse();
     } else {
-      this.points = layer.data as BoxPoint[];
+      // Copied, like the reversed branch above: `dispose()` truncates the
+      // array it holds, and held by reference that would empty the caller's
+      // spec, so a figure rebuilt from it came up empty.
+      this.points = [...(layer.data as BoxPoint[])];
     }
 
     // Standard box plot sections: full Tukey structure

--- a/src/model/boxen.ts
+++ b/src/model/boxen.ts
@@ -155,8 +155,12 @@ export class BoxenTrace extends AbstractTrace {
   private mapToSvgElements(
     selectors?: MaidrLayer['selectors'],
   ): SVGElement[][] | null {
+    // Resolved live here and cloned by `pairWith` only once the count fits.
+    // A clone is inserted beside its original the moment it is made, so
+    // declining after cloning left every copy in the chart for `dispose()`
+    // never to reach -- and the next resolution matched the copies too.
     if (typeof selectors === 'string') {
-      return this.pairWith(Svg.selectAllElements(selectors));
+      return this.pairWith(Svg.selectAllElements(selectors, false));
     }
     // `MaidrLayer['selectors']` also admits `(string | null)[][]` and the box and
     // candlestick shapes, and `Array.isArray` alone lets all of them through
@@ -168,7 +172,7 @@ export class BoxenTrace extends AbstractTrace {
       return null;
     }
 
-    return this.pairWith(selectors.flatMap(one => Svg.selectAllElements(one)));
+    return this.pairWith(selectors.flatMap(one => Svg.selectAllElements(one, false)));
   }
 
   /**
@@ -178,13 +182,14 @@ export class BoxenTrace extends AbstractTrace {
    * one highlights a neighbouring distribution for the rest of the chart,
    * which is worse than not highlighting at all.
    *
-   * @param flat - The elements the selectors resolved to
+   * @param live - The chart's own elements the selectors resolved to
    * @returns Elements shaped rungs x distributions, or null on a mismatch
    */
-  private pairWith(flat: SVGElement[]): SVGElement[][] | null {
-    if (flat.length !== this.points.length) {
+  private pairWith(live: SVGElement[]): SVGElement[][] | null {
+    if (live.length !== this.points.length) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
     return this.rungValues.map((ladder, row) => ladder.map(() => flat[row]));
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -830,8 +830,12 @@ export class Candlestick extends AbstractTrace {
         const { open, close } = this.candles[i];
         // Which edge of the body is the open depends on which way the body
         // ran, so a candle with none has no edge to derive -- and no `open`
-        // section for the element to be reached through either.
-        if (body && open !== undefined) {
+        // section for the element to be reached through either. The section
+        // is a property of the chart, not of the candle: on a chart without
+        // one, a candle that does state an open still has nowhere to place
+        // the line, and `createLineElement` inserts it the moment it is made,
+        // so deriving it left a `<line>` in the chart `dispose()` never saw.
+        if (body && this.hasOpen && open !== undefined) {
           const edge: 'top' | 'bottom'
             = close > open ? 'bottom' : close < open ? 'top' : 'bottom';
           openEl = Svg.createLineElement(body, edge);

--- a/src/model/choropleth.ts
+++ b/src/model/choropleth.ts
@@ -570,18 +570,23 @@ export class ChoroplethTrace extends AbstractTrace {
     selectors: MaidrLayer['selectors'],
     declared: number,
   ): SVGElement[][] | null {
-    let flat: SVGElement[];
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    let live: SVGElement[];
     if (typeof selectors === 'string') {
-      flat = Svg.selectAllElements(selectors);
+      live = Svg.selectAllElements(selectors, false);
     } else if (Array.isArray(selectors) && selectors.every(one => typeof one === 'string')) {
-      flat = selectors.flatMap(one => Svg.selectAllElements(one));
+      live = selectors.flatMap(one => Svg.selectAllElements(one, false));
     } else {
       return null;
     }
 
-    if (flat.length !== declared) {
+    if (live.length !== declared) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
 
     return this.regions.map(band =>
       band.map(region => flat[region.source] ?? Svg.createEmptyElement()));

--- a/src/model/dumbbell.ts
+++ b/src/model/dumbbell.ts
@@ -174,13 +174,18 @@ export class DumbbellTrace extends AbstractTrace {
       return null;
     }
 
-    const flat = typeof selectors === 'string'
-      ? Svg.selectAllElements(selectors)
-      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    const live = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors, false)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one, false));
 
-    if (flat.length !== this.points.length) {
+    if (live.length !== this.points.length) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
     return ENDS.map(() => flat);
   }
 

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -259,13 +259,18 @@ export class ErrorBarTrace extends AbstractTrace {
       return null;
     }
 
-    const flat = typeof selectors === 'string'
-      ? Svg.selectAllElements(selectors)
-      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    const live = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors, false)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one, false));
 
-    if (flat.length !== this.points.length) {
+    if (live.length !== this.points.length) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
     // One whip per point, and the flat list runs in the same group-major
     // order the rows do -- so each group's rows take that group's slice, and
     // every section within a group highlights the same whips. Handing every

--- a/src/model/flow.ts
+++ b/src/model/flow.ts
@@ -739,18 +739,23 @@ export class FlowTrace extends AbstractTrace implements PointCloudHighlightable 
     selectors: MaidrLayer['selectors'],
     declared: number,
   ): SVGElement[][] | null {
-    let flat: SVGElement[];
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    let live: SVGElement[];
     if (typeof selectors === 'string') {
-      flat = Svg.selectAllElements(selectors);
+      live = Svg.selectAllElements(selectors, false);
     } else if (Array.isArray(selectors) && selectors.every(one => typeof one === 'string')) {
-      flat = selectors.flatMap(one => Svg.selectAllElements(one));
+      live = selectors.flatMap(one => Svg.selectAllElements(one, false));
     } else {
       return null;
     }
 
-    if (flat.length !== declared) {
+    if (live.length !== declared) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
     this.ribbons = flat;
 
     // Indexed by the edge's own declared position. Walking the sorted edge
@@ -773,6 +778,24 @@ export class FlowTrace extends AbstractTrace implements PointCloudHighlightable 
    */
   public getGeometryElements(): SVGElement[] {
     return [...this.ribbons];
+  }
+
+  /**
+   * Removes every ribbon clone, not only the ones the highlight covers.
+   *
+   * `AbstractTrace.dispose()` walks `highlightValues`, which holds one ribbon
+   * per node; a ribbon that is nobody's widest is referenced only from
+   * {@link ribbons}, and left in the chart it accumulated on every focus
+   * cycle and live-data rebuild.
+   */
+  public override dispose(): void {
+    for (const ribbon of this.ribbons) {
+      if (Svg.isOwned(ribbon)) {
+        ribbon.remove();
+      }
+    }
+    this.ribbons = [];
+    super.dispose();
   }
 
   /**

--- a/src/model/gantt.ts
+++ b/src/model/gantt.ts
@@ -131,13 +131,18 @@ export class GanttTrace extends AbstractTrace {
       return null;
     }
 
-    const flat = typeof selectors === 'string'
-      ? Svg.selectAllElements(selectors)
-      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    const live = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors, false)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one, false));
 
-    if (flat.length !== this.lanes.flat().length) {
+    if (live.length !== this.lanes.flat().length) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
 
     let taken = 0;
     return this.lanes.map(lane => flat.slice(taken, taken += lane.length));

--- a/src/model/gauge.ts
+++ b/src/model/gauge.ts
@@ -90,11 +90,15 @@ export class GaugeTrace extends AbstractTrace {
       return null;
     }
 
+    // Resolved live, and only the one element kept is cloned. Cloning every
+    // match up front inserted a hidden copy of each beside its original, and
+    // the copies past the first were never referenced again, so `dispose()`
+    // could not remove them.
     const drawn = typeof selectors === 'string'
-      ? Svg.selectAllElements(selectors)
-      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+      ? Svg.selectAllElements(selectors, false)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one, false));
 
-    return drawn.length > 0 ? [[drawn[0]]] : null;
+    return drawn.length > 0 ? [[Svg.cloneHidden(drawn[0])]] : null;
   }
 
   /**

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -71,7 +71,10 @@ export class Heatmap extends AbstractTrace {
     super(layer);
 
     const data = layer.data as HeatmapData;
-    this.x = data.x;
+    // Both copied: `dispose()` truncates the arrays it holds, and `x` held by
+    // reference emptied the caller's column labels, so a heatmap rebuilt from
+    // the same spec announced no column at all.
+    this.x = [...data.x];
     this.y = [...data.y].reverse();
     this.heatmapValues = [...data.points].reverse().map(measuredRow);
 

--- a/src/model/network.ts
+++ b/src/model/network.ts
@@ -103,6 +103,13 @@ export class NetworkTrace extends AbstractTrace implements PointCloudHighlightab
   protected readonly highlightValues: SVGElement[][] | null;
 
   /**
+   * Every line clone the selectors resolved to, in declared link order. The
+   * highlight covers one line per node, so this is what `dispose()` walks to
+   * remove the rest.
+   */
+  private lines: SVGElement[] = [];
+
+  /**
    * Creates a new network trace.
    *
    * @param layer - The MAIDR layer carrying the links
@@ -507,18 +514,24 @@ export class NetworkTrace extends AbstractTrace implements PointCloudHighlightab
     selectors: MaidrLayer['selectors'],
     declared: number,
   ): SVGElement[][] | null {
-    let flat: SVGElement[];
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    let live: SVGElement[];
     if (typeof selectors === 'string') {
-      flat = Svg.selectAllElements(selectors);
+      live = Svg.selectAllElements(selectors, false);
     } else if (Array.isArray(selectors) && selectors.every(one => typeof one === 'string')) {
-      flat = selectors.flatMap(one => Svg.selectAllElements(one));
+      live = selectors.flatMap(one => Svg.selectAllElements(one, false));
     } else {
       return null;
     }
 
-    if (flat.length !== declared) {
+    if (live.length !== declared) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
+    this.lines = flat;
 
     // The line drawn for the node's most connected neighbour, which is also
     // the rotor's first step from here -- so the highlight agrees with where
@@ -531,6 +544,24 @@ export class NetworkTrace extends AbstractTrace implements PointCloudHighlightab
         const element = at === undefined ? undefined : flat[at];
         return element ?? Svg.createEmptyElement();
       }));
+  }
+
+  /**
+   * Removes every line clone, not only the ones the highlight covers.
+   *
+   * `AbstractTrace.dispose()` walks `highlightValues`, which holds one line
+   * per node; a line that is nobody's first step is referenced only from
+   * {@link lines}, and left in the chart it accumulated on every focus cycle
+   * and live-data rebuild.
+   */
+  public override dispose(): void {
+    for (const line of this.lines) {
+      if (Svg.isOwned(line)) {
+        line.remove();
+      }
+    }
+    this.lines = [];
+    super.dispose();
   }
 
   /**

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -158,21 +158,33 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
     this.yLabel = maidr.axes?.y?.label ?? DEFAULT_FIGURE_AXIS;
 
     const subplots = maidr.subplots as MaidrSubplot[][];
-    this.subplots = subplots.map((row, r) =>
-      row.map((subplot, c) => {
-        // Reporting the position is the only signal a producer author ever
-        // gets, and reading the cell as empty in silence would trade a loud
-        // failure for an invisible one.
-        if (!hasLayerArray(subplot)) {
-          console.warn(
-            `[Figure] Subplot [${r}][${c}] has no \`layers\` array; reading `
-            + `it as an empty subplot. The producer of this schema should `
-            + `emit \`{ id, layers: [] }\` for positions no chart occupies.`,
-          );
-        }
-        return new Subplot(subplot);
-      }),
-    );
+    // Built one at a time so a subplot that throws does not strand what the
+    // subplots before it inserted into the chart: a figure that never
+    // finishes constructing is never disposed.
+    const built: Subplot[][] = [];
+    try {
+      subplots.forEach((row, r) => {
+        const cells: Subplot[] = [];
+        built.push(cells);
+        row.forEach((subplot, c) => {
+          // Reporting the position is the only signal a producer author ever
+          // gets, and reading the cell as empty in silence would trade a loud
+          // failure for an invisible one.
+          if (!hasLayerArray(subplot)) {
+            console.warn(
+              `[Figure] Subplot [${r}][${c}] has no \`layers\` array; reading `
+              + `it as an empty subplot. The producer of this schema should `
+              + `emit \`{ id, layers: [] }\` for positions no chart occupies.`,
+            );
+          }
+          cells.push(new Subplot(subplot));
+        });
+      });
+    } catch (error) {
+      built.forEach(row => row.forEach(subplot => subplot.dispose()));
+      throw error;
+    }
+    this.subplots = built;
     this.size = this.subplots.reduce((sum, row) => sum + row.length, 0);
 
     // Defaults until applyLayout() is called.
@@ -441,9 +453,21 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
         || layerTypes.includes(TraceType.VIOLIN_BOX);
 
     // Each layer's type maps directly to a trace — no heuristic needed.
-    this.traces = layers.map(layer => [
-      TraceFactory.create(layer),
-    ]);
+    //
+    // Built one at a time so a layer the factory rejects does not strand
+    // what the layers before it inserted: every trace clones its highlight
+    // elements into the chart as it is constructed, and a subplot that never
+    // finishes constructing is never disposed.
+    const traces: Trace[][] = [];
+    try {
+      for (const layer of layers) {
+        traces.push([TraceFactory.create(layer)]);
+      }
+    } catch (error) {
+      traces.forEach(row => row.forEach(trace => trace.dispose()));
+      throw error;
+    }
+    this.traces = traces;
     // Read the lightweight traceType accessor rather than trace.state, which
     // would eagerly compute full audio/braille/text/highlight state per trace
     // on every construction (including every live-data rebuild).

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -168,6 +168,12 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
 
   private readonly highlightXValues: SVGElement[][] | null;
   private readonly highlightYValues: SVGElement[][] | null;
+  /**
+   * Every clone the selector resolved, in data order, whether or not its
+   * coordinates could be read. A marker with none joins neither a column nor
+   * a row, so this is the only list `dispose()` can remove it through.
+   */
+  private readonly svgClones: SVGElement[];
   protected highlightCenters:
     | { x: number; y: number; row: number; col: number; element: SVGElement }[]
     | null;
@@ -345,6 +351,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     // Select SVG elements once, then share for COL/ROW grouping and grid cell mapping
     const selector = layer.selectors as string;
     const allSvgClones = selector ? Svg.selectAllElements(selector) : [];
+    this.svgClones = allSvgClones;
 
     [this.highlightXValues, this.highlightYValues] = this.groupSvgElements(allSvgClones);
     this.highlightCenters = this.mapSvgElementsToCenters();
@@ -505,14 +512,27 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     this.xPoints.length = 0;
     this.yPoints.length = 0;
 
+    // Removed through the full list rather than through the column and row
+    // groupings alone: a clone whose coordinates could not be read is in
+    // neither grouping, and left in the chart it accumulated on every
+    // focus-out and live-data rebuild.
+    this.svgClones.forEach(el => Svg.isOwned(el) && el.remove());
+    this.svgClones.length = 0;
     if (this.highlightXValues) {
-      this.highlightXValues.forEach(row => row.forEach(el => Svg.isOwned(el) && el.remove()));
       this.highlightXValues.length = 0;
     }
     if (this.highlightYValues) {
-      this.highlightYValues.forEach(row => row.forEach(el => Svg.isOwned(el) && el.remove()));
       this.highlightYValues.length = 0;
     }
+    this.highlightCenters = null;
+
+    // Grid and grid-cell navigation hold the same clones by another route.
+    this.gridCells?.forEach(row => row.forEach((cell) => {
+      cell.svgElements.length = 0;
+      cell.points.length = 0;
+    }));
+    this.cellSvgGroups.length = 0;
+    this.cellIndexGroups.length = 0;
 
     // Point and intersection navigation cache their own references to the
     // chart's live geometry; leaving them behind retains a detached DOM tree

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -414,7 +414,12 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       return this.mapGridToSvgElements(selector);
     }
 
-    const domElements = Svg.selectAllElements(selector);
+    // Resolved live; `claim` clones each mark as a cell takes it. Cloning
+    // every match up front inserted a hidden copy beside each mark, and a
+    // selector matching more marks than there are cells left the surplus
+    // copies unreferenced -- so `dispose()` never removed them, and the next
+    // resolution matched them too.
+    const domElements = Svg.selectAllElements(selector, false);
     if (domElements.length === 0) {
       return null;
     }
@@ -465,7 +470,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       if (domIndex >= domElements.length) {
         return Svg.createEmptyElement();
       }
-      return domElements[domIndex++];
+      return Svg.cloneHidden(domElements[domIndex++]);
     };
 
     if (!isColumnMajor) {

--- a/src/model/treemap.ts
+++ b/src/model/treemap.ts
@@ -706,18 +706,23 @@ export class TreemapTrace extends AbstractTrace {
     selectors: MaidrLayer['selectors'],
     declared: number,
   ): SVGElement[][] | null {
-    let flat: SVGElement[];
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
+    let live: SVGElement[];
     if (typeof selectors === 'string') {
-      flat = Svg.selectAllElements(selectors);
+      live = Svg.selectAllElements(selectors, false);
     } else if (Array.isArray(selectors) && selectors.every(one => typeof one === 'string')) {
-      flat = selectors.flatMap(one => Svg.selectAllElements(one));
+      live = selectors.flatMap(one => Svg.selectAllElements(one, false));
     } else {
       return null;
     }
 
-    if (flat.length !== declared) {
+    if (live.length !== declared) {
       return null;
     }
+    const flat = live.map(element => Svg.cloneHidden(element));
 
     return this.nodes.map(level =>
       level.map((node) => {

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -72,7 +72,10 @@ export class ViolinKdeTrace extends AbstractTrace {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.points = [...(layer.data as ViolinKdePoint[][])].reverse();
     } else {
-      this.points = layer.data as ViolinKdePoint[][];
+      // Copied, like the reversed branch above: `dispose()` truncates the
+      // array it holds, and held by reference that would empty the caller's
+      // spec, so a figure rebuilt from it came up empty.
+      this.points = [...(layer.data as ViolinKdePoint[][])];
     }
 
     // Extract density and y values for each violin

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -68,7 +68,10 @@ export class ViolinBoxTrace extends AbstractTrace {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.points = [...(layer.data as BoxPoint[])].reverse();
     } else {
-      this.points = layer.data as BoxPoint[];
+      // Copied, like the reversed branch above: `dispose()` truncates the
+      // array it holds, and held by reference that would empty the caller's
+      // spec, so a figure rebuilt from it came up empty.
+      this.points = [...(layer.data as BoxPoint[])];
     }
 
     // Build sections based on violin options

--- a/src/model/waterfall.ts
+++ b/src/model/waterfall.ts
@@ -90,14 +90,18 @@ export class WaterfallTrace extends AbstractTrace {
       return null;
     }
 
+    // Resolved live first and cloned only once the count fits. A clone is
+    // inserted beside its original the moment it is made, so declining after
+    // cloning left every copy in the chart for `dispose()` never to reach --
+    // and the next resolution matched the copies too.
     const flat = typeof selectors === 'string'
-      ? Svg.selectAllElements(selectors)
-      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+      ? Svg.selectAllElements(selectors, false)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one, false));
 
     if (flat.length !== this.points.length) {
       return null;
     }
-    return [flat];
+    return [flat.map(element => Svg.cloneHidden(element))];
   }
 
   protected get values(): number[][] {

--- a/test/model/barInputMutation.test.ts
+++ b/test/model/barInputMutation.test.ts
@@ -1,4 +1,4 @@
-import type { BarPoint, MaidrLayer, SegmentedPoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, HeatmapData, MaidrLayer, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
 import { beforeEach, describe, expect, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
 import { Orientation, TraceType } from '@type/grammar';
@@ -134,5 +134,102 @@ describe('a bar trace does not write to the spec it was given', () => {
     trace.dispose();
 
     expect(barData).toHaveLength(2);
+  });
+});
+
+/**
+ * The same truncation reached four more traces through the same route: box,
+ * violin box and violin KDE hold `layer.data` by reference on their vertical
+ * branch (the horizontal one copies to reverse), and the heatmap holds
+ * `data.x` by reference while copying `data.y` to reverse it. Each one
+ * truncated what it held on `dispose()`, so a spec built into a figure once
+ * could not build a second one.
+ */
+describe('the other traces that held the spec by reference', () => {
+  /**
+   * A summary-statistics group with no outliers.
+   * @param z The group's label
+   * @param mid Its median, with the other quartiles spread around it
+   * @returns The group
+   */
+  function group(z: string, mid: number): BoxPoint {
+    return {
+      z,
+      lowerOutliers: [],
+      min: mid - 2,
+      q1: mid - 1,
+      q2: mid,
+      q3: mid + 1,
+      max: mid + 2,
+      upperOutliers: [],
+    };
+  }
+
+  test.each([TraceType.BOX, TraceType.VIOLIN_BOX])(
+    'disposing a vertical %s trace leaves the caller data intact',
+    (type) => {
+      const data = [group('a', 5), group('b', 7)];
+      const layer: MaidrLayer = {
+        id: 'layer',
+        type,
+        orientation: Orientation.VERTICAL,
+        axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+        data,
+      };
+      const trace = TraceFactory.create(layer);
+
+      trace.dispose();
+
+      expect(data).toHaveLength(2);
+      expect(TraceFactory.create(layer).state.empty).toBe(false);
+    },
+  );
+
+  test('disposing a vertical violin KDE trace leaves the caller data intact', () => {
+    const data: ViolinKdePoint[][] = [
+      [{ x: 'a', y: 0, density: 0.1 }, { x: 'a', y: 1, density: 0.4 }],
+      [{ x: 'b', y: 0, density: 0.2 }, { x: 'b', y: 1, density: 0.3 }],
+    ];
+    const layer: MaidrLayer = {
+      id: 'layer',
+      type: TraceType.VIOLIN_KDE,
+      orientation: Orientation.VERTICAL,
+      axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+      data,
+    };
+    const trace = TraceFactory.create(layer);
+
+    trace.dispose();
+
+    expect(data).toHaveLength(2);
+    expect(TraceFactory.create(layer).state.empty).toBe(false);
+  });
+
+  test('disposing a heatmap leaves the caller column labels intact', () => {
+    const data: HeatmapData = {
+      x: ['Mon', 'Tue'],
+      y: ['r1', 'r2'],
+      points: [[1, 2], [3, 4]],
+    };
+    const layer: MaidrLayer = {
+      id: 'layer',
+      type: TraceType.HEATMAP,
+      axes: { x: { label: 'Day' }, y: { label: 'Row' } },
+      data,
+    };
+    const trace = TraceFactory.create(layer);
+
+    trace.dispose();
+
+    expect(data.x).toEqual(['Mon', 'Tue']);
+    expect(data.y).toEqual(['r1', 'r2']);
+    // A rebuilt heatmap still announces the column it sits on.
+    const second = TraceFactory.create(layer);
+    second.moveToIndex(0, 0);
+    const state = second.state;
+    if (state.empty) {
+      throw new Error('Expected a populated state');
+    }
+    expect(state.text.main.value).toBe('Mon');
   });
 });

--- a/test/model/candlestickDerivedLines.test.ts
+++ b/test/model/candlestickDerivedLines.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * A candlestick derives the open and close edges it was given no selector for
+ * by drawing a line along the body, and `Svg.createLineElement` inserts that
+ * line into the chart the moment it is made. On a chart whose candles do not
+ * all state an open there is no `open` row (#1188), so a derived open edge has
+ * no row to be placed in: it was inserted, referenced by nothing, and left
+ * behind by `dispose()` -- one hidden `<line>` per opened candle per focus
+ * cycle, for the lifetime of the page.
+ */
+
+import type { MaidrLayer } from '@type/grammar';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+const BODY = '.body';
+
+/** How many MAIDR-owned elements the document holds right now. */
+function ownedCount(): number {
+  return document.querySelectorAll('[data-maidr-owned]').length;
+}
+
+/**
+ * Two of three candles state an open, so the chart reads as high-low-close
+ * and has no `open` row -- but each of the two still has a body to derive an
+ * open edge from.
+ */
+const layer: Omit<MaidrLayer, 'selectors'> = {
+  id: 'test-candlestick',
+  type: TraceType.CANDLESTICK,
+  axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+  data: [
+    { value: 'd0', open: 10, high: 15, low: 9, close: 14, volume: 1, volatility: 6 },
+    { value: 'd1', high: 16, low: 12, close: 13, volume: 1, volatility: 4 },
+    { value: 'd2', open: 13, high: 14, low: 10, close: 11, volume: 1, volatility: 4 },
+  ],
+};
+
+describe('a candlestick without an open row', () => {
+  beforeEach(() => {
+    // jsdom lays nothing out, so the body has no measured box to draw along.
+    Object.defineProperty(SVGElement.prototype, 'getBBox', {
+      value: () => ({ x: 0, y: 0, width: 2, height: 4 }),
+      configurable: true,
+    });
+    document.body.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${
+      '<rect class="body" x="0" y="0" width="2" height="4" />'.repeat(3)}</svg>`;
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(SVGElement.prototype, 'getBBox');
+    document.body.innerHTML = '';
+  });
+
+  test('disposing removes every element it inserted beside the bodies', () => {
+    const trace = TraceFactory.create({ ...layer, selectors: { body: BODY } });
+    const inserted = ownedCount();
+
+    trace.dispose();
+
+    expect(inserted).toBeGreaterThan(0);
+    expect(ownedCount()).toBe(0);
+  });
+});

--- a/test/model/figureConstructionFailure.test.ts
+++ b/test/model/figureConstructionFailure.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * A figure that fails to construct leaves the chart as it found it.
+ *
+ * `Subplot` builds its traces eagerly and `Figure` its subplots, and every
+ * trace constructor inserts MAIDR-owned hidden clones into the SVG as it
+ * resolves its selectors. A layer whose `type` is unregistered makes
+ * `TraceFactory.create` throw part-way through, so the figure never finishes
+ * constructing and nothing ever calls `dispose()` on the pieces built before
+ * it -- their clones were orphaned in the chart, and on the live-data path
+ * (`Context.replaceFigure`) every failed update added another set.
+ */
+
+import type { Maidr, MaidrLayer, MaidrSubplot, TraceType } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { Figure, Subplot } from '@model/plot';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/** How many MAIDR-owned elements the document holds right now. */
+function ownedCount(): number {
+  return document.querySelectorAll('[data-maidr-owned]').length;
+}
+
+/** Renders two bars under `#bars` so a valid selector has something to match. */
+function renderBars(): void {
+  document.body.innerHTML = '';
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+  const group = document.createElementNS(SVG_NAMESPACE, 'g');
+  group.setAttribute('id', 'bars');
+  group.appendChild(document.createElementNS(SVG_NAMESPACE, 'rect'));
+  group.appendChild(document.createElementNS(SVG_NAMESPACE, 'rect'));
+  svg.appendChild(group);
+  document.body.appendChild(svg);
+}
+
+/**
+ * A bar layer over the two rendered bars.
+ * @param type What the layer declares itself as; the grammar's `TraceType`
+ *   for a layer the factory accepts, anything else for one it rejects
+ * @returns The layer
+ */
+function barLayer(type: string): MaidrLayer {
+  return {
+    id: `layer-${type}`,
+    type: type as TraceType,
+    selectors: '#bars > rect',
+    data: [{ x: 'A', y: 1 }, { x: 'B', y: 2 }],
+  };
+}
+
+describe('a figure that fails to construct', () => {
+  beforeEach(renderBars);
+
+  test('a subplot disposes the traces built before the layer that threw', () => {
+    const subplot: MaidrSubplot = {
+      layers: [barLayer('bar'), barLayer('not-a-chart')],
+    };
+
+    expect(() => new Subplot(subplot)).toThrow(/Invalid trace type/);
+
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('a figure disposes the subplots built before the one that threw', () => {
+    const maidr: Maidr = {
+      id: 'partial',
+      subplots: [
+        [{ selector: '#bars', layers: [barLayer('bar')] }],
+        [{ layers: [barLayer('not-a-chart')] }],
+      ],
+    };
+
+    expect(() => new Figure(maidr)).toThrow(/Invalid trace type/);
+
+    expect(ownedCount()).toBe(0);
+  });
+});

--- a/test/model/hiddenCloneDisposal.test.ts
+++ b/test/model/hiddenCloneDisposal.test.ts
@@ -225,6 +225,90 @@ describe('a segmented bar clones only the marks its cells claim', () => {
   });
 });
 
+describe('a flow removes every ribbon clone, not only the ones its nodes highlight', () => {
+  // A highlights its widest flow (A-B) and C its widest inflow (D-C), so
+  // the A-C ribbon is nobody's highlight and nothing in `highlightValues`
+  // reaches its clone.
+  const layer: Omit<MaidrLayer, 'selectors'> = {
+    id: 'test-sankey',
+    type: TraceType.SANKEY,
+    axes: { x: { label: 'Node' }, y: { label: 'Flow' } },
+    data: [
+      { source: 'A', target: 'B', value: 10 },
+      { source: 'A', target: 'C', value: 5 },
+      { source: 'D', target: 'C', value: 8 },
+    ],
+  };
+
+  test('declining a selector list that does not fit leaves the document untouched', () => {
+    draw(4);
+
+    const trace = TraceFactory.create({ ...layer, selectors: MARK });
+
+    expect(ownedCount()).toBe(0);
+    trace.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('disposing removes every clone it inserted, so a rebuild resolves the same marks', () => {
+    draw(3);
+
+    const first = TraceFactory.create({ ...layer, selectors: MARK });
+    expect(ownedCount()).toBe(3);
+
+    first.dispose();
+    expect(ownedCount()).toBe(0);
+
+    const second = TraceFactory.create({ ...layer, selectors: MARK });
+    expect(ownedCount()).toBe(3);
+    second.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+});
+
+describe('a network removes every link clone, not only the ones its nodes highlight', () => {
+  // Ada highlights one of her three links, Grace and Alan the link between
+  // them or to Ada, and Ida her loop -- at most three of the five lines are
+  // anybody's highlight.
+  const layer: Omit<MaidrLayer, 'selectors'> = {
+    id: 'test-network',
+    type: TraceType.NETWORK,
+    axes: { x: { label: 'Person' }, y: { label: 'Links' } },
+    data: [
+      { source: 'Ada', target: 'Edsger' },
+      { source: 'Ada', target: 'Grace' },
+      { source: 'Ada', target: 'Alan' },
+      { source: 'Grace', target: 'Alan' },
+      { source: 'Ida', target: 'Ida' },
+    ],
+  };
+
+  test('declining a selector list that does not fit leaves the document untouched', () => {
+    draw(6);
+
+    const trace = TraceFactory.create({ ...layer, selectors: MARK });
+
+    expect(ownedCount()).toBe(0);
+    trace.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('disposing removes every clone it inserted, so a rebuild resolves the same marks', () => {
+    draw(5);
+
+    const first = TraceFactory.create({ ...layer, selectors: MARK });
+    expect(ownedCount()).toBe(5);
+
+    first.dispose();
+    expect(ownedCount()).toBe(0);
+
+    const second = TraceFactory.create({ ...layer, selectors: MARK });
+    expect(ownedCount()).toBe(5);
+    second.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+});
+
 describe('a gauge keeps one drawn element and leaves no clone of the others', () => {
   const layer: Omit<MaidrLayer, 'selectors'> = {
     id: 'test-gauge',

--- a/test/model/hiddenCloneDisposal.test.ts
+++ b/test/model/hiddenCloneDisposal.test.ts
@@ -189,6 +189,42 @@ describe.each(CASES)('$type leaves no hidden clone behind', (one) => {
   });
 });
 
+describe('a segmented bar clones only the marks its cells claim', () => {
+  const layer: Omit<MaidrLayer, 'selectors'> = {
+    id: 'test-stacked',
+    type: TraceType.STACKED,
+    axes: { x: { label: 'Category' }, y: { label: 'Value' }, z: { label: 'Series' } },
+    data: [
+      [{ x: 'a', y: 3, z: 'A' }, { x: 'b', y: 5, z: 'A' }],
+      [{ x: 'a', y: 2, z: 'B' }, { x: 'b', y: 4, z: 'B' }],
+    ],
+  };
+
+  test('a selector matching more marks than cells leaves no clone of the surplus', () => {
+    // Four cells; six marks -- a legend the selector also caught, say. The
+    // first four are claimed, and nothing referenced the other two.
+    draw(6);
+
+    const trace = TraceFactory.create({ ...layer, selectors: MARK });
+
+    expect(ownedCount()).toBe(4);
+    trace.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('a rebuild after dispose claims the same marks', () => {
+    draw(4);
+
+    const first = TraceFactory.create({ ...layer, selectors: MARK });
+    first.dispose();
+    const second = TraceFactory.create({ ...layer, selectors: MARK });
+
+    expect(ownedCount()).toBe(4);
+    second.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+});
+
 describe('a gauge keeps one drawn element and leaves no clone of the others', () => {
   const layer: Omit<MaidrLayer, 'selectors'> = {
     id: 'test-gauge',

--- a/test/model/hiddenCloneDisposal.test.ts
+++ b/test/model/hiddenCloneDisposal.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Every hidden clone a trace inserts is gone once the trace is disposed.
+ *
+ * `Svg.selectAllElements(selector)` clones every match, marks the clone
+ * `data-maidr-owned` and inserts it beside the original *before* the trace
+ * decides whether it can use it. A trace that then declines the whole list
+ * (the count does not fit its points) or keeps only part of it dropped the
+ * rest on the floor: `AbstractTrace.dispose()` walks `highlightValues`, and a
+ * clone that never reached it was never removed.
+ *
+ * The cost compounds. Focus-out and focus-in rebuild the controller, and a
+ * live-data push rebuilds the figure, so every cycle adds another set of
+ * hidden elements to the chart's SVG. Worse, the clones are siblings of the
+ * marks they copy, so the next resolution of the same selector matches them
+ * too -- the count is wrong again, and a chart that mismatched once can never
+ * highlight again (#1004 is the same failure through positional selectors).
+ *
+ * Two properties, one per case, asserted for every trace that resolves a
+ * flat selector list:
+ *
+ *   - a resolution the trace declines leaves the document as it found it;
+ *   - a resolution it accepts is undone in full by `dispose()`, so a second
+ *     construction over the same document resolves the same elements.
+ */
+
+import type { MaidrLayer } from '@type/grammar';
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+const MARK = '.mark';
+
+/** How many MAIDR-owned elements the document holds right now. */
+function ownedCount(): number {
+  return document.querySelectorAll('[data-maidr-owned]').length;
+}
+
+/**
+ * Draw `count` marks, each addressable through {@link MARK}.
+ * @param count How many marks the chart drew
+ */
+function draw(count: number): void {
+  const marks = Array.from({ length: count }, (_, i) => `<rect class="mark" id="m${i}" />`);
+  document.body.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${marks.join('')}</svg>`;
+}
+
+/**
+ * One row per trace: the layer, minus its selectors, and how many marks its
+ * data declares.
+ */
+interface Case {
+  type: TraceType;
+  declared: number;
+  layer: Omit<MaidrLayer, 'selectors' | 'id' | 'type'>;
+}
+
+const CASES: Case[] = [
+  {
+    type: TraceType.WATERFALL,
+    declared: 3,
+    layer: {
+      axes: { x: { label: 'Step' }, y: { label: 'Amount' } },
+      data: [
+        { x: 'Opening', start: 0, end: 100, delta: 100, kind: 'total' },
+        { x: 'Sales', start: 100, end: 150, delta: 50, kind: 'increase' },
+        { x: 'Closing', start: 0, end: 150, delta: 150, kind: 'total' },
+      ],
+    },
+  },
+  {
+    type: TraceType.ERROR_BAR,
+    declared: 2,
+    layer: {
+      axes: { x: { label: 'Group' }, y: { label: 'Response' } },
+      data: [
+        { x: 'control', y: 4, yMin: 3, yMax: 5 },
+        { x: 'treated', y: 7, yMin: 6, yMax: 8 },
+      ],
+    },
+  },
+  {
+    type: TraceType.DUMBBELL,
+    declared: 2,
+    layer: {
+      axes: { x: { label: 'Country' }, y: { label: 'Years' } },
+      data: {
+        points: [
+          { x: 'Denmark', start: 71, end: 78 },
+          { x: 'Latvia', start: 74, end: 69 },
+        ],
+      },
+    },
+  },
+];
+
+/**
+ * Build the trace for a case over a selector addressing every mark.
+ * @param one The case
+ * @returns The constructed trace
+ */
+function build(one: Case): ReturnType<typeof TraceFactory.create> {
+  return TraceFactory.create({
+    id: `test-${one.type}`,
+    type: one.type,
+    selectors: MARK,
+    ...one.layer,
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe.each(CASES)('$type leaves no hidden clone behind', (one) => {
+  test('declining a selector list that does not fit leaves the document untouched', () => {
+    // One mark too many -- a legend swatch the selector also caught, say.
+    draw(one.declared + 1);
+
+    const trace = build(one);
+
+    expect(ownedCount()).toBe(0);
+    trace.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('disposing removes every clone it inserted, so a rebuild resolves the same marks', () => {
+    draw(one.declared);
+
+    const first = build(one);
+    expect(ownedCount()).toBe(one.declared);
+
+    first.dispose();
+    expect(ownedCount()).toBe(0);
+
+    const second = build(one);
+    expect(ownedCount()).toBe(one.declared);
+    second.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+});
+
+describe('a gauge keeps one drawn element and leaves no clone of the others', () => {
+  const layer: Omit<MaidrLayer, 'selectors'> = {
+    id: 'test-gauge',
+    type: TraceType.GAUGE,
+    axes: { x: { label: 'Measure' }, y: { label: 'Percent' } },
+    data: { value: 73, min: 0, max: 100 },
+  };
+
+  test('a selector matching several marks clones only the one it highlights', () => {
+    draw(3);
+
+    const trace = TraceFactory.create({ ...layer, selectors: MARK });
+
+    expect(ownedCount()).toBe(1);
+    trace.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('a rebuild after dispose resolves the same mark', () => {
+    draw(1);
+
+    const first = TraceFactory.create({ ...layer, selectors: MARK });
+    first.dispose();
+    const second = TraceFactory.create({ ...layer, selectors: MARK });
+
+    expect(ownedCount()).toBe(1);
+    second.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+});

--- a/test/model/hiddenCloneDisposal.test.ts
+++ b/test/model/hiddenCloneDisposal.test.ts
@@ -27,9 +27,10 @@
  *     construction over the same document resolves the same elements.
  */
 
-import type { MaidrLayer } from '@type/grammar';
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import { afterEach, describe, expect, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
+import { ScatterTrace } from '@model/scatter';
 import { TraceType } from '@type/grammar';
 
 const MARK = '.mark';
@@ -306,6 +307,45 @@ describe('a network removes every link clone, not only the ones its nodes highli
     expect(ownedCount()).toBe(5);
     second.dispose();
     expect(ownedCount()).toBe(0);
+  });
+});
+
+describe('a scatter removes the clones whose coordinates it could not read', () => {
+  // A `<g>` with no x/y, cx/cy, transform or `d` never joins a column or a
+  // row, so nothing in `highlightXValues` / `highlightYValues` reaches it.
+  const points: ScatterPoint[] = [{ x: 1, y: 2 }, { x: 3, y: 4 }, { x: 7, y: 8 }];
+  const layer: MaidrLayer = {
+    id: 'test-scatter',
+    type: TraceType.SCATTER,
+    selectors: MARK,
+    axes: {
+      x: { label: 'X', min: 0, max: 10, tickStep: 5 },
+      y: { label: 'Y', min: 0, max: 10, tickStep: 5 },
+    },
+    data: points,
+  };
+
+  test('disposing removes every clone, readable coordinates or not', () => {
+    document.body.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${
+      '<g class="mark"></g>'.repeat(points.length)}</svg>`;
+
+    const trace = new ScatterTrace(layer);
+    expect(ownedCount()).toBe(points.length);
+
+    trace.dispose();
+    expect(ownedCount()).toBe(0);
+  });
+
+  test('a disposed trace no longer offers a nearest point', () => {
+    document.body.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${
+      points.map(point =>
+        `<circle class="mark" cx="${point.x}" cy="${point.y}" r="1" />`).join('')}</svg>`;
+    const trace = new ScatterTrace(layer);
+    expect(trace.findNearestPoint(0, 0)).not.toBeNull();
+
+    trace.dispose();
+
+    expect(trace.findNearestPoint(0, 0)).toBeNull();
   });
 });
 

--- a/test/model/hiddenCloneDisposal.test.ts
+++ b/test/model/hiddenCloneDisposal.test.ts
@@ -95,6 +95,52 @@ const CASES: Case[] = [
       },
     },
   },
+  {
+    type: TraceType.TREEMAP,
+    declared: 2,
+    layer: {
+      axes: { x: { label: 'Region' }, y: { label: 'Population' } },
+      data: [
+        { x: 'France', y: 67, path: ['Europe'] },
+        { x: 'Japan', y: 125, path: ['Asia'] },
+      ],
+    },
+  },
+  {
+    type: TraceType.BOXEN,
+    declared: 2,
+    layer: {
+      axes: { x: { label: 'Group' }, y: { label: 'Milliseconds' } },
+      data: [
+        { z: 'light', median: 50, levels: [{ p: 0.25, lo: 45, hi: 55 }] },
+        { z: 'heavy', median: 80, levels: [{ p: 0.25, lo: 70, hi: 90 }] },
+      ],
+    },
+  },
+  {
+    type: TraceType.CHOROPLETH,
+    declared: 2,
+    layer: {
+      axes: { x: { label: 'State' }, y: { label: 'Rate' } },
+      data: [
+        { x: 'Washington', y: 10, lat: 47.4, lon: -120.5, neighbors: ['Oregon'] },
+        { x: 'Oregon', y: 20, lat: 43.9, lon: -120.6, neighbors: ['Washington'] },
+      ],
+    },
+  },
+  {
+    type: TraceType.GANTT,
+    declared: 2,
+    layer: {
+      axes: { x: { label: 'Task' }, y: { label: 'Day' } },
+      data: {
+        points: [
+          [{ x: 'Design', start: 0, end: 10 }],
+          [{ x: 'Build', start: 10, end: 30 }],
+        ],
+      },
+    },
+  },
 ];
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

`Svg.selectAllElements(selector)` inserts a hidden `data-maidr-owned` clone beside every match *before* a trace decides whether it can use them. Several traces then bail out (`return null` on a count mismatch) or keep only a subset, so the rest are orphaned: `AbstractTrace.dispose()` walks `highlightValues` and never reaches them. They accumulate across focus cycles and live-data rebuilds, and because they are inserted as siblings they shift positional (`:nth-child`) selectors on the next resolution, which is the #1004 failure mode. Separately, four traces truncate the layer's data array on dispose without having copied it, destroying the caller's spec so a rebuilt figure comes up empty.

A codebase audit found these; each fix has a jsdom test that counts `[data-maidr-owned]` elements before and after `dispose()` and after a second construction.

## Related Issues

Related to #1004 (positional selectors resolving against earlier clones) and the bar-family fix pinned by `test/model/barInputMutation.test.ts`.

## Changes Made

- **box, violin box, violin KDE, heatmap**: copy the layer data (`points`, heatmap `x`) on construction, as the horizontal branches already did, so `dispose()` no longer empties the caller's `layer.data`. `barInputMutation.test.ts` now covers these four types.
- **waterfall, error bar, dumbbell, gauge, treemap, boxen, choropleth, gantt, flow, network**: resolve live elements first (`shouldClone = false`), check the count, then `Svg.cloneHidden` only when it fits. A mismatched selector no longer leaves N hidden copies in the chart, and a repeated construction no longer double-matches.
- **segmented**: clone a mark only when a cell claims it, so a selector matching more marks than there are cells no longer orphans the surplus.
- **flow, network**: override `dispose()` to remove every ribbon/link clone, not just the one per node that the highlight references.
- **scatter**: `dispose()` removes every clone through the full selected list (a marker whose coordinates could not be read was in neither the column nor the row grouping) and clears the grid-cell, cell-group and centre caches that pinned detached elements.
- **candlestick**: derive an "open" edge line only on a chart that has an open row; on a mixed chart it was inserted but never referenced, so it survived dispose.
- **figure/subplot**: when a later layer's `TraceFactory.create` throws, dispose the traces and subplots already built so their clones do not stay in the DOM.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint`, `npm run type-check`, `npm test` and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_