### PR TITLE
fix(command): announce the reader's real position and hand the rotor back when leaving a trace

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -691,7 +691,7 @@ export class AnnouncePositionCommand extends AnnounceCommand {
     // Check for special chart types
     const traceType = state.traceType;
 
-    if (traceType === TraceType.BOX) {
+    if (traceType === TraceType.BOX || traceType === TraceType.VIOLIN_BOX) {
       this.announceBoxplotPosition(state);
     } else if (traceType === TraceType.PIE) {
       this.announcePiePosition(state);

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -5,7 +5,7 @@ import type { HighlightService } from '@service/highlight';
 import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
-import type { BarBrailleState, BoxBrailleState, LineBrailleState, NonEmptyTraceState } from '@type/state';
+import type { BarBrailleState, BoxBrailleState, FigureState, LineBrailleState, NonEmptyTraceState } from '@type/state';
 import type { Command } from './command';
 import { focusedSubplotTitle } from '@model/plot';
 import { Scope } from '@type/event';
@@ -670,13 +670,19 @@ export class AnnouncePositionCommand extends AnnounceCommand {
     const state = this.context.state;
 
     // Handle no data case
-    if (state.empty || state.type !== 'trace') {
+    if (state.empty || (state.type !== 'trace' && state.type !== 'figure')) {
       this.textViewModel.update('Not in a chart, unable to show position.');
       return;
     }
 
     // Warn if text mode is off instead of announcing position
     if (this.textViewModel.warnIfTextOff()) {
+      return;
+    }
+
+    // Multi-panel lobby: the position is which subplot is focused
+    if (state.type === 'figure') {
+      this.announceFigurePosition(state);
       return;
     }
 
@@ -749,6 +755,23 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       this.announce2DPosition(x, y, rows, cols);
     } else {
       this.announce1DPosition(x, cols);
+    }
+  }
+
+  /**
+   * Announces which subplot is focused at the multi-panel lobby.
+   *
+   * The lobby binds the position key and lists it in help, so it has to
+   * answer with the position the figure state already carries rather than
+   * refuse. Terse keeps the two numbers and drops the label word, the way the
+   * trace-level readings keep the percentage and drop "Position is".
+   * @param state - The populated figure state
+   */
+  private announceFigurePosition(state: Extract<FigureState, { empty: false }>): void {
+    if (this.textService.isTerse() || this.textService.isOff()) {
+      this.textViewModel.update(`${state.index} of ${state.size}`);
+    } else {
+      this.textViewModel.update(`Subplot ${state.index} of ${state.size}`);
     }
   }
 

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -5,7 +5,7 @@ import type { HighlightService } from '@service/highlight';
 import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
-import type { BarBrailleState, BoxBrailleState, FigureState, LineBrailleState, NonEmptyTraceState } from '@type/state';
+import type { BarBrailleState, BoxBrailleState, BrailleState, FigureState, LineBrailleState, NonEmptyTraceState } from '@type/state';
 import type { Command } from './command';
 import { focusedSubplotTitle } from '@model/plot';
 import { Scope } from '@type/event';
@@ -612,6 +612,23 @@ export class AnnouncePointCommand extends AnnounceCommand {
  * for a horizontal chart. The position announcement reads the former for
  * these; see {@link AnnouncePositionCommand.navigationPosition}.
  */
+/**
+ * Whether a braille state carries a row-of-rows grid, the shape
+ * {@link AnnouncePositionCommand.navigationPosition} reads a position out of.
+ *
+ * Checked rather than asserted: every trace in {@link BAR_FAMILY} is
+ * registered against the bar encoder today, but nothing in the type system
+ * ties the two lists together, and a trace added to one and not the other
+ * would otherwise read a position out of a state that has no grid in it.
+ * @param braille - The trace's braille state
+ * @returns True when the state has a `values` grid to index
+ */
+function isGridBrailleState(braille: BrailleState): braille is BarBrailleState {
+  return !braille.empty
+    && Array.isArray((braille as BarBrailleState).values)
+    && Array.isArray((braille as BarBrailleState).values[0]);
+}
+
 const BAR_FAMILY: ReadonlySet<TraceType> = new Set([
   TraceType.BAR,
   TraceType.DOT,
@@ -794,13 +811,12 @@ export class AnnouncePositionCommand extends AnnounceCommand {
   private navigationPosition(
     state: NonEmptyTraceState,
   ): { x: number; y: number; rows: number; cols: number } {
-    if (BAR_FAMILY.has(state.traceType) && !state.braille.empty) {
-      const braille = state.braille as BarBrailleState;
+    if (BAR_FAMILY.has(state.traceType) && isGridBrailleState(state.braille)) {
       return {
-        x: braille.col,
-        y: braille.row,
-        rows: braille.values.length,
-        cols: braille.values[braille.row]?.length ?? 0,
+        x: state.braille.col,
+        y: state.braille.row,
+        rows: state.braille.values.length,
+        cols: state.braille.values[state.braille.row]?.length ?? 0,
       };
     }
     return state.audio.panning;

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -607,12 +607,6 @@ export class AnnouncePointCommand extends AnnounceCommand {
 }
 
 /**
- * The traces built on `AbstractBarPlot`, whose braille state is
- * `values[row][col]` normalised to the bar axis and whose audio panning swaps
- * for a horizontal chart. The position announcement reads the former for
- * these; see {@link AnnouncePositionCommand.navigationPosition}.
- */
-/**
  * Whether a braille state carries a row-of-rows grid, the shape
  * {@link AnnouncePositionCommand.navigationPosition} reads a position out of.
  *
@@ -629,6 +623,12 @@ function isGridBrailleState(braille: BrailleState): braille is BarBrailleState {
     && Array.isArray((braille as BarBrailleState).values[0]);
 }
 
+/**
+ * The traces built on `AbstractBarPlot`, whose braille state is
+ * `values[row][col]` normalised to the bar axis and whose audio panning swaps
+ * for a horizontal chart. The position announcement reads the former for
+ * these; see {@link AnnouncePositionCommand.navigationPosition}.
+ */
 const BAR_FAMILY: ReadonlySet<TraceType> = new Set([
   TraceType.BAR,
   TraceType.DOT,

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -607,6 +607,25 @@ export class AnnouncePointCommand extends AnnounceCommand {
 }
 
 /**
+ * The traces built on `AbstractBarPlot`, whose braille state is
+ * `values[row][col]` normalised to the bar axis and whose audio panning swaps
+ * for a horizontal chart. The position announcement reads the former for
+ * these; see {@link AnnouncePositionCommand.navigationPosition}.
+ */
+const BAR_FAMILY: ReadonlySet<TraceType> = new Set([
+  TraceType.BAR,
+  TraceType.DOT,
+  TraceType.LOLLIPOP,
+  TraceType.FUNNEL,
+  TraceType.HISTOGRAM,
+  TraceType.STACKED,
+  TraceType.NORMALIZED,
+  TraceType.DODGED,
+  TraceType.DIVERGING,
+  TraceType.MOSAIC,
+]);
+
+/**
  * Turns a fraction of the way round the dial into a clock hour.
  *
  * Twelve o'clock is both the origin and the full turn, so a fraction of 0 and
@@ -667,9 +686,7 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       return;
     }
 
-    // Get position from audio.panning (contains x, y, rows, cols).
-    const { panning } = state.audio;
-    const { x, y, rows, cols } = panning;
+    const { x, y, rows, cols } = this.navigationPosition(state);
 
     // Check for special chart types
     const traceType = state.traceType;
@@ -733,6 +750,37 @@ export class AnnouncePositionCommand extends AnnounceCommand {
     } else {
       this.announce1DPosition(x, cols);
     }
+  }
+
+  /**
+   * The cursor's grid position: `x` of `cols` along the bars or samples, `y`
+   * of `rows` across the groups.
+   *
+   * For most traces this is `audio.panning`, whose `x`/`cols` are the column
+   * index and count. But panning is a stereo position, not an index contract
+   * ({@link AudioState.panning}), and a horizontal bar chart swaps it so the
+   * pan follows the bars down the page. Read as an index, that announced every
+   * horizontal bar as "1 of 1" and a horizontal stacked bar's level as its
+   * category. The braille state keeps `values[row][col]` normalised to the bar
+   * axis whichever way the chart is drawn, so the bar family reads its position
+   * from there -- the same route {@link announceBoxplotPosition} takes.
+   *
+   * @param state - The active trace state
+   * @returns The zero-based column and row, with their counts
+   */
+  private navigationPosition(
+    state: NonEmptyTraceState,
+  ): { x: number; y: number; rows: number; cols: number } {
+    if (BAR_FAMILY.has(state.traceType) && !state.braille.empty) {
+      const braille = state.braille as BarBrailleState;
+      return {
+        x: braille.col,
+        y: braille.row,
+        rows: braille.values.length,
+        cols: braille.values[braille.row]?.length ?? 0,
+      };
+    }
+    return state.audio.panning;
   }
 
   /**

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -703,7 +703,7 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       || traceType === TraceType.DODGED
     ) {
       this.announceSegmentedBarPosition(state, x, cols);
-    } else if (traceType === TraceType.SMOOTH) {
+    } else if (traceType === TraceType.SMOOTH || traceType === TraceType.VIOLIN_KDE) {
       if (rows > 1) {
         // Multi-violin plots: y=violin index, x=position within violin
         this.announceMultiViolinPosition(y, rows, x, cols);

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -235,9 +235,9 @@ export class CommandFactory {
       case 'MOVE_TO_TRACE_CONTEXT':
         return new MoveToTraceContextCommand(this.context, this.brailleService, this.displayService, this.subplotCue);
       case 'MOVE_TO_SUBPLOT_CONTEXT':
-        return new MoveToSubplotContextCommand(this.context, this.displayService, this.subplotCue);
+        return new MoveToSubplotContextCommand(this.context, this.displayService, this.subplotCue, this.rotorService);
       case 'EXIT_BRAILLE_AND_SUBPLOT':
-        return new ExitBrailleAndSubplotCommand(this.context, this.displayService, this.brailleViewModel, this.candlestickDeltaService, this.subplotCue);
+        return new ExitBrailleAndSubplotCommand(this.context, this.displayService, this.brailleViewModel, this.candlestickDeltaService, this.subplotCue, this.rotorService);
       case 'MOVE_TO_NEXT_TRACE':
         return new MoveToNextTraceCommand(this.context, this.candlestickDeltaService, this.rotorService);
       case 'MOVE_TO_PREV_TRACE':

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -298,21 +298,25 @@ export class MoveToSubplotContextCommand implements Command {
   private readonly context: Context;
   private readonly displayService: DisplayService;
   private readonly cue: SubplotCue;
+  private readonly rotor: RotorNavigationService;
 
   /**
    * Creates an instance of MoveToSubplotContextCommand.
    * @param {Context} context - The context in which the move operation is performed.
    * @param {DisplayService} displayService - The display service for focus management.
    * @param {SubplotCue} cue - Plays the exit tone and announces the figure position.
+   * @param {RotorNavigationService} rotor - Returns the rotor to data mode before leaving the trace, so the lobby's arrow keys are moves again.
    */
   public constructor(
     context: Context,
     displayService: DisplayService,
     cue: SubplotCue,
+    rotor: RotorNavigationService,
   ) {
     this.context = context;
     this.displayService = displayService;
     this.cue = cue;
+    this.rotor = rotor;
   }
 
   /**
@@ -326,8 +330,21 @@ export class MoveToSubplotContextCommand implements Command {
    * dispatches into a single re-render, so the user hears one clear exit
    * message plus the falling exit tone. In OFF text mode the message is null,
    * so only the tone plays.
+   *
+   * A rotor mode is an index on the service but a boolean on the trace, and
+   * `Context.isRotorEnabled()` routes every arrow key to the rotor while it is
+   * on. The lobby has no trace for the rotor to act on and binds no key that
+   * could switch it off, so leaving with it on left every arrow key silently
+   * swallowed. Hand the rotor back to data mode first, while the outgoing
+   * trace is still active and its own flag is the one cleared -- as a
+   * PageUp/PageDown trace switch does. Only when the exit is real: on a
+   * single-subplot chart exitSubplot() is a no-op and the reader stays on the
+   * trace in the mode they chose.
    */
   public execute(): void {
+    if (this.context.isMultiPanel) {
+      this.rotor.resetToDataMode();
+    }
     this.context.exitSubplot();
     // Mirror the enter path: keep the focus stack in sync with the scope, but
     // only when the exit actually happened. On a single-subplot chart
@@ -363,6 +380,7 @@ export class ExitBrailleAndSubplotCommand implements Command {
   private readonly brailleViewModel: BrailleViewModel;
   private readonly candlestickDeltaService: CandlestickDeltaService;
   private readonly cue: SubplotCue;
+  private readonly rotor: RotorNavigationService;
 
   /**
    * Creates an instance of ExitBrailleAndSubplotCommand.
@@ -371,6 +389,7 @@ export class ExitBrailleAndSubplotCommand implements Command {
    * @param {BrailleViewModel} brailleViewModel - The braille view model for the single-panel fallback.
    * @param {CandlestickDeltaService} candlestickDeltaService - Releases the virtual delta layer on the multi-panel exit path.
    * @param {SubplotCue} cue - Plays the exit tone and announces the lobby position on the multi-panel exit.
+   * @param {RotorNavigationService} rotor - Returns the rotor to data mode before the multi-panel exit, so the lobby's arrow keys are moves again.
    */
   public constructor(
     context: Context,
@@ -378,12 +397,14 @@ export class ExitBrailleAndSubplotCommand implements Command {
     brailleViewModel: BrailleViewModel,
     candlestickDeltaService: CandlestickDeltaService,
     cue: SubplotCue,
+    rotor: RotorNavigationService,
   ) {
     this.context = context;
     this.displayService = displayService;
     this.brailleViewModel = brailleViewModel;
     this.candlestickDeltaService = candlestickDeltaService;
     this.cue = cue;
+    this.rotor = rotor;
   }
 
   /**
@@ -398,6 +419,11 @@ export class ExitBrailleAndSubplotCommand implements Command {
       // first, so it does not survive on the real chart layer. This command
       // manages the stack and focus itself, so discardActiveLayer() must not.
       this.candlestickDeltaService.discardActiveLayer();
+      // discardActiveLayer() resets the rotor only when a delta layer existed.
+      // The rotor has to go back to data mode on every multi-panel exit, for
+      // the reason given on MoveToSubplotContextCommand: the lobby cannot act
+      // on a rotor mode and has no key to leave one.
+      this.rotor.resetToDataMode();
       this.displayService.dismissModalScope(Scope.SUBPLOT);
       this.context.exitSubplot();
       this.displayService.notifyFocusChange(Scope.SUBPLOT);

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -965,6 +965,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
           points,
           xValue,
           this.moveToIndex.bind(this),
+          this.row,
         );
       }
     }

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -1,6 +1,7 @@
 import type { ExtremaTarget } from '@type/extrema';
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
+import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { MathUtil } from '@util/math';
@@ -174,6 +175,38 @@ export class Heatmap extends AbstractTrace {
       rows: this.heatmapValues.length,
       cols: this.heatmapValues[this.row]?.length ?? 0,
     };
+  }
+
+  /**
+   * The label of the column the cursor is in.
+   *
+   * A heatmap has no `points`, so the base implementation fell back to
+   * scanning `values` -- a grid of magnitudes with no X in it -- and handed the
+   * focused cell's magnitude to the next layer as the reader's X.
+   * @returns The current column's label, or null when the cursor is off the grid
+   */
+  public override getCurrentXValue(): XValue | null {
+    return this.x[this.col] ?? null;
+  }
+
+  /**
+   * Moves to the column labelled `xValue`, staying on the current row.
+   *
+   * Column labels are strings, so a numeric X arriving from a neighbouring
+   * layer is matched by its spelling: a grid whose columns are `'1'`, `'2'`,
+   * `'3'` answers `moveToXValue(3)` with its third column. There is no
+   * nearest-column fallback: a label that is not there is not there, and the
+   * base implementation's search of the magnitudes instead was the bug.
+   * @param xValue - The column label to move to
+   * @returns True when a column carries that label and the cursor moved
+   */
+  public override moveToXValue(xValue: XValue): boolean {
+    const label = String(xValue);
+    const col = this.x.findIndex(candidate => String(candidate) === label);
+    if (col === -1) {
+      return false;
+    }
+    return this.moveToIndex(this.row, col);
   }
 
   private mapToSvgElements(

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -163,15 +163,23 @@ export class NavigationService implements Disposable {
 
   /**
    * Navigate to a specific X value within the points array and invoke callback with new position.
+   *
+   * An exact match on `preferredRow` wins over one on any other row. A layer
+   * switch away and back calls this with the X the reader left at, and
+   * resolving that to the first row holding it silently moved a reader on
+   * line 3 to line 1: same X, different series, and every Up/Down from then
+   * on started from the wrong one.
    * @param points - Array of points (single or multi-row)
    * @param xValue - The target X value to navigate to
    * @param moveToIndex - Callback function to execute when position is found
+   * @param preferredRow - The row to try first, normally the trace's current row
    * @returns True if navigation was successful, false otherwise
    */
   public moveToXValueInPoints(
     points: PointWithX[][] | PointWithX[],
     xValue: XValue,
     moveToIndex: (row: number, col: number) => void,
+    preferredRow = 0,
   ): boolean {
     // Single-row traces (like BarTrace)
     if (Array.isArray(points) && points.length === 1 && Array.isArray(points[0])) {
@@ -195,7 +203,17 @@ export class NavigationService implements Disposable {
       }
     }
 
-    // Multi-row traces (like LineTrace)
+    // Multi-row traces (like LineTrace): the row the cursor is on first, so an
+    // X that several series share keeps the reader on their series.
+    const preferredPoints = Array.isArray(points) ? points[preferredRow] : undefined;
+    if (Array.isArray(preferredPoints)) {
+      const colIndex = this.findPointIndexByX(preferredPoints, xValue);
+      if (colIndex !== -1) {
+        moveToIndex(preferredRow, colIndex);
+        return true;
+      }
+    }
+
     let bestRow = -1;
     let bestCol = -1;
     let bestDist = Number.POSITIVE_INFINITY;

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -3,13 +3,13 @@ import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { TextService } from '@service/text';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
-import type { BoxPoint, CandlestickPoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, SegmentedPoint } from '@type/grammar';
 import type { PlotState } from '@type/state';
 import { AnnouncePositionCommand } from '@command/describe';
 import { describe, expect, jest, test } from '@jest/globals';
 import { CANDLESTICK_SECTIONS } from '@model/candlestick';
 import { TraceFactory } from '@model/factory';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 interface MultilineOptions {
   /** Zero-based index of the line the cursor is on. */
@@ -554,5 +554,133 @@ describe('AnnouncePositionCommand names a section as the trace authored it', () 
 
     expect(sectionOf(state)).toBe('close');
     expect(textViewModel.update).toHaveBeenCalledWith('Position is 2 of 3, close');
+  });
+});
+
+/**
+ * A real bar trace's state with the cursor on one bar, drawn either way up.
+ *
+ * `audio.panning` is a stereo position, and a horizontal bar plot swaps it so
+ * the pan follows the bars down the page. Building the state from the trace
+ * rather than by hand is what lets these cases catch the command reading that
+ * pan as a bar index.
+ *
+ * @param orientation Which way the bars run
+ * @param bar Zero-based index of the bar the cursor is on
+ * @returns The trace's state with the cursor there
+ */
+function barTraceState(orientation: Orientation, bar: number): PlotState {
+  const categories = ['North', 'South', 'West'];
+  const magnitudes = [4, 8, 6];
+  const trace = TraceFactory.create({
+    id: 'position-bar',
+    type: TraceType.BAR,
+    title: 'Sales',
+    orientation,
+    axes: { x: { label: 'Region' }, y: { label: 'Sales' } },
+    data: categories.map((category, i) =>
+      orientation === Orientation.HORIZONTAL
+        ? { x: magnitudes[i], y: category }
+        : { x: category, y: magnitudes[i] },
+    ) as BarPoint[],
+  });
+  trace.moveToIndex(0, bar);
+
+  return trace.state as PlotState;
+}
+
+/**
+ * A real stacked bar trace's state, drawn either way up.
+ *
+ * @param orientation Which way the bars run
+ * @param level Zero-based index of the stack level the cursor is on
+ * @param category Zero-based index of the category the cursor is on
+ * @returns The trace's state with the cursor there
+ */
+function stackedTraceState(
+  orientation: Orientation,
+  level: number,
+  category: number,
+): PlotState {
+  // Four categories against two levels (three rows, once the summary row is
+  // added), so a level index or level count read as a category shows up.
+  const categories = ['a', 'b', 'c', 'd'];
+  const levels = ['Low', 'High'];
+  const trace = TraceFactory.create({
+    id: 'position-stacked',
+    type: TraceType.STACKED,
+    title: 'Stacked',
+    orientation,
+    axes: { x: { label: 'Category' }, y: { label: 'Count' } },
+    data: levels.map((z, row) =>
+      categories.map((category, col) => {
+        const magnitude = row * 10 + col + 1;
+        return orientation === Orientation.HORIZONTAL
+          ? { x: magnitude, y: category, z }
+          : { x: category, y: magnitude, z };
+      }),
+    ) as SegmentedPoint[][],
+  });
+  trace.moveToIndex(level, category);
+
+  return trace.state as PlotState;
+}
+
+describe('AnnouncePositionCommand on horizontal bar charts', () => {
+  test('announces the bar index on a horizontal bar chart, as on a vertical one', () => {
+    const vertical = createCommand(barTraceState(Orientation.VERTICAL, 1));
+    const horizontal = createCommand(barTraceState(Orientation.HORIZONTAL, 1));
+
+    vertical.command.execute();
+    horizontal.command.execute();
+
+    expect(vertical.textViewModel.update).toHaveBeenCalledWith('Position is 2 of 3');
+    expect(horizontal.textViewModel.update).toHaveBeenCalledWith('Position is 2 of 3');
+  });
+
+  test('moves the announced position with the cursor on a horizontal bar chart', () => {
+    const first = createCommand(barTraceState(Orientation.HORIZONTAL, 0));
+    const last = createCommand(barTraceState(Orientation.HORIZONTAL, 2));
+
+    first.command.execute();
+    last.command.execute();
+
+    expect(first.textViewModel.update).toHaveBeenCalledWith('Position is 1 of 3');
+    expect(last.textViewModel.update).toHaveBeenCalledWith('Position is 3 of 3');
+  });
+
+  test('gives the terse percentage along the bars, not across them', () => {
+    const { command, textViewModel } = createCommand(
+      barTraceState(Orientation.HORIZONTAL, 2),
+      'terse',
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('100%');
+  });
+
+  test('announces the category, not the level, on a horizontal stacked bar', () => {
+    const { command, textViewModel } = createCommand(
+      stackedTraceState(Orientation.HORIZONTAL, 0, 2),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 3 of 4, Level is Low',
+    );
+  });
+
+  test('reads a vertical stacked bar the same way it always has', () => {
+    const { command, textViewModel } = createCommand(
+      stackedTraceState(Orientation.VERTICAL, 0, 2),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 3 of 4, Level is Low',
+    );
   });
 });

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -3,7 +3,7 @@ import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { TextService } from '@service/text';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
-import type { BarPoint, BoxPoint, CandlestickPoint, SegmentedPoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
 import type { PlotState } from '@type/state';
 import { AnnouncePositionCommand } from '@command/describe';
 import { describe, expect, jest, test } from '@jest/globals';
@@ -754,5 +754,47 @@ describe('AnnouncePositionCommand on a violin box', () => {
     expect(textViewModel.update).toHaveBeenCalledWith(
       `Position is 2 of 2 in ${sectionOf(state)}`,
     );
+  });
+});
+
+/**
+ * A real violin KDE trace's state: three violins of five density samples.
+ *
+ * @param violin Zero-based index of the violin the cursor is on
+ * @param sample Zero-based index of the density sample within it
+ * @returns The trace's state with the cursor there
+ */
+function violinKdeTraceState(violin: number, sample: number): PlotState {
+  const trace = TraceFactory.create({
+    id: 'position-violin-kde',
+    type: TraceType.VIOLIN_KDE,
+    title: 'Violins',
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data: ['A', 'B', 'C'].map(x =>
+      [1, 2, 3, 4, 5].map(y => ({ x, y, density: 0.1 * y })),
+    ) as ViolinKdePoint[][],
+  });
+  trace.moveToIndex(violin, sample);
+
+  return trace.state as PlotState;
+}
+
+describe('AnnouncePositionCommand on a multi-violin KDE', () => {
+  test('names the violin rather than a column and row', () => {
+    const { command, textViewModel } = createCommand(violinKdeTraceState(1, 2));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Violin 2 of 3, Position is 3 of 5',
+    );
+  });
+
+  test('keeps the violin identity in terse mode', () => {
+    const { command, textViewModel } = createCommand(violinKdeTraceState(1, 2), 'terse');
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Violin 2 of 3, 50%');
   });
 });

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -798,3 +798,39 @@ describe('AnnouncePositionCommand on a multi-violin KDE', () => {
     expect(textViewModel.update).toHaveBeenCalledWith('Violin 2 of 3, 50%');
   });
 });
+
+describe('AnnouncePositionCommand at the multi-panel lobby', () => {
+  function figureState(index: number, size: number): PlotState {
+    return { type: 'figure', empty: false, index, size } as unknown as PlotState;
+  }
+
+  test('announces which subplot is focused', () => {
+    // The lobby binds `p` and lists it in help, so it has to answer with the
+    // position the figure state already carries rather than a refusal.
+    const { command, textViewModel } = createCommand(figureState(2, 4));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Subplot 2 of 4');
+  });
+
+  test('drops the label word in terse mode', () => {
+    const { command, textViewModel } = createCommand(figureState(2, 4), 'terse');
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('2 of 4');
+  });
+
+  test('still refuses when there is no chart at all', () => {
+    const { command, textViewModel } = createCommand(
+      { type: 'figure', empty: true } as unknown as PlotState,
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Not in a chart, unable to show position.',
+    );
+  });
+});

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -684,3 +684,75 @@ describe('AnnouncePositionCommand on horizontal bar charts', () => {
     );
   });
 });
+
+/**
+ * A real violin box trace's state. Its audio panning encodes the value, as a
+ * boxplot's does, so the position has to come from the same place the
+ * boxplot branch reads it.
+ *
+ * @param orientation Which way the violins run
+ * @param section Section index, in the trace's own section order
+ * @param violin Zero-based index of the violin the cursor is on
+ * @returns The trace's state with the cursor there
+ */
+function violinBoxTraceState(
+  orientation: Orientation,
+  section: number,
+  violin: number,
+): PlotState {
+  const trace = TraceFactory.create({
+    id: 'position-violin-box',
+    type: TraceType.VIOLIN_BOX,
+    title: 'Violins',
+    orientation,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data: [
+      { z: 'A', lowerOutliers: [], min: 1, q1: 3, q2: 5, q3: 7, max: 9, upperOutliers: [] },
+      { z: 'B', lowerOutliers: [], min: 2, q1: 4, q2: 6, q3: 8, max: 10, upperOutliers: [] },
+    ] as BoxPoint[],
+  });
+  if (orientation === Orientation.HORIZONTAL) {
+    trace.moveToIndex(violin, section);
+  } else {
+    trace.moveToIndex(section, violin);
+  }
+
+  return trace.state as PlotState;
+}
+
+describe('AnnouncePositionCommand on a violin box', () => {
+  test('announces which violin the cursor is on, with its section', () => {
+    const state = violinBoxTraceState(Orientation.VERTICAL, 0, 1);
+    const { command, textViewModel } = createCommand(state);
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      `Position is 2 of 2 in ${sectionOf(state)}`,
+    );
+  });
+
+  test('changes the announcement when the cursor moves to another violin', () => {
+    const first = createCommand(violinBoxTraceState(Orientation.VERTICAL, 2, 0));
+    const second = createCommand(violinBoxTraceState(Orientation.VERTICAL, 2, 1));
+
+    first.command.execute();
+    second.command.execute();
+
+    const firstText = jest.mocked(first.textViewModel.update).mock.calls[0][0] as string;
+    const secondText = jest.mocked(second.textViewModel.update).mock.calls[0][0] as string;
+    expect(firstText).toContain('Position is 1 of 2');
+    expect(secondText).toContain('Position is 2 of 2');
+  });
+
+  test('reads the violin index on a horizontal violin box too', () => {
+    const state = violinBoxTraceState(Orientation.HORIZONTAL, 0, 1);
+    const { command, textViewModel } = createCommand(state);
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      `Position is 2 of 2 in ${sectionOf(state)}`,
+    );
+  });
+});

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -4,6 +4,7 @@ import type { BrailleService } from '@service/braille';
 import type { CandlestickDeltaService } from '@service/candlestickDelta';
 import type { DisplayService } from '@service/display';
 import type { NotificationService } from '@service/notification';
+import type { RotorNavigationService } from '@service/rotor';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import { ExitBrailleAndSubplotCommand, MoveToTraceContextCommand } from '@command/move';
 import { SubplotCue } from '@command/subplotCue';
@@ -82,6 +83,13 @@ function createMockContext(overrides: Record<string, unknown> = {}): Context {
  * Creates a mock DisplayService with dismissModalScope, notifyFocusChange,
  * and toggleFocus stubs.
  */
+/**
+ * A rotor stub: the exit commands hand it back to data mode on the way out.
+ */
+function createMockRotor(): RotorNavigationService {
+  return { resetToDataMode: jest.fn() } as unknown as RotorNavigationService;
+}
+
 function createMockDisplayService(overrides: Record<string, unknown> = {}): DisplayService {
   return {
     dismissModalScope: jest.fn(),
@@ -134,7 +142,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       });
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(callOrder).toEqual([
@@ -149,7 +157,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(displayService.dismissModalScope).toHaveBeenCalledWith(Scope.SUBPLOT);
@@ -160,7 +168,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(displayService.notifyFocusChange).toHaveBeenCalledWith(Scope.SUBPLOT);
@@ -171,7 +179,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(context.exitSubplot).toHaveBeenCalled();
@@ -182,7 +190,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(brailleViewModel.toggle).not.toHaveBeenCalled();
@@ -204,6 +212,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
         brailleViewModel,
         createMockCandlestickDeltaService(),
         createSubplotCue(audioService, notificationService, createMockTextService()),
+        createMockRotor(),
       );
       command.execute();
 
@@ -229,7 +238,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
         }),
       });
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, candlestickDeltaService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, candlestickDeltaService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(candlestickDeltaService.discardActiveLayer).toHaveBeenCalled();
@@ -245,7 +254,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService(), createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(brailleViewModel.toggle).toHaveBeenCalledWith(traceState);
@@ -260,7 +269,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const brailleViewModel = createMockBrailleViewModel();
       const candlestickDeltaService = createMockCandlestickDeltaService();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, candlestickDeltaService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()));
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, candlestickDeltaService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextService()), createMockRotor());
       command.execute();
 
       expect(candlestickDeltaService.discardActiveLayer).not.toHaveBeenCalled();

--- a/test/command/exitRotorReset.test.ts
+++ b/test/command/exitRotorReset.test.ts
@@ -1,0 +1,104 @@
+import type { SubplotCue } from '@command/subplotCue';
+import type { Context } from '@model/context';
+import type { CandlestickDeltaService } from '@service/candlestickDelta';
+import type { DisplayService } from '@service/display';
+import type { RotorNavigationService } from '@service/rotor';
+import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
+import type { PlotState } from '@type/state';
+import { ExitBrailleAndSubplotCommand, MoveToSubplotContextCommand } from '@command/move';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Scope } from '@type/event';
+
+/**
+ * A rotor mode is an index on {@link RotorNavigationService} but a boolean on
+ * the trace, and `Context.isRotorEnabled()` decides whether an arrow key is a
+ * move or a rotor step. Leaving a trace for the multi-panel lobby with the
+ * rotor still on hands every arrow key to the rotor, which has no trace to
+ * act on and swallows them -- and the lobby binds no key that could switch the
+ * rotor back off. So the exit has to return the rotor to data mode first,
+ * while the outgoing trace is still active and its own flag is the one
+ * cleared, the same as a PageUp/PageDown trace switch already does.
+ */
+describe('leaving a trace for the lobby returns the rotor to data mode', () => {
+  function createHarness(): {
+    calls: string[];
+    context: Context;
+    rotor: RotorNavigationService;
+    displayService: DisplayService;
+    cue: SubplotCue;
+  } {
+    const calls: string[] = [];
+    const figureState = { type: 'figure', empty: false, index: 1, size: 2 } as unknown as PlotState;
+    const context = {
+      scope: Scope.TRACE,
+      state: figureState,
+      isMultiPanel: true,
+      exitSubplot: jest.fn(() => {
+        calls.push('exitSubplot');
+        (context as { scope: Scope }).scope = Scope.SUBPLOT;
+      }),
+    } as unknown as Context;
+    const rotor = {
+      resetToDataMode: jest.fn(() => {
+        calls.push('resetToDataMode');
+      }),
+    } as unknown as RotorNavigationService;
+    const displayService = {
+      syncFocusStack: jest.fn(),
+      dismissModalScope: jest.fn(),
+      notifyFocusChange: jest.fn(),
+    } as unknown as DisplayService;
+    const cue = { announceExit: jest.fn() } as unknown as SubplotCue;
+    return { calls, context, rotor, displayService, cue };
+  }
+
+  test('Esc from trace scope resets the rotor before exiting the subplot', () => {
+    const { calls, context, rotor, displayService, cue } = createHarness();
+
+    new MoveToSubplotContextCommand(context, displayService, cue, rotor).execute();
+
+    expect(calls).toEqual(['resetToDataMode', 'exitSubplot']);
+    expect(cue.announceExit).toHaveBeenCalled();
+  });
+
+  test('Esc from braille mode on a multi-panel figure resets the rotor before exiting', () => {
+    const { calls, context, rotor, displayService, cue } = createHarness();
+    const brailleViewModel = { toggle: jest.fn() } as unknown as BrailleViewModel;
+    const delta = { discardActiveLayer: jest.fn() } as unknown as CandlestickDeltaService;
+
+    new ExitBrailleAndSubplotCommand(
+      context,
+      displayService,
+      brailleViewModel,
+      delta,
+      cue,
+      rotor,
+    ).execute();
+
+    expect(calls).toEqual(['resetToDataMode', 'exitSubplot']);
+    expect(brailleViewModel.toggle).not.toHaveBeenCalled();
+  });
+
+  test('Esc from braille mode on a single-panel figure leaves the rotor alone', () => {
+    // There is no lobby to be stranded at: the trace stays active, so its
+    // rotor mode is still the one the reader chose.
+    const { context, rotor, displayService, cue } = createHarness();
+    (context as { isMultiPanel: boolean }).isMultiPanel = false;
+    const traceState = { type: 'trace', empty: false } as unknown as PlotState;
+    (context as { state: PlotState }).state = traceState;
+    const brailleViewModel = { toggle: jest.fn() } as unknown as BrailleViewModel;
+    const delta = { discardActiveLayer: jest.fn() } as unknown as CandlestickDeltaService;
+
+    new ExitBrailleAndSubplotCommand(
+      context,
+      displayService,
+      brailleViewModel,
+      delta,
+      cue,
+      rotor,
+    ).execute();
+
+    expect(rotor.resetToDataMode).not.toHaveBeenCalled();
+    expect(brailleViewModel.toggle).toHaveBeenCalledWith(traceState);
+  });
+});

--- a/test/command/scopeRestore.test.ts
+++ b/test/command/scopeRestore.test.ts
@@ -2,6 +2,7 @@ import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { NotificationService } from '@service/notification';
+import type { RotorNavigationService } from '@service/rotor';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
 import { AnnounceXCommand } from '@command/describe';
 import { EnterGridCellCommand } from '@command/gridCell';
@@ -27,6 +28,13 @@ function createMockContext(overrides: Record<string, unknown> = {}): Context {
     enterGridCell: jest.fn(() => true),
     ...overrides,
   } as unknown as Context;
+}
+
+/**
+ * A rotor stub: the exit commands hand it back to data mode on the way out.
+ */
+function createMockRotor(): RotorNavigationService {
+  return { resetToDataMode: jest.fn() } as unknown as RotorNavigationService;
 }
 
 function createMockDisplayService(): DisplayService {
@@ -70,7 +78,7 @@ describe('MoveToSubplotContextCommand', () => {
     });
     const displayService = createMockDisplayService();
 
-    new MoveToSubplotContextCommand(context, displayService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextServiceForExit())).execute();
+    new MoveToSubplotContextCommand(context, displayService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextServiceForExit()), createMockRotor()).execute();
 
     expect(displayService.syncFocusStack).toHaveBeenCalledWith(Scope.SUBPLOT);
   });
@@ -80,7 +88,7 @@ describe('MoveToSubplotContextCommand', () => {
     const context = createMockContext();
     const displayService = createMockDisplayService();
 
-    new MoveToSubplotContextCommand(context, displayService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextServiceForExit())).execute();
+    new MoveToSubplotContextCommand(context, displayService, createSubplotCue(createMockAudioService(), createMockNotificationService(), createMockTextServiceForExit()), createMockRotor()).execute();
 
     expect(context.exitSubplot).toHaveBeenCalled();
     expect(displayService.syncFocusStack).not.toHaveBeenCalled();

--- a/test/command/subplot-transitions.test.ts
+++ b/test/command/subplot-transitions.test.ts
@@ -3,6 +3,7 @@ import type { AudioService } from '@service/audio';
 import type { BrailleService } from '@service/braille';
 import type { DisplayService } from '@service/display';
 import type { NotificationService } from '@service/notification';
+import type { RotorNavigationService } from '@service/rotor';
 import type { TactileService } from '@service/tactile';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { PlotState } from '@type/state';
@@ -43,6 +44,13 @@ function createTextService(mode: 'verbose' | 'terse' | 'off' = 'verbose'): TextS
     service.toggle(); // TERSE -> OFF
   }
   return service;
+}
+
+/**
+ * A rotor stub: the exit commands hand it back to data mode on the way out.
+ */
+function createMockRotor(): RotorNavigationService {
+  return { resetToDataMode: jest.fn() } as unknown as RotorNavigationService;
 }
 
 function createMockDisplayService(): DisplayService {
@@ -335,6 +343,7 @@ describe('MoveToSubplotContextCommand exit cue', () => {
       context,
       createMockDisplayService(),
       createSubplotCue(audioService, notificationService, createTextService()),
+      createMockRotor(),
     );
 
     command.execute();
@@ -357,6 +366,7 @@ describe('MoveToSubplotContextCommand exit cue', () => {
       context,
       createMockDisplayService(),
       createSubplotCue(createMockAudioService(), notificationService, createTextService('terse')),
+      createMockRotor(),
     );
 
     command.execute();
@@ -394,6 +404,7 @@ describe('MoveToSubplotContextCommand exit cue', () => {
       context,
       createMockDisplayService(),
       createSubplotCue(createMockAudioService(), notificationService, createTextService('terse')),
+      createMockRotor(),
     );
 
     command.execute();
@@ -428,6 +439,7 @@ describe('MoveToSubplotContextCommand exit cue', () => {
       context,
       createMockDisplayService(),
       createSubplotCue(createMockAudioService(), notificationService, createTextService('verbose')),
+      createMockRotor(),
     );
 
     command.execute();
@@ -450,6 +462,7 @@ describe('MoveToSubplotContextCommand exit cue', () => {
       context,
       createMockDisplayService(),
       createSubplotCue(audioService, notificationService, createTextService('off')),
+      createMockRotor(),
     );
 
     command.execute();
@@ -471,6 +484,7 @@ describe('MoveToSubplotContextCommand exit cue', () => {
       context,
       createMockDisplayService(),
       createSubplotCue(audioService, notificationService, createTextService()),
+      createMockRotor(),
     );
 
     command.execute();

--- a/test/model/heatmapLayerSwitch.test.ts
+++ b/test/model/heatmapLayerSwitch.test.ts
@@ -1,0 +1,88 @@
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { Heatmap } from '@model/heatmap';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A layer switch carries the reader's X across traces: the outgoing trace
+ * reports `getCurrentXValue()` and the incoming one answers `moveToXValue()`.
+ * A heatmap has no `points`, so the base class fell back to scanning its
+ * `values` grid -- and a grid of magnitudes has no X in it. The magnitude of
+ * the focused cell went out as the reader's X, and an incoming X was matched
+ * against magnitudes across the whole grid, landing on whichever cell happened
+ * to hold that number.
+ */
+
+function layerOf(points: number[][]): MaidrLayer {
+  return {
+    id: 'hm',
+    type: TraceType.HEATMAP,
+    title: 'test',
+    axes: { x: { label: 'Day' }, y: { label: 'Half' }, z: { label: 'Count' } },
+    data: {
+      x: ['a', 'b', 'c'],
+      // Top row first, which `Heatmap` turns over on construction.
+      y: ['PM', 'AM'],
+      points,
+    } satisfies HeatmapData,
+  };
+}
+
+describe('Heatmap layer switching', () => {
+  test('reports the column label as its current X, not the cell magnitude', () => {
+    const heatmap = new Heatmap(layerOf([[10, 11, 12], [20, 21, 22]]));
+    heatmap.moveToIndex(0, 2);
+
+    const xValue = heatmap.getCurrentXValue();
+
+    expect(xValue).toBe('c');
+  });
+
+  test('moves to the column with that X label, staying on the current row', () => {
+    const heatmap = new Heatmap(layerOf([[10, 11, 12], [20, 21, 22]]));
+    heatmap.moveToIndex(0, 2);
+
+    const moved = heatmap.moveToXValue('b');
+
+    expect(moved).toBe(true);
+    const state = heatmap.state;
+    expect(state.empty).toBe(false);
+    if (!state.empty) {
+      expect(state.braille.empty).toBe(false);
+      if (!state.braille.empty) {
+        expect([state.braille.row, state.braille.col]).toEqual([0, 1]);
+      }
+    }
+  });
+
+  test('does not treat an incoming number as a cell magnitude to search for', () => {
+    // 11 is the magnitude of the cell at the bottom row's second column; a
+    // numeric X is a column position, and no column here is labelled 11.
+    const heatmap = new Heatmap(layerOf([[10, 11, 12], [20, 21, 22]]));
+    heatmap.moveToIndex(0, 2);
+
+    const moved = heatmap.moveToXValue(11);
+
+    expect(moved).toBe(false);
+    const state = heatmap.state;
+    if (!state.empty && !state.braille.empty) {
+      expect([state.braille.row, state.braille.col]).toEqual([0, 2]);
+    }
+  });
+
+  test('finds a numeric column label when the grid is labelled with numbers', () => {
+    const heatmap = new Heatmap({
+      ...layerOf([[10, 11, 12], [20, 21, 22]]),
+      data: { x: ['1', '2', '3'], y: ['PM', 'AM'], points: [[10, 11, 12], [20, 21, 22]] },
+    });
+    heatmap.moveToIndex(1, 0);
+
+    const moved = heatmap.moveToXValue(3);
+
+    expect(moved).toBe(true);
+    const state = heatmap.state;
+    if (!state.empty && !state.braille.empty) {
+      expect([state.braille.row, state.braille.col]).toEqual([1, 2]);
+    }
+  });
+});

--- a/test/service/navigation.test.ts
+++ b/test/service/navigation.test.ts
@@ -1,0 +1,71 @@
+import type { MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { LineTrace } from '@model/line';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Two lines sampled at the same X positions, so every X has an exact match on
+ * both rows and the row the move lands on is the one the resolver chose.
+ */
+function twoLineTrace(): LineTrace {
+  const layer: MaidrLayer = {
+    id: 'lines',
+    type: TraceType.LINE,
+    title: 'Two lines',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data: [
+      [{ x: 0, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 3 }, { x: 3, y: 4 }],
+      [{ x: 0, y: 5 }, { x: 1, y: 6 }, { x: 2, y: 7 }, { x: 3, y: 8 }],
+    ],
+  };
+  return new LineTrace(layer);
+}
+
+function cursorOf(trace: LineTrace): [number, number] {
+  const state = trace.state;
+  if (state.empty || state.braille.empty) {
+    throw new Error('Expected a populated trace state');
+  }
+  return [state.braille.row, state.braille.col];
+}
+
+describe('NavigationService.moveToXValueInPoints keeps the current row', () => {
+  test('an exact X match lands on the row the cursor is already on', () => {
+    // A layer switch away and back calls moveToXValue with the X the reader
+    // left at; resolving it to the first row would silently change series.
+    const trace = twoLineTrace();
+    trace.moveToIndex(1, 2);
+
+    const moved = trace.moveToXValue(2);
+
+    expect(moved).toBe(true);
+    expect(cursorOf(trace)).toEqual([1, 2]);
+  });
+
+  test('a different X on the same row stays on that row', () => {
+    const trace = twoLineTrace();
+    trace.moveToIndex(1, 0);
+
+    trace.moveToXValue(3);
+
+    expect(cursorOf(trace)).toEqual([1, 3]);
+  });
+
+  test('falls back to another row only when the current row has no such X', () => {
+    const trace = new LineTrace({
+      id: 'ragged',
+      type: TraceType.LINE,
+      title: 'Ragged lines',
+      axes: { x: { label: 'X' }, y: { label: 'Y' } },
+      data: [
+        [{ x: 0, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 3 }],
+        [{ x: 0, y: 5 }, { x: 1, y: 6 }],
+      ],
+    });
+    trace.moveToIndex(1, 1);
+
+    trace.moveToXValue(2);
+
+    expect(cursorOf(trace)).toEqual([0, 2]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The position key reads `audio.panning` as though it were a cursor index. It is a stereo pan position, and `AbstractBarPlot` swaps it for a horizontal chart so the pan follows the bars down the page. Read as an index, every horizontal bar and histogram announced "Position is 1 of 1", and a horizontal stacked bar announced its level as its category. Alongside that, leaving a trace for the multi-panel lobby left the rotor on, and since the lobby binds no rotor key and has no trace for the rotor to act on, every arrow key there was silently swallowed with no way back.

Found in a codebase audit; each fix has a test that failed before the change.

## Related Issues

None.

## Changes Made

- **command (position)**: the bar family reads its position from the braille state, whose `values[row][col]` is normalised to the bar axis whichever way the chart is drawn. Other traces still read `audio.panning`, so no other announcement moved.
- **command (position)**: a violin box is routed to the box-position branch, which exists because the box family's panning encodes the value rather than an index; it previously announced "column 1 of 5, row 1 of 9" from the section count and the data range.
- **command (position)**: violin KDE traces reach the violin wording. The branch keyed on `TraceType.SMOOTH`, which violins stopped being emitted as, so the wording was unreachable.
- **command (position)**: at the multi-panel lobby the key answers "Subplot N of M" from the figure state instead of refusing, since the lobby binds it and lists it in help.
- **command (exit)**: `MoveToSubplotContextCommand` and `ExitBrailleAndSubplotCommand` return the rotor to data mode before leaving a trace, while the outgoing trace is still active, as a layer switch already does.
- **heatmap**: `getCurrentXValue` and `moveToXValue` are overridden to answer with the column label. A heatmap has no `points`, so the base implementation scanned the magnitudes and handed the focused cell's value to the next layer as the reader's X.
- **navigation**: `moveToXValueInPoints` tries the trace's current row first. A reader on line 3 who switched layers and came back was silently moved to line 1: same X, different series.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Two command constructors gained a `RotorNavigationService` parameter, wired in `CommandFactory`; the existing command tests pass a stub, with their assertions unchanged. `NavigationService.moveToXValueInPoints` gained an optional trailing `preferredRow` defaulting to 0, so only `AbstractTrace.moveToXValue` changes behaviour.

`npm run lint`, `npm run type-check`, `npm test` (6528 + 158) and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_