### PR TITLE
fix(candlestick): use one row/col frame in both orientations

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -436,7 +436,7 @@ export class Controller implements Disposable {
    * @returns The column shift to apply during position restoration
    */
   private resolveActiveColShift(appended?: AppendedPointInfo): number {
-    if (!appended || appended.trimmed === 0 || appended.trimShift !== 'col') {
+    if (!appended || appended.trimmed === 0) {
       return 0;
     }
     try {

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -199,10 +199,14 @@ export class Candlestick extends AbstractTrace {
     this.candleValues = this.sections.map(key =>
       this.candles.map(c => this.priceOf(c, key)),
     );
-    const options = this.orientation === Orientation.HORIZONTAL
-      ? { col: this.sections.length - 1 }
-      : { row: this.sections.length - 1 };
-    this.movable = new MovableGrid<number>(this.candleValues, options);
+    // The grid is [section][candle] in BOTH orientations: the highlight
+    // grid (mapToSvgElements), the braille cell (get braille) and the
+    // MovableGrid bounds are all laid out that way, and the cursor has to
+    // agree with them. Orientation only changes which screen axis the
+    // candles run along, which is the concern of `text` and of panning.
+    this.movable = new MovableGrid<number>(this.candleValues, {
+      row: this.sections.length - 1,
+    });
 
     this.min = MathUtil.minFrom2D(this.candleValues);
     this.max = MathUtil.maxFrom2D(this.candleValues);
@@ -233,11 +237,7 @@ export class Candlestick extends AbstractTrace {
     this.currentSegmentType = 'close';
 
     // Initialize visual positioning for highlighting (keep original structure)
-    if (this.orientation === Orientation.HORIZONTAL) {
-      this.col = 0; // Points to 'open' segment index in sections array
-    } else {
-      this.row = 0; // Points to 'open' segment index in sections array
-    }
+    this.row = 0; // Points to 'open' segment index in sections array
 
     this.highlightValues = this.mapToSvgElements(
       layer.selectors as string | string[] | CandlestickSelector | undefined,
@@ -353,25 +353,17 @@ export class Candlestick extends AbstractTrace {
   private updateVisualSegmentPosition(): void {
     // Use the sorted navigation order (with volatility first)
     const navOrder = this.sortedSegmentsByPoint[this.currentPointIndex];
-    const dynamicSegmentPosition = navOrder.indexOf(
-      this.currentSegmentType ?? this.sections[0],
-    );
-    if (this.orientation === Orientation.HORIZONTAL) {
-      this.col = dynamicSegmentPosition;
-    } else {
-      this.row = dynamicSegmentPosition;
-    }
+    // The row is the segment's value-sorted position in both orientations;
+    // see the constructor for why the frame does not follow the layout.
+    this.row = navOrder.indexOf(this.currentSegmentType ?? this.sections[0]);
   }
 
   /**
    * Updates visual position for point highlighting and segment position
    */
   protected override updateVisualPointPosition(): void {
-    if (this.orientation === Orientation.HORIZONTAL) {
-      this.row = this.currentPointIndex;
-    } else {
-      this.col = this.currentPointIndex;
-    }
+    // The col is the candle index in both orientations.
+    this.col = this.currentPointIndex;
 
     // Also update segment position since candlestick needs both
     this.updateVisualSegmentPosition();
@@ -520,12 +512,7 @@ export class Candlestick extends AbstractTrace {
     this.isComputingStateAt = true;
     try {
       const { pointIndex, segmentType }
-        = this.navigationService.computeIndexAndSegment(
-          row,
-          col,
-          this.orientation,
-          this.sections,
-        );
+        = this.navigationService.computeIndexAndSegment(row, col, this.sections);
       this.currentPointIndex = pointIndex;
       this.currentSegmentType = segmentType;
       return super.getStateAt(row, col);
@@ -540,6 +527,14 @@ export class Candlestick extends AbstractTrace {
   }
 
   public override moveToIndex(row: number, col: number): boolean {
+    // The cell is [section][candle], the shape of the grid; a cell the chart
+    // does not have is refused here rather than indexing past the candles
+    // below, which threw out of the braille cursor handler.
+    if (!this.isMovable([row, col])) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
     // Delegate navigation logic to service and only handle data state updates
     if (this.isInitialEntry) {
       this.handleInitialEntry();
@@ -547,12 +542,7 @@ export class Candlestick extends AbstractTrace {
 
     // Use navigation service to compute the mapping
     const { pointIndex, segmentType }
-      = this.navigationService.computeIndexAndSegment(
-        row,
-        col,
-        this.orientation,
-        this.sections,
-      );
+      = this.navigationService.computeIndexAndSegment(row, col, this.sections);
 
     // Update Core Model state
     this.currentPointIndex = pointIndex;
@@ -677,7 +667,6 @@ export class Candlestick extends AbstractTrace {
   }
 
   protected get audio(): AudioState {
-    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
     const candleCount = this.candles.length;
     const sectionCount = this.candleValues.length;
     // `?? this.sections[0]` rather than `?? 'open'`: the fallback has to be
@@ -696,12 +685,11 @@ export class Candlestick extends AbstractTrace {
         raw: value,
       },
       panning: {
-        // x is the candle index in both orientations (this.col vertical,
-        // this.row horizontal); rows/cols describe the grid shape
-        // (sections x candles) independent of orientation, so panning pans by
-        // candle position regardless of how many candles the chart holds.
-        x: isHorizontal ? this.row : this.col,
-        y: isHorizontal ? this.col : this.row,
+        // x is the candle index (this.col) in both orientations, so a
+        // horizontal chart still pans by candle; rows/cols describe the grid
+        // shape (sections x candles), which is also orientation-independent.
+        x: this.col,
+        y: this.row,
         rows: sectionCount,
         cols: candleCount,
       },
@@ -717,8 +705,7 @@ export class Candlestick extends AbstractTrace {
     //
     // This getter must stay side-effect free: it runs on every state emission
     // (AbstractTrace.state) and during getStateAt, so mutating this.row/col
-    // here would corrupt the highlight computed alongside it (and, for
-    // horizontal charts, clobber the candle index this.row holds). All heavy
+    // here would corrupt the highlight computed alongside it. All heavy
     // data (per-row min/max, trends) is precomputed in the constructor.
     return {
       empty: false,
@@ -1192,11 +1179,8 @@ export class Candlestick extends AbstractTrace {
       this.handleInitialEntry();
     }
 
-    // Drive off currentPointIndex, which is the candle index in BOTH
-    // orientations. Reading this.col directly is only correct in the vertical
-    // layout — in the horizontal layout this.col holds the segment position
-    // and this.row holds the candle index (see updateVisualPointPosition).
-    // updateVisualPointPosition() maps currentPointIndex back to row/col.
+    // Drive off currentPointIndex, the candle index the navigation state
+    // keeps; updateVisualPointPosition() maps it back to this.col.
     const currentIndex = this.currentPointIndex;
     if (currentIndex < 0 || currentIndex >= this.candles.length) {
       return false;

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -185,7 +185,13 @@ export class Candlestick extends AbstractTrace {
       // not a neutral by default, which would announce that the price
       // finished where it started on a chart that never said where it
       // started.
-      trend: candle.open === undefined
+      //
+      // Gated on the chart's `hasOpen` rather than on this candle's open:
+      // the sections, the braille shading, the data table and the pattern
+      // asides all follow the chart, so on a chart with an open for only
+      // some candles a per-candle trend would be announced and sonified for
+      // candles whose braille row and table say there is no body.
+      trend: !this.hasOpen || candle.open === undefined
         ? undefined
         : candle.close > candle.open
           ? 'Bull'

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -16,7 +16,7 @@ import type {
   ViolinKdePoint,
 } from '@type/grammar';
 import { candlestickSectionsOf } from '@model/candlestick';
-import { Orientation, TraceType } from '@type/grammar';
+import { TraceType } from '@type/grammar';
 
 /**
  * Trace types whose layer data is a nested array of groups
@@ -91,12 +91,6 @@ export interface AppendedPointInfo {
    * rows are OHLC sections).
    */
   nested: boolean;
-  /**
-   * Which trace axis a sliding-window trim shifts: 'col' when columns index
-   * data points, 'none' when the point axis is not the column axis (e.g.
-   * horizontal candlesticks) and no cursor shift should be applied.
-   */
-  trimShift: 'col' | 'none';
 }
 
 /**
@@ -207,7 +201,6 @@ export function appendPointToMaidr(
   let col: number;
   let trimmed: number;
   let nested: boolean;
-  let trimShift: 'col' | 'none' = 'col';
 
   // Nested layers are detected by trace type so that an initially empty
   // outer array (`data: []`) still gets the correct `LiveDataPoint[][]`
@@ -254,18 +247,11 @@ export function appendPointToMaidr(
       // superset. A chart drawn without an opening price has four rows, not
       // five, so the static index of `close` is past the last row it has and
       // the announcement would target one that does not exist (#1188).
-      const closeSection = candlestickSectionsOf(
-        newData as CandlestickPoint[],
-      ).indexOf('close');
-      if (layer.orientation === Orientation.HORIZONTAL) {
-        // Horizontal layout: rows index candles, columns index sections —
-        // a window trim shifts rows, so no column shift applies.
-        row = col;
-        col = closeSection;
-        trimShift = 'none';
-      } else {
-        row = closeSection;
-      }
+      //
+      // Rows index sections and columns index candles in both orientations
+      // (see the Candlestick constructor), so the same cell is targeted
+      // whichever way the chart is drawn.
+      row = candlestickSectionsOf(newData as CandlestickPoint[]).indexOf('close');
     }
   }
 
@@ -297,7 +283,6 @@ export function appendPointToMaidr(
       col,
       trimmed,
       nested,
-      trimShift,
     },
   };
 }

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -3,7 +3,6 @@ import type { Disposable } from '@type/disposable';
 import type { MovableDirection } from '@type/movable';
 import type { PointWithX, ValuesArray, XValue } from '@type/navigation';
 import type { LayerSwitchTraceState } from '@type/state';
-import { Orientation } from '@type/grammar';
 import { hasXProperty, isPointWithX, isXValue } from '@type/navigation';
 
 /**
@@ -66,61 +65,29 @@ export class NavigationService implements Disposable {
   }
 
   /**
-   * Compute normalized point index and segment type based on orientation
+   * Compute the point index and segment type a grid cell names.
+   *
+   * The cell is `[section][point]` in every orientation: the highlight grid,
+   * the braille cell and the movable grid of a sectioned trace all share
+   * that frame, and the orientation only says which screen axis the points
+   * run along.
    * @param row The row coordinate from UI/ViewModel
    * @param col The column coordinate from UI/ViewModel
-   * @param orientation The data orientation
    * @param sections Array of available section names (e.g., ['open', 'high', 'low', 'close'])
    * @returns Object containing pointIndex and segmentType
    */
   public computeIndexAndSegment<T extends string>(
     row: number,
     col: number,
-    orientation: Orientation,
     sections: readonly T[],
   ): {
     pointIndex: number;
     segmentType: T;
   } {
-    if (orientation === Orientation.HORIZONTAL) {
-      return {
-        pointIndex: row,
-        segmentType: sections[col],
-      };
-    } else {
-      return {
-        pointIndex: col,
-        segmentType: sections[row],
-      };
-    }
-  }
-
-  /**
-   * Compute visual coordinates for highlighting based on orientation
-   * @param pointIndex The data point index
-   * @param segmentPosition The segment position (e.g., dynamic sorted position)
-   * @param orientation The data orientation
-   * @returns Object containing row and col for visual highlighting
-   */
-  public computeVisualCoordinates(
-    pointIndex: number,
-    segmentPosition: number,
-    orientation: Orientation,
-  ): {
-    row: number;
-    col: number;
-  } {
-    if (orientation === Orientation.HORIZONTAL) {
-      return {
-        row: pointIndex,
-        col: segmentPosition,
-      };
-    } else {
-      return {
-        row: segmentPosition,
-        col: pointIndex,
-      };
-    }
+    return {
+      pointIndex: col,
+      segmentType: sections[row],
+    };
   }
 
   /**

--- a/test/model/candlestickCompareOrientation.test.ts
+++ b/test/model/candlestickCompareOrientation.test.ts
@@ -63,30 +63,31 @@ describe('candlestick compare navigation is orientation-independent', () => {
     // Default entry segment is 'close'; start at d0 (close 10).
     expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
     expect(currentDate(trace)).toBe('d2'); // close 12, skipping d1 (8)
-    expect(trace.col).toBe(2); // candle index lives in col when vertical
+    expect(trace.col).toBe(2); // the candle index lives in col
   });
 
   test('horizontal: moveRight/higher lands on the same candle as vertical', () => {
-    // Regression guard for the orientation bug: before the fix this read
-    // this.col (the segment position in horizontal layout) as the candle
-    // index and jumped to the wrong candle.
+    // Regression guard for the orientation bug: the compare search once read
+    // the cursor's grid coordinate as the candle index while the horizontal
+    // layout stored the cursor the other way round, and jumped to the wrong
+    // candle. The search now drives off the navigation state, and the cursor
+    // frame is [section][candle] in both layouts.
     const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
     expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
     expect(currentDate(trace)).toBe('d2');
-    expect(trace.row).toBe(2); // candle index lives in row when horizontal
+    expect(trace.col).toBe(2); // the candle index lives in col in both layouts
   });
 
   test('horizontal: moveRight/lower finds the next lower-close candle', () => {
     const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
     expect(trace.moveToNextCompareValue('right', 'lower')).toBe(true);
     expect(currentDate(trace)).toBe('d1'); // close 8 < 10
-    expect(trace.row).toBe(1);
+    expect(trace.col).toBe(1);
   });
 
   test('horizontal: compare works after navigating in, not only from entry', () => {
-    // Exercises the currentPointIndex path from a moved position (this.col
-    // holds the segment index here, this.row the candle index), so it guards
-    // the fix independently of the initial-entry code path.
+    // Exercises the currentPointIndex path from a moved position, so it
+    // guards the fix independently of the initial-entry code path.
     const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
     trace.moveOnce('FORWARD'); // initial entry -> d0
     trace.moveOnce('FORWARD'); // d0 -> d1
@@ -95,7 +96,7 @@ describe('candlestick compare navigation is orientation-independent', () => {
     // From d1 (close 8) the next higher close to the right is d2 (12).
     expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
     expect(currentDate(trace)).toBe('d2');
-    expect(trace.row).toBe(2);
+    expect(trace.col).toBe(2);
   });
 
   test('horizontal: boundary returns false and stays on the current candle', () => {

--- a/test/model/candlestickHorizontalFrame.test.ts
+++ b/test/model/candlestickHorizontalFrame.test.ts
@@ -1,0 +1,277 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * A horizontal candlestick uses the same (row, col) frame as a vertical one.
+ *
+ * Everything that consumes a candlestick's cursor -- the highlight grid, the
+ * braille cell the display routes a cursor press back through, and the
+ * movable grid's bounds -- is laid out `[segment position][candle index]`
+ * regardless of orientation. The horizontal layout used to store the cursor
+ * the other way round (row = candle, col = segment), so on such a chart the
+ * highlight landed on the wrong element, or on none for a candle past the
+ * section count; a braille cursor press landed on the wrong candle and the
+ * wrong segment; and on a short chart it threw out of the braille handler.
+ */
+
+import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { Candlestick, CANDLESTICK_SECTIONS } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const CANDLE_ATTRIBUTE = 'data-candle';
+const CLOSE_ROW = CANDLESTICK_SECTIONS.indexOf('close');
+
+/**
+ * Renders one `rect` per candle under `#candles`, each stamped with its
+ * index so a highlighted clone can say which candle it was cut from.
+ * @param count - How many candles to draw
+ */
+function renderCandles(count: number): void {
+  document.body.innerHTML = '';
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+  const group = document.createElementNS(SVG_NAMESPACE, 'g');
+  group.setAttribute('id', 'candles');
+  for (let i = 0; i < count; i++) {
+    const rect = document.createElementNS(SVG_NAMESPACE, 'rect');
+    rect.setAttribute(CANDLE_ATTRIBUTE, String(i));
+    group.appendChild(rect);
+  }
+  svg.appendChild(group);
+  document.body.appendChild(svg);
+}
+
+/**
+ * Builds a rising candle so every candle has the same sorted segment order
+ * and the trend is a known Bull.
+ * @param index - The candle's position, which also names it (`d<index>`)
+ * @returns A candlestick point
+ */
+function candle(index: number): CandlestickPoint {
+  const open = 10 + index;
+  return {
+    value: `d${index}`,
+    open,
+    high: open + 3,
+    low: open - 1,
+    close: open + 2,
+    volume: 100,
+    trend: 'Bull',
+    volatility: 4,
+  };
+}
+
+/**
+ * Creates a candlestick layer of `count` candles in the given orientation,
+ * with a legacy (single-selector) highlight.
+ * @param orientation - Vertical or horizontal layout
+ * @param count - How many candles the chart has
+ * @returns A candlestick layer definition
+ */
+function makeLayer(orientation: Orientation, count: number): MaidrLayer {
+  return {
+    id: 'candle',
+    type: TraceType.CANDLESTICK,
+    orientation,
+    selectors: '#candles > rect',
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: Array.from({ length: count }, (_, i) => candle(i)),
+  };
+}
+
+/**
+ * The candle index stamped on the currently highlighted element, or `null`
+ * when the trace reports no highlight at all.
+ * @param trace - The trace to inspect
+ * @returns The `data-candle` value of the highlighted element
+ */
+function highlightedCandle(trace: Candlestick): string | null {
+  const state = trace.state;
+  if (state.empty || state.highlight.empty) {
+    return null;
+  }
+  const { elements } = state.highlight;
+  const element = Array.isArray(elements) ? elements[0] : elements;
+  return element.getAttribute(CANDLE_ATTRIBUTE);
+}
+
+/**
+ * The candle and segment the cursor currently announces.
+ * @param trace - The trace to inspect
+ * @returns The current candle's value and section, or `undefined` when empty
+ */
+function announced(
+  trace: Candlestick,
+): { candle: unknown; section: unknown } | undefined {
+  const state = trace.state;
+  return state.empty
+    ? undefined
+    : { candle: state.text.main.value, section: state.text.section };
+}
+
+/**
+ * The braille cell the current cursor reports, as the display would read it.
+ * @param trace - The trace to inspect
+ * @returns The braille row and col
+ */
+function brailleCell(trace: Candlestick): { row: number; col: number } {
+  const state = trace.state;
+  if (state.empty || state.braille.empty) {
+    throw new Error('expected a braille state');
+  }
+  return { row: state.braille.row, col: state.braille.col };
+}
+
+describe('highlighting a horizontal candlestick through a legacy selector', () => {
+  const COUNT = 7;
+
+  beforeEach(() => {
+    renderCandles(COUNT);
+  });
+
+  test('outlines the element of the candle the cursor is on', () => {
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, COUNT));
+
+    // A legacy selector maps candle k to element k in every section, so
+    // walking the candles must walk the elements in step. The walk starts
+    // with the initial-entry move, which lands on candle 0.
+    const seen: (string | null)[] = [];
+    trace.moveOnce('FORWARD');
+    seen.push(highlightedCandle(trace));
+    for (let i = 1; i < COUNT; i++) {
+      trace.moveOnce('FORWARD');
+      seen.push(highlightedCandle(trace));
+    }
+
+    expect(seen).toEqual(['0', '1', '2', '3', '4', '5', '6']);
+  });
+
+  test('outlines a candle whose index is past the section count', () => {
+    // Five sections; candles 5 and 6 are only reachable as columns. Stored
+    // as rows they were past the end of the grid and got no highlight.
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, COUNT));
+
+    trace.moveToExtreme('FORWARD');
+
+    expect(highlightedCandle(trace)).toBe('6');
+  });
+
+  test('outlines the same element a vertical chart does', () => {
+    const horizontal = new Candlestick(makeLayer(Orientation.HORIZONTAL, COUNT));
+    renderCandles(COUNT);
+    const vertical = new Candlestick(makeLayer(Orientation.VERTICAL, COUNT));
+
+    horizontal.moveToIndex(CLOSE_ROW, 5);
+    vertical.moveToIndex(CLOSE_ROW, 5);
+
+    expect(highlightedCandle(horizontal)).toBe('5');
+    expect(highlightedCandle(horizontal)).toBe(highlightedCandle(vertical));
+  });
+});
+
+describe('a braille cursor press on a horizontal candlestick', () => {
+  beforeEach(() => {
+    renderCandles(7);
+  });
+
+  test('lands on the close of the pressed candle', () => {
+    // The braille display routes a press back through moveToIndex with the
+    // cell it reported: row = static section index, col = candle index. On
+    // a horizontal chart that used to be read the other way round, landing
+    // on candle 4 in the volatility section.
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, 7));
+
+    trace.moveToIndex(CLOSE_ROW, 6);
+
+    expect(announced(trace)).toEqual({ candle: 'd6', section: 'close' });
+  });
+
+  test('reports back the cell it was sent to', () => {
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, 7));
+
+    trace.moveToIndex(CLOSE_ROW, 6);
+
+    expect(brailleCell(trace)).toEqual({ row: CLOSE_ROW, col: 6 });
+  });
+
+  test('does not throw on a chart with fewer candles than sections', () => {
+    // Read as a candle index, the close row (4) named a candle a 3-candle
+    // chart does not have, and the sorted-segment lookup threw a TypeError
+    // out of the braille handler.
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, 3));
+
+    expect(() => trace.moveToIndex(CLOSE_ROW, 1)).not.toThrow();
+    expect(announced(trace)).toEqual({ candle: 'd1', section: 'close' });
+  });
+
+  test('refuses a cell the chart does not have rather than throwing', () => {
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, 3));
+
+    expect(trace.moveToIndex(CLOSE_ROW, 3)).toBe(false);
+    expect(trace.moveToIndex(CANDLESTICK_SECTIONS.length, 0)).toBe(false);
+  });
+});
+
+describe('the movable grid of a horizontal candlestick', () => {
+  beforeEach(() => {
+    renderCandles(7);
+  });
+
+  test('accepts the cursor position the trace itself is on', () => {
+    // On the last of seven candles the horizontal cursor used to sit at
+    // row 6 -- past the five sections -- so the trace's own position was
+    // one isMovable rejected.
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL, 7));
+
+    trace.moveToExtreme('FORWARD');
+
+    expect(trace.isMovable([trace.row, trace.col])).toBe(true);
+  });
+
+  test('is on the same cell as a vertical chart after the same moves', () => {
+    const horizontal = new Candlestick(makeLayer(Orientation.HORIZONTAL, 7));
+    const vertical = new Candlestick(makeLayer(Orientation.VERTICAL, 7));
+
+    for (const trace of [horizontal, vertical]) {
+      trace.moveToExtreme('FORWARD');
+      trace.moveOnce('DOWNWARD');
+    }
+
+    expect([horizontal.row, horizontal.col]).toEqual([vertical.row, vertical.col]);
+    expect(horizontal.col).toBe(6);
+  });
+
+  test('bounds a section row and a candle column the same way in both layouts', () => {
+    const horizontal = new Candlestick(makeLayer(Orientation.HORIZONTAL, 7));
+    const vertical = new Candlestick(makeLayer(Orientation.VERTICAL, 7));
+
+    expect(horizontal.isMovable([CLOSE_ROW, 6])).toBe(vertical.isMovable([CLOSE_ROW, 6]));
+    expect(horizontal.isMovable([6, CLOSE_ROW])).toBe(vertical.isMovable([6, CLOSE_ROW]));
+    expect(horizontal.isMovable([CLOSE_ROW, 6])).toBe(true);
+  });
+});
+
+describe('audio panning of a horizontal candlestick', () => {
+  beforeEach(() => {
+    renderCandles(7);
+  });
+
+  test('pans by candle index, as the vertical chart does', () => {
+    const horizontal = new Candlestick(makeLayer(Orientation.HORIZONTAL, 7));
+    const vertical = new Candlestick(makeLayer(Orientation.VERTICAL, 7));
+
+    horizontal.moveToIndex(CLOSE_ROW, 5);
+    vertical.moveToIndex(CLOSE_ROW, 5);
+    const h = horizontal.state;
+    const v = vertical.state;
+    if (h.empty || v.empty) {
+      throw new Error('expected populated states');
+    }
+
+    expect(h.audio.panning).toEqual(v.audio.panning);
+    expect(h.audio.panning.x).toBe(5);
+    expect(h.audio.panning.cols).toBe(7);
+  });
+});

--- a/test/model/candlestickNoOpen.test.ts
+++ b/test/model/candlestickNoOpen.test.ts
@@ -216,6 +216,58 @@ describe('what a chart without an open lets a reader reach', () => {
   });
 });
 
+describe('a chart where only some candles record an open', () => {
+  // The rows are a property of the chart, so a series with an open for some
+  // periods and not others is read as the high-low-close it can be read as
+  // throughout: no open row, no trend column, no shading. The candles that
+  // do have an open must not carry a trend on their own, or the reader hears
+  // a body direction for a candle on a chart the rest of the model says has
+  // no bodies.
+  const MIXED = [WITH_OPEN[0], WITHOUT_OPEN[1], WITH_OPEN[2]];
+
+  /** The populated state on the first candle, which does record an open. */
+  function stateOnOpenedCandle(trace: Candlestick) {
+    const state = trace.state;
+    if (state.empty || state.braille.empty) {
+      throw new Error('expected a populated state');
+    }
+    // Returned field by field so the narrowing of `braille` survives.
+    return { text: state.text, audio: state.audio, braille: state.braille };
+  }
+
+  test('reads it as a chart with no open', () => {
+    expect(candlestickSectionsOf(MIXED)).not.toContain('open');
+  });
+
+  test('announces no trend on a candle that does have an open', () => {
+    const { text } = stateOnOpenedCandle(new Candlestick(layerOf(MIXED)));
+
+    expect(text.z).toBeUndefined();
+  });
+
+  test('plays no trend palette on it either', () => {
+    const { audio } = stateOnOpenedCandle(new Candlestick(layerOf(MIXED)));
+
+    expect(audio.trend).toBeUndefined();
+  });
+
+  test('offers no trend rotor unit', () => {
+    const labels = new Candlestick(layerOf(MIXED))
+      .getRotorFilterUnits()
+      .map(unit => unit.label);
+
+    expect(labels).not.toContain(BULLISH_POINT_MODE);
+    expect(labels).not.toContain(BEARISH_POINT_MODE);
+    expect(labels).not.toContain(NEUTRAL_POINT_MODE);
+  });
+
+  test('shades the braille with no trend markers, as the sections say', () => {
+    const { braille } = stateOnOpenedCandle(new Candlestick(layerOf(MIXED)));
+
+    expect(braille.custom).toStrictEqual([]);
+  });
+});
+
 describe('the sections one chart has', () => {
   test('is the superset where every candle records an open', () => {
     expect(candlestickSectionsOf(WITH_OPEN)).toEqual([...CANDLESTICK_SECTIONS]);

--- a/test/service/liveData.test.ts
+++ b/test/service/liveData.test.ts
@@ -173,7 +173,6 @@ describe('appendPointToMaidr', () => {
       col: 2,
       trimmed: 0,
       nested: false,
-      trimShift: 'col',
     });
   });
 
@@ -213,7 +212,6 @@ describe('appendPointToMaidr', () => {
     const result = appendPointToMaidr(maidr, { x: 3, y: 30 });
 
     expect(result!.appended.nested).toBe(true);
-    expect(result!.appended.trimShift).toBe('col');
   });
 
   test('appends a full OHLC candle to a candlestick layer', () => {
@@ -240,7 +238,6 @@ describe('appendPointToMaidr', () => {
     expect(result!.appended.row).toBe(4);
     expect(result!.appended.col).toBe(2);
     expect(result!.appended.nested).toBe(false);
-    expect(result!.appended.trimShift).toBe('col');
   });
 
   test('applies the maxWidth sliding window to candlestick data', () => {
@@ -601,7 +598,6 @@ function createAppended(overrides: Partial<AppendedPointInfo> = {}): AppendedPoi
     col: 1,
     trimmed: 0,
     nested: false,
-    trimShift: 'col',
     ...overrides,
   };
 }


### PR DESCRIPTION
# Pull Request

## Description

A horizontal candlestick stored its cursor as `row = candle, col = segment`, while every consumer of `(row, col)` reads the opposite frame regardless of orientation: the highlight grid is built `[segment][candle]` in both, `AbstractTrace.highlight` indexes `highlightValues[row][col]`, the braille state reports `row = section, col = candle` and `BrailleService` feeds those straight back into `moveToIndex`, and `MovableGrid.isMovable` bounds rows by sections. Orientation only decides which screen axis the candles run along, which is a concern of the text and the panning, not of the cursor.

Found in a codebase audit and confirmed against a 7-candle horizontal chart.

## Related Issues

Builds on the horizontal-candlestick handling from #1188.

## Changes Made

- **candlestick**: the cursor is `row = value-sorted segment position, col = candle index` in both orientations. This fixes three consequences of the old split frame on a horizontal chart:
  - the highlight resolved to the wrong element, and candles past the section count got no highlight at all;
  - a braille cursor-routing move landed on the wrong candle and the wrong segment, and on a chart with fewer candles than sections it threw a `TypeError` out of the `selectionchange` handler;
  - `isMovable` disagreed with `moveToIndex` about which coordinate was bounded by what.
  `moveToIndex` now refuses a cell outside the grid and reports out of bounds instead of indexing past the candles. `audio.panning` keeps panning by candle in both layouts.
- **navigation**: `computeIndexAndSegment` no longer takes an orientation, since the cell is `[section][point]` in every orientation; the unused `computeVisualCoordinates` is removed with it.
- **liveData**: the horizontal-candlestick row/col swap for monitor announcements is gone, and with it `AppendedPointInfo.trimShift`, which existed only to suppress the cursor shift that swap made wrong.
- **candlestick**: the per-candle trend is gated on the chart's `hasOpen`, so a chart with an open for only some candles no longer announces and sonifies a body direction for candles its braille shading, data table and section list say have no body.

`test/model/candlestickCompareOrientation.test.ts` pinned the inconsistent frame (it asserted the candle index lives in `row` when horizontal); it now asserts `col` in both layouts, as the commit body explains.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint`, `npm run type-check`, `npm test` (6474 + 143) and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_