### PR TITLE
fix(model): navigation and announcement correctness across the trace types

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -1129,7 +1129,11 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     if (!onCurve) {
       return;
     }
-    if (this.row === nearest.row && this.col === nearest.col) {
+    // A fresh trace parks its cursor on (0, 0) with nothing announced and the
+    // highlight withheld, so pointing at that first mark is an entry rather
+    // than a repeat: it has to move, notify and clear the entry flag exactly
+    // as the first arrow key does.
+    if (!this.isInitialEntry && this.row === nearest.row && this.col === nearest.col) {
       return;
     }
     this.moveToIndex(nearest.row, nearest.col);

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -329,6 +329,45 @@ export abstract class AbstractPlot<State> implements Movable, Observable<State>,
   }
 
   /**
+   * Rotor compare search along one row of numeric values.
+   *
+   * Steps from the current column in the given direction and moves to the
+   * first value that satisfies the comparison; reports the rotor boundary
+   * when nothing further qualifies. For the traces whose values are a plain
+   * numeric grid indexed [row][col]; a trace with a richer layout (the bar's
+   * orientation-normalised rows, the candlestick's segments) keeps its own.
+   *
+   * @param rowValues - The values of the row being searched
+   * @param direction - Which way to search
+   * @param type - Whether a lower or a higher value is sought
+   * @returns True when a matching value was found and moved to
+   */
+  protected compareSearchAlongRow(
+    rowValues: readonly number[],
+    direction: 'left' | 'right',
+    type: 'lower' | 'higher',
+  ): boolean {
+    // Establish the entry position on the first move so the compare jump
+    // highlights and a subsequent ordinary keypress isn't swallowed by the
+    // initial-entry branch of moveOnce.
+    if (this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+
+    const current = this.col;
+    const step = direction === 'right' ? 1 : -1;
+    for (let i = current + step; i >= 0 && i < rowValues.length; i += step) {
+      if (this.compare(rowValues[i], rowValues[current], type)) {
+        this.col = i;
+        this.notifyStateUpdate();
+        return true;
+      }
+    }
+    this.notifyRotorBounds();
+    return false;
+  }
+
+  /**
    * Override left, right, upward and downward navigation functionality in rotor
    */
   /**

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -630,9 +630,21 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     for (const row of this.highlightValues) {
       for (const cell of row) {
         const cellElements = Array.isArray(cell) ? cell : cell ? [cell] : [];
-        for (const clone of cellElements) {
+        for (const element of cellElements) {
+          // Live chart geometry held for in-place highlighting -- a heatmap
+          // cell, a box part, a bar addressed by its own selector -- IS the
+          // original. Its previous sibling is the neighbouring mark, and
+          // reading that shifts the whole list by one: the last mark goes
+          // missing and whatever precedes the first is styled as data.
+          // Ownership is the signal `dispose()` already uses to tell a
+          // MAIDR-made clone from the chart's own element.
+          if (!Svg.isOwned(element)) {
+            elements.push(element);
+            continue;
+          }
+
           // The original element is the previous sibling of the hidden clone
-          const original = clone.previousElementSibling as SVGElement | null;
+          const original = element.previousElementSibling as SVGElement | null;
 
           // Verify this is actually the paired original element:
           // - Must exist
@@ -640,7 +652,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
           // - Must NOT be hidden (the clone is hidden, original is visible)
           if (
             original
-            && original.tagName === clone.tagName
+            && original.tagName === element.tagName
             && original.getAttribute('visibility') !== 'hidden'
           ) {
             elements.push(original);

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -468,6 +468,13 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
    * @returns True if a matching bar was found, false otherwise
    */
   protected compareSearchInRow(direction: 'left' | 'right', type: 'lower' | 'higher'): boolean {
+    // Establish the entry position on the first move so the compare jump
+    // highlights and a subsequent ordinary keypress isn't swallowed by the
+    // initial-entry branch of moveOnce (mirrors Candlestick).
+    if (this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+
     const currentGroup = this.row;
     if (currentGroup < 0 || currentGroup >= this.barValues.length) {
       return false;

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -233,11 +233,13 @@ export class BoxTrace extends AbstractTrace {
         max: this.max,
         raw: this.boxValues[this.row][this.col],
       },
+      // Stereo position follows the on-screen x: on a vertical layout that is
+      // the box (the column), not the section (the row) being climbed.
       panning: {
-        x: isHorizontal ? panning : this.row,
+        x: isHorizontal ? panning : this.col,
         y: isHorizontal ? this.row : panning,
         rows: isHorizontal ? this.boxValues.length : this.max - this.min,
-        cols: isHorizontal ? this.max - this.min : this.boxValues.length,
+        cols: isHorizontal ? this.max - this.min : (this.boxValues[this.row]?.length ?? 1),
       },
     };
   }

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -711,7 +711,7 @@ export class Context implements Disposable {
         const subplotTraceOrientation = !state.trace.empty ? state.trace.orientation : undefined;
         const subplotPlotType = formatPlotType(state.trace.traceType, subplotTraceOrientation);
         return `This is a maidr plot containing ${state.size} layers, and
-        this is layer 1 of ${state.size}: ${subplotPlotType} plot. ${clickPrompt}
+        this is layer ${state.index} of ${state.size}: ${subplotPlotType} plot. ${clickPrompt}
         Use Arrows to navigate data points. Toggle B for Braille, T for Text,
         S for Sonification, and R for Review mode.`;
       }

--- a/src/model/dumbbell.ts
+++ b/src/model/dumbbell.ts
@@ -1,6 +1,7 @@
 import type { ExtremaTarget } from '@type/extrema';
 import type { DumbbellData, DumbbellPoint, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
+import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Orientation } from '@type/grammar';
@@ -186,6 +187,31 @@ export class DumbbellTrace extends AbstractTrace {
 
   protected get values(): number[][] {
     return this.endValues;
+  }
+
+  /**
+   * The pair under the cursor, whichever end is being read. `points` is a
+   * flat list, which the inherited reading -- built for one list per row --
+   * cannot index, and a trace that answers no x is offered rotor compare
+   * modes that then do nothing and cannot keep the reader's category across
+   * a layer switch.
+   *
+   * @returns The current pair's x
+   */
+  public override getCurrentXValue(): XValue | null {
+    return this.points[this.col]?.x ?? null;
+  }
+
+  public override moveToXValue(xValue: XValue): boolean {
+    const index = this.points.findIndex(point => point.x === xValue);
+    return index !== -1 && this.moveToIndex(this.row, index);
+  }
+
+  public override moveToNextCompareValue(
+    direction: 'left' | 'right',
+    type: 'lower' | 'higher',
+  ): boolean {
+    return this.compareSearchAlongRow(this.endValues[this.row] ?? [], direction, type);
   }
 
   protected get dimension(): Dimension {

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -1,6 +1,7 @@
 import type { ExtremaTarget } from '@type/extrema';
 import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
+import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Orientation } from '@type/grammar';
@@ -281,6 +282,32 @@ export class ErrorBarTrace extends AbstractTrace {
 
   protected get values(): number[][] {
     return this.sectionValues;
+  }
+
+  /**
+   * The category under the cursor, within the current group. `points` is a
+   * flat list, which the inherited reading -- built for one list per row --
+   * cannot index, and a trace that answers no x is offered rotor compare
+   * modes that then do nothing and cannot keep the reader's category across
+   * a layer switch.
+   *
+   * @returns The current category's x
+   */
+  public override getCurrentXValue(): XValue | null {
+    return this.groups[this.groupOf(this.row)]?.[this.col]?.x ?? null;
+  }
+
+  public override moveToXValue(xValue: XValue): boolean {
+    const group = this.groups[this.groupOf(this.row)] ?? [];
+    const index = group.findIndex(point => point.x === xValue);
+    return index !== -1 && this.moveToIndex(this.row, index);
+  }
+
+  public override moveToNextCompareValue(
+    direction: 'left' | 'right',
+    type: 'lower' | 'higher',
+  ): boolean {
+    return this.compareSearchAlongRow(this.sectionValues[this.row] ?? [], direction, type);
   }
 
   protected get dimension(): Dimension {

--- a/src/model/flow.ts
+++ b/src/model/flow.ts
@@ -406,7 +406,9 @@ export class FlowTrace extends AbstractTrace implements PointCloudHighlightable 
   public override moveOnce(direction: MovableDirection): boolean {
     // Recorded before the move, because `super.moveOnce` notifies during the
     // call and the announcement is assembled from `text` at that moment.
-    const node = this.current;
+    // The initial entry lands on the first node without following anything,
+    // so it names no ribbon either.
+    const node = this.isInitialEntry ? null : this.current;
     this.arrivedVia = node === null
       ? null
       : direction === 'FORWARD'

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -1843,6 +1843,15 @@ export class LineTrace extends AbstractTrace {
   }
 
   public override moveToNextCompareValue(direction: string, type: 'lower' | 'higher'): boolean {
+    // Establish the entry position on the first move so the compare jump
+    // highlights and a subsequent ordinary keypress isn't swallowed by the
+    // initial-entry branch of moveOnce (mirrors Candlestick). The flag alone
+    // is cleared: the graph's entry handler would re-seat the cursor on the
+    // first point, discarding the position the search starts from.
+    if (this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+
     const currentGroup = this.row;
     if (currentGroup < 0 || currentGroup >= this.lineValues.length) {
       return false;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -519,15 +519,16 @@ export class LineTrace extends AbstractTrace {
 
     if (intersections.length > 1) {
       // Multiple lines intersect - create intersection text
-      let lineTypes = intersections.map((intersection) => {
-        const lineIndex = intersection.group!;
-        return this.points[lineIndex][0]?.z || `l${lineIndex + 1}`;
-      });
+      // Named the way every other announcement names a series, so an unnamed
+      // line is "Line 2" here as well rather than an abbreviation the reader
+      // has never been given.
+      let lineTypes = intersections.map(intersection =>
+        this.groupNameAt(intersection.group!),
+      );
 
       // If previousRow is in the intersection, put its label first
       if (this.previousRow !== null) {
-        const prevZ
-          = this.points[this.previousRow][0]?.z || `l${this.previousRow + 1}`;
+        const prevZ = this.groupNameAt(this.previousRow);
         if (lineTypes.includes(prevZ)) {
           lineTypes = [prevZ, ...lineTypes.filter(l => l !== prevZ)];
         }

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -406,6 +406,13 @@ export class PieTrace extends AbstractTrace {
     direction: 'left' | 'right',
     type: 'lower' | 'higher',
   ): boolean {
+    // Establish the entry position on the first move so the compare jump
+    // highlights and a subsequent ordinary keypress isn't swallowed by the
+    // initial-entry branch of moveOnce (mirrors Candlestick).
+    if (this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+
     const values = this.sliceValues[this.row];
     const current = this.col;
     const step = direction === 'right' ? 1 : -1;

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -527,6 +527,26 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
     return super.moveOnce(direction);
   }
 
+  /**
+   * Steps the active layer without notifying observers.
+   *
+   * A layer switch is announced from the newly positioned trace (see
+   * `NavigationService.stepTraceInSubplot`). A subplot notification at this
+   * point would describe the new trace at whatever column it was left on,
+   * before X-preservation has moved it. Like {@link moveOnce}, the first step
+   * on a multi-layer subplot is a real step rather than the initial-entry
+   * no-op.
+   *
+   * @param direction - The direction to step in
+   * @returns True when the active layer changed
+   */
+  public stepLayer(direction: MovableDirection): boolean {
+    if (this.size > 1 && this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+    return this.movable.moveOnce(direction);
+  }
+
   public get state(): SubplotState {
     const trace = this.activeTrace;
     // A subplot with no layers has no trace state to report. Fall through to

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1,6 +1,6 @@
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
-import type { GridNavigable, PointCloudHighlightable, PointNavigable } from '@type/navigation';
+import type { GridNavigable, PointCloudHighlightable, PointNavigable, XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, HighlightState, TextState, TraceEmptyState, TraceState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Constant } from '@util/constant';
@@ -1521,6 +1521,76 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
         return false;
       }
     }
+  }
+
+  /**
+   * The x the reader is at, in terms of the axis they are walking.
+   *
+   * COL mode walks the x values, so it is the column's x. ROW mode walks the
+   * y values, so the x reported is the one the reader would land on when
+   * switching back to columns (the same middle-of-the-row rule
+   * `toggleNavigation` applies), which keeps a layer switch near the points
+   * they were hearing. The inherited reading of `values[row][col]` over
+   * `[xValues, yValues]` answered with a y value at row 1 and with nothing
+   * at all above it.
+   *
+   * @returns The current x, or null when the cursor is off the data
+   */
+  public override getCurrentXValue(): XValue | null {
+    if (this.mode === NavMode.COL) {
+      return this.xPoints[this.col]?.x ?? null;
+    }
+    const xs = this.yPoints[this.row]?.x;
+    if (xs === undefined || xs.length === 0) {
+      return null;
+    }
+    return xs[Math.floor(xs.length / 2)];
+  }
+
+  /**
+   * Moves to the column at an x value, entering COL mode to do so.
+   *
+   * An exact x wins; a numeric x with no exact column falls back to the
+   * nearest one, as the shared helper does for other traces, and a
+   * categorical x is matched against the column labels.
+   *
+   * @param xValue - The x to move to
+   * @returns True when a column was found and the cursor moved
+   */
+  public override moveToXValue(xValue: XValue): boolean {
+    const index = this.xIndexNearest(xValue);
+    if (index === -1) {
+      return false;
+    }
+    this.mode = NavMode.COL;
+    return this.moveToIndex(0, index);
+  }
+
+  /**
+   * The column index for an x value: exact, else nearest numeric, else by
+   * column label.
+   *
+   * @param xValue - The x to look up
+   * @returns The column index, or -1 when nothing matches
+   */
+  private xIndexNearest(xValue: XValue): number {
+    if (typeof xValue !== 'number') {
+      return this.xPoints.findIndex(point => point.label === xValue);
+    }
+    const exact = this.xIndexByValue.get(xValue);
+    if (exact !== undefined) {
+      return exact;
+    }
+    let best = -1;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    this.xValues.forEach((x, index) => {
+      const distance = Math.abs(x - xValue);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = index;
+      }
+    });
+    return best;
   }
 
   /**

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -2450,11 +2450,11 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
    * Reads state at an explicit cursor, with the trace-local navigation modes
    * suspended for the duration.
    *
-   * `getStateAt` moves row/col and reads the state getters, but point and
-   * intersection mode short-circuit those getters onto their own cursor — so a
-   * live-appended point would be announced as whichever point the user happens
-   * to be focused on. Suspending the flags makes the read positional again,
-   * which is what every caller of this method asks for.
+   * `getStateAt` moves row/col and reads the state getters, but point,
+   * intersection and grid mode short-circuit those getters onto their own
+   * cursor — so a live-appended point would be announced as whichever point
+   * or cell the user happens to be focused on. Suspending the flags makes the
+   * read positional again, which is what every caller of this method asks for.
    *
    * @param row - Row index to read at
    * @param col - Column index to read at
@@ -2463,13 +2463,19 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
   public override getStateAt(row: number, col: number): TraceState {
     const wasInPointMode = this.isInPointMode;
     const wasInIntersectionMode = this.isInIntersectionMode;
+    const wasInGridMode = this.isInGridMode;
+    const wasInGridCellMode = this.isInGridCellMode;
     this.isInPointMode = false;
     this.isInIntersectionMode = false;
+    this.isInGridMode = false;
+    this.isInGridCellMode = false;
     try {
       return super.getStateAt(row, col);
     } finally {
       this.isInPointMode = wasInPointMode;
       this.isInIntersectionMode = wasInIntersectionMode;
+      this.isInGridMode = wasInGridMode;
+      this.isInGridCellMode = wasInGridCellMode;
     }
   }
 

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1450,6 +1450,24 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
   }
 
   public override moveToExtreme(direction: MovableDirection): boolean {
+    // Cell, grid, point and intersection mode own the cursor (see moveOnce).
+    // Ctrl+Arrow is bound whatever mode is active, so the extreme is taken
+    // within the mode: jumping the row/col cursor underneath it would
+    // re-announce the unchanged point and leave the reader somewhere else,
+    // unannounced, the moment they left the mode.
+    if (this.isInGridCellMode) {
+      return this.moveToExtremeInGridCell(direction);
+    }
+    if (this.isInGridMode && this.gridCells) {
+      return this.moveToExtremeInGrid(direction);
+    }
+    if (this.isInPointMode) {
+      return this.moveToExtremePoint(direction);
+    }
+    if (this.isInIntersectionMode) {
+      return this.moveToExtremeIntersection(direction);
+    }
+
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }
@@ -1489,6 +1507,95 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
           break;
       }
     }
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  /**
+   * The extreme within an entered cell, which is walked one way, by x.
+   *
+   * @param direction - The direction of the jump
+   * @returns True when the cell cursor moved to its first or last point
+   */
+  private moveToExtremeInGridCell(direction: MovableDirection): boolean {
+    if (this.cellXPoints.length === 0 || direction === 'UPWARD' || direction === 'DOWNWARD') {
+      this.notifyOutOfBounds();
+      return false;
+    }
+    this.cellPointIndex = direction === 'FORWARD' ? this.cellXPoints.length - 1 : 0;
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  /**
+   * The extreme cell of the grid in a direction.
+   *
+   * @param direction - The direction of the jump
+   * @returns True, the grid always has an edge to jump to
+   */
+  private moveToExtremeInGrid(direction: MovableDirection): boolean {
+    switch (direction) {
+      case 'UPWARD':
+        this.gridRow = this.numGridRows - 1;
+        break;
+      case 'DOWNWARD':
+        this.gridRow = 0;
+        break;
+      case 'FORWARD':
+        this.gridCol = this.numGridCols - 1;
+        break;
+      case 'BACKWARD':
+        this.gridCol = 0;
+        break;
+    }
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  /**
+   * The first or last point of the order point mode walks in a direction:
+   * reading order for left/right, column order for up/down.
+   *
+   * @param direction - The direction of the jump
+   * @returns True when there is a point to land on
+   */
+  private moveToExtremePoint(direction: MovableDirection): boolean {
+    if (this.flatPoints.length === 0) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+    switch (direction) {
+      case 'FORWARD':
+        this.pointModeIndex = this.readingOrder[this.readingOrder.length - 1];
+        break;
+      case 'BACKWARD':
+        this.pointModeIndex = this.readingOrder[0];
+        break;
+      // columnOrder is sorted (x asc, y desc), so up is backward in it.
+      case 'UPWARD':
+        this.pointModeIndex = this.columnOrder[0];
+        break;
+      case 'DOWNWARD':
+        this.pointModeIndex = this.columnOrder[this.columnOrder.length - 1];
+        break;
+    }
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  /**
+   * The first or last point of the stack intersection mode is walking.
+   *
+   * @param direction - The direction of the jump
+   * @returns True when the stack has a point to land on
+   */
+  private moveToExtremeIntersection(direction: MovableDirection): boolean {
+    const size = this.getIntersectionStackValues().length;
+    if (size === 0) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+    this.intersectionStackIndex = direction === 'FORWARD' || direction === 'UPWARD' ? size - 1 : 0;
     this.notifyStateUpdate();
     return true;
   }

--- a/src/model/survival.ts
+++ b/src/model/survival.ts
@@ -95,15 +95,11 @@ export class SurvivalTrace extends StepTrace {
       state.section = CENSORED;
     }
 
-    const low = Number(point.yMin);
-    const high = Number(point.yMax);
-    if (Number.isFinite(low) && Number.isFinite(high)) {
-      // The band, alongside the estimate rather than instead of it. How wide
-      // the interval is at a time is how much the curve is worth there, and
-      // it is the comparison a reader makes when two arms look separated.
-      state.crossRange = { min: low, max: high };
-    }
-
+    // The band travels as the `interval` the line trace already read off
+    // `yMin`/`yMax`: the text service speaks it after the estimate. Setting
+    // `crossRange` from the same bounds would *replace* the estimate with the
+    // band, so the survival probability -- the number the curve is read
+    // for -- would never be spoken, and the band would be read twice.
     return state;
   }
 

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -340,9 +340,13 @@ export class ViolinKdeTrace extends AbstractTrace {
   protected get audio(): AudioState {
     const isHorizontal = this.orientation === Orientation.HORIZONTAL;
     const colCount = this.points[this.row]?.length ?? 0;
+    // Stereo position follows the on-screen x. Horizontal: the curve runs
+    // along x, so the position on it (col) pans. Vertical: the violins sit
+    // side by side along x, so the violin (row) pans and climbing the curve
+    // holds the pan still.
     const panning = isHorizontal
       ? { x: this.col, y: this.row, rows: this.points.length, cols: colCount }
-      : { y: this.row, x: this.col, rows: this.points.length, cols: colCount };
+      : { x: this.row, y: this.col, rows: colCount, cols: this.points.length };
 
     // Use precomputed reference violin values (cached in constructor)
     if (!this.refHasPositive) {

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -321,11 +321,13 @@ export class ViolinBoxTrace extends AbstractTrace {
         max: this.max,
         raw: this.boxValues[this.row][this.col],
       },
+      // Stereo position follows the on-screen x: on a vertical layout that is
+      // the box (the column), not the section (the row) being climbed.
       panning: {
-        x: isHorizontal ? panning : this.row,
+        x: isHorizontal ? panning : this.col,
         y: isHorizontal ? this.row : panning,
         rows: isHorizontal ? this.boxValues.length : this.max - this.min,
-        cols: isHorizontal ? this.max - this.min : this.boxValues.length,
+        cols: isHorizontal ? this.max - this.min : (this.boxValues[this.row]?.length ?? 1),
       },
     };
   }

--- a/src/model/waterfall.ts
+++ b/src/model/waterfall.ts
@@ -1,6 +1,7 @@
 import type { ExtremaTarget } from '@type/extrema';
 import type { MaidrLayer, WaterfallKind, WaterfallPoint } from '@type/grammar';
 import type { Movable } from '@type/movable';
+import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { MathUtil } from '@util/math';
@@ -102,6 +103,30 @@ export class WaterfallTrace extends AbstractTrace {
 
   protected get values(): number[][] {
     return this.deltaValues;
+  }
+
+  /**
+   * The step under the cursor. `points` is a flat list, which the inherited
+   * reading -- built for one list per row -- cannot index, and a trace that
+   * answers no x is offered rotor compare modes that then do nothing and
+   * cannot keep the reader's category across a layer switch.
+   *
+   * @returns The current step's x
+   */
+  public override getCurrentXValue(): XValue | null {
+    return this.points[this.col]?.x ?? null;
+  }
+
+  public override moveToXValue(xValue: XValue): boolean {
+    const index = this.points.findIndex(point => point.x === xValue);
+    return index !== -1 && this.moveToIndex(0, index);
+  }
+
+  public override moveToNextCompareValue(
+    direction: 'left' | 'right',
+    type: 'lower' | 'higher',
+  ): boolean {
+    return this.compareSearchAlongRow(this.deltaValues[0] ?? [], direction, type);
   }
 
   protected get dimension(): Dimension {

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -28,19 +28,26 @@ export class NavigationService implements Disposable {
       return null;
     }
 
-    // Switch to next/previous trace
+    // At the edge of the layers there is one boundary to report: the trace's
+    // tone and the subplot's "no additional layer", once each. Checked before
+    // moving, because `subplot.moveOnce` would notify the subplot's boundary
+    // itself and the pair below would then repeat it.
+    if (!subplot.isMovable(direction)) {
+      currentTrace.notifyOutOfBounds();
+      subplot.notifyOutOfBounds();
+      return currentTrace;
+    }
+
+    // Switch to next/previous trace. Stepped silently: a subplot notification
+    // here would describe the new trace at the column it was left on, before
+    // X-preservation has positioned it. The switch is announced from the
+    // positioned trace below.
     const currentXValue = currentTrace.getCurrentXValue();
-    subplot.moveOnce(direction);
+    subplot.stepLayer(direction);
     const newTrace = subplot.activeTrace;
 
     if (!newTrace) {
       return null;
-    }
-
-    if (newTrace.getId() === currentTrace.getId()) {
-      newTrace.notifyOutOfBounds();
-      subplot.notifyOutOfBounds();
-      return newTrace;
     }
 
     // Attempt Y-preservation: if both traces support Y values, preserve both X and Y

--- a/test/model/boxVerticalPanning.test.ts
+++ b/test/model/boxVerticalPanning.test.ts
@@ -1,0 +1,81 @@
+import type { BoxPoint, MaidrLayer } from '@type/grammar';
+import type { AudioState, TraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { BoxTrace } from '@model/box';
+import { ViolinBoxTrace } from '@model/violinBox';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Stereo panning follows the on-screen x position. On a vertical box plot the
+ * boxes sit side by side along x, so moving between boxes is what pans left
+ * to right; climbing the sections of one box is a vertical movement and must
+ * not move the pan at all.
+ *
+ * `AudioService.stereoSlotOf` reads only `panning.x` against `panning.cols`,
+ * which is why those two are what the tests pin.
+ */
+
+function box(z: string, offset: number): BoxPoint {
+  return {
+    z,
+    lowerOutliers: [offset],
+    min: offset + 1,
+    q1: offset + 2,
+    q2: offset + 3,
+    q3: offset + 4,
+    max: offset + 5,
+    upperOutliers: [offset + 6],
+  };
+}
+
+const GROUPS: BoxPoint[] = [box('A', 0), box('B', 10), box('C', 20)];
+
+function boxLayer(type: TraceType): MaidrLayer {
+  return {
+    id: 'boxes',
+    type,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data: GROUPS,
+  };
+}
+
+function audioOf(trace: { state: TraceState }): AudioState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.audio;
+}
+
+describe.each([
+  ['box', (): BoxTrace => new BoxTrace(boxLayer(TraceType.BOX))],
+  ['violin box', (): ViolinBoxTrace => new ViolinBoxTrace(boxLayer(TraceType.VIOLIN_BOX))],
+])('vertical %s panning', (_name, build) => {
+  test('pans across the groups', () => {
+    const trace = build();
+
+    // Sections are rows and groups are columns on a vertical layout.
+    trace.moveToIndex(0, 0);
+    const first = audioOf(trace).panning;
+    trace.moveToIndex(0, 2);
+    const last = audioOf(trace).panning;
+
+    expect(first.x).toBe(0);
+    expect(last.x).toBe(2);
+    expect(first.cols).toBe(3);
+    expect(last.cols).toBe(3);
+  });
+
+  test('holds the pan while climbing one group', () => {
+    const trace = build();
+
+    trace.moveToIndex(0, 1);
+    const bottom = audioOf(trace).panning;
+    trace.moveToIndex(3, 1);
+    const higher = audioOf(trace).panning;
+
+    expect(higher.x).toBe(bottom.x);
+    expect(higher.cols).toBe(bottom.cols);
+  });
+});

--- a/test/model/compareInitialEntry.test.ts
+++ b/test/model/compareInitialEntry.test.ts
@@ -1,0 +1,81 @@
+import type { AbstractTrace } from '@model/abstract';
+import type { MaidrLayer } from '@type/grammar';
+import { describe, expect, it } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { Histogram } from '@model/histogram';
+import { LineTrace } from '@model/line';
+import { PieTrace } from '@model/pie';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A reader who enters a chart, cycles the rotor to LOWER / HIGHER VALUE and
+ * presses Right lands in `moveToNextCompareValue` while the trace is still in
+ * its initial-entry state. The jump has to establish the entry position the
+ * way an ordinary arrow does: otherwise the highlight stays suppressed and the
+ * next arrow press is swallowed by the initial-entry branch of `moveOnce`,
+ * which re-announces the point the compare jump already landed on instead of
+ * moving.
+ */
+
+const BAR: MaidrLayer = {
+  id: 'bars',
+  type: TraceType.BAR,
+  axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+  data: [{ x: 'Q1', y: 1 }, { x: 'Q2', y: 5 }, { x: 'Q3', y: 9 }],
+};
+
+const HISTOGRAM: MaidrLayer = {
+  id: 'bins',
+  type: TraceType.HISTOGRAM,
+  axes: { x: { label: 'Petal Length' }, y: { label: 'Count' } },
+  data: [
+    { x: 1, y: 1, xMin: 0, xMax: 2, yMin: 0, yMax: 1 },
+    { x: 3, y: 5, xMin: 2, xMax: 4, yMin: 0, yMax: 5 },
+    { x: 5, y: 9, xMin: 4, xMax: 6, yMin: 0, yMax: 9 },
+  ],
+};
+
+const PIE: MaidrLayer = {
+  id: 'slices',
+  type: TraceType.PIE,
+  axes: { x: { label: 'Fruit' }, y: { label: 'Units' } },
+  data: [{ x: 'Apples', y: 1 }, { x: 'Bananas', y: 5 }, { x: 'Cherries', y: 9 }],
+};
+
+const LINE: MaidrLayer = {
+  id: 'line',
+  type: TraceType.LINE,
+  axes: { x: { label: 'X' }, y: { label: 'Y' } },
+  data: [[{ x: 1, y: 1 }, { x: 2, y: 5 }, { x: 3, y: 9 }]],
+};
+
+describe.each([
+  ['bar', (): AbstractTrace => new BarTrace(BAR)],
+  ['histogram', (): AbstractTrace => new Histogram(HISTOGRAM)],
+  ['pie', (): AbstractTrace => new PieTrace(PIE)],
+  ['line', (): AbstractTrace => new LineTrace(LINE)],
+])('rotor compare from initial entry on a %s', (_name, build) => {
+  it('leaves the initial-entry state behind when the compare jump lands', () => {
+    const trace = build();
+    trace.resetToInitialEntry();
+
+    const moved = trace.moveToNextCompareValue('right', 'higher');
+
+    expect(moved).toBe(true);
+    expect(trace.col).toBe(1);
+    expect(trace.isInitialEntry).toBe(false);
+  });
+
+  it('does not swallow the arrow key that follows the compare jump', () => {
+    const trace = build();
+    trace.resetToInitialEntry();
+    trace.moveToNextCompareValue('right', 'higher');
+
+    const moved = trace.moveOnce('FORWARD');
+
+    // The compare jump landed on the second point; an ordinary step then
+    // reaches the third rather than re-announcing the second.
+    expect(moved).toBe(true);
+    expect(trace.col).toBe(2);
+  });
+});

--- a/test/model/flatPointsXValue.test.ts
+++ b/test/model/flatPointsXValue.test.ts
@@ -1,0 +1,156 @@
+import type { DumbbellData, ErrorBarPoint, MaidrLayer, WaterfallPoint } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { DumbbellTrace } from '@model/dumbbell';
+import { ErrorBarTrace } from '@model/errorBar';
+import { WaterfallTrace } from '@model/waterfall';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Waterfall, error bar and dumbbell keep their points in a flat list rather
+ * than one list per row. The base X-value helpers only understand the nested
+ * shape, so without their own answer these traces report no X at all: the
+ * rotor's LOWER / HIGHER VALUE modes are offered and then go silent, and a
+ * layer switch cannot keep the reader on the same category.
+ */
+
+const STEPS: WaterfallPoint[] = [
+  { x: 'Opening', start: 0, end: 1200, delta: 1200, kind: 'total' },
+  { x: 'Marketing', start: 1200, end: 950, delta: -250, kind: 'decrease' },
+  { x: 'Sales', start: 950, end: 1430, delta: 480, kind: 'increase' },
+  { x: 'Support', start: 1430, end: 1360, delta: -70, kind: 'decrease' },
+  { x: 'Closing', start: 0, end: 1360, delta: 1360, kind: 'total' },
+];
+
+const GAINS: DumbbellData = {
+  startLabel: '1990',
+  endLabel: '2020',
+  points: [
+    { x: 'Denmark', start: 71.2, end: 78.4 },
+    { x: 'Latvia', start: 74.6, end: 69.5 },
+    { x: 'Malta', start: 76.0, end: 76.0 },
+  ],
+};
+
+const CONTROL: ErrorBarPoint[] = [
+  { x: 'a', y: 2, yMin: 1.5, yMax: 2.9, z: 'control' },
+  { x: 'b', y: 4, yMin: 3.2, yMax: 5.5, z: 'control' },
+  { x: 'c', y: 3, yMin: 2.7, yMax: 3.2, z: 'control' },
+];
+
+const TREATED: ErrorBarPoint[] = [
+  { x: 'a', y: 3, yMin: 2.4, yMax: 3.6, z: 'treated' },
+  { x: 'b', y: 5, yMin: 4.1, yMax: 6.0, z: 'treated' },
+  { x: 'c', y: 6, yMin: 5.2, yMax: 6.9, z: 'treated' },
+];
+
+function layer(type: TraceType, data: MaidrLayer['data']): MaidrLayer {
+  return {
+    id: `${type}-layer`,
+    type,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  };
+}
+
+function crossValue(trace: { state: TraceState }): unknown {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.text.cross?.value;
+}
+
+describe('waterfall x values', () => {
+  test('reports the step under the cursor', () => {
+    const trace = new WaterfallTrace(layer(TraceType.WATERFALL, STEPS));
+    trace.moveToIndex(0, 1);
+
+    expect(trace.getCurrentXValue()).toBe('Marketing');
+  });
+
+  test('moves to a named step', () => {
+    const trace = new WaterfallTrace(layer(TraceType.WATERFALL, STEPS));
+
+    expect(trace.moveToXValue('Sales')).toBe(true);
+    expect(trace.col).toBe(2);
+    expect(trace.moveToXValue('Nowhere')).toBe(false);
+  });
+
+  test('finds the next higher delta in rotor compare mode', () => {
+    const trace = new WaterfallTrace(layer(TraceType.WATERFALL, STEPS));
+    trace.moveToIndex(0, 1);
+
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(trace.getCurrentXValue()).toBe('Sales');
+    expect(trace.moveToNextCompareValue('right', 'lower')).toBe(true);
+    expect(trace.getCurrentXValue()).toBe('Support');
+  });
+
+  test('reports the boundary when nothing further qualifies', () => {
+    const trace = new WaterfallTrace(layer(TraceType.WATERFALL, STEPS));
+    trace.moveToIndex(0, 4);
+
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(false);
+    expect(trace.col).toBe(4);
+  });
+});
+
+describe('dumbbell x values', () => {
+  test('reports the pair under the cursor on either end', () => {
+    const trace = new DumbbellTrace(layer(TraceType.DUMBBELL, GAINS));
+
+    trace.moveToIndex(1, 1);
+
+    expect(trace.getCurrentXValue()).toBe('Latvia');
+  });
+
+  test('moves to a named pair without leaving the current end', () => {
+    const trace = new DumbbellTrace(layer(TraceType.DUMBBELL, GAINS));
+    trace.moveToIndex(1, 0);
+
+    expect(trace.moveToXValue('Malta')).toBe(true);
+    expect(trace.row).toBe(1);
+    expect(trace.col).toBe(2);
+  });
+
+  test('compares along the current end', () => {
+    const trace = new DumbbellTrace(layer(TraceType.DUMBBELL, GAINS));
+    trace.moveToIndex(0, 0);
+
+    // Starts: 71.2, 74.6, 76.0 — every step right is higher.
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(trace.getCurrentXValue()).toBe('Latvia');
+    expect(trace.moveToNextCompareValue('right', 'lower')).toBe(false);
+  });
+});
+
+describe('error bar x values', () => {
+  test('reports the category under the cursor within the current group', () => {
+    const trace = new ErrorBarTrace(layer(TraceType.ERROR_BAR, [CONTROL, TREATED]));
+
+    // Rows run group-major, three sections each: row 3 is the treated group.
+    trace.moveToIndex(3, 1);
+
+    expect(trace.getCurrentXValue()).toBe('b');
+  });
+
+  test('moves to a named category without leaving the current row', () => {
+    const trace = new ErrorBarTrace(layer(TraceType.ERROR_BAR, [CONTROL, TREATED]));
+    trace.moveToIndex(3, 0);
+
+    expect(trace.moveToXValue('c')).toBe(true);
+    expect(trace.row).toBe(3);
+    expect(trace.col).toBe(2);
+  });
+
+  test('compares along the current row', () => {
+    const trace = new ErrorBarTrace(layer(TraceType.ERROR_BAR, [CONTROL, TREATED]));
+    trace.moveToIndex(1, 0);
+    const before = crossValue(trace) as number;
+
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(crossValue(trace) as number).toBeGreaterThan(before);
+    expect(trace.row).toBe(1);
+  });
+});

--- a/test/model/flowEntry.test.ts
+++ b/test/model/flowEntry.test.ts
@@ -1,0 +1,59 @@
+import type { FlowPoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { FlowTrace } from '@model/flow';
+import { TraceType } from '@type/grammar';
+
+/**
+ * The first arrow press on a flow chart is the initial entry: it lands on the
+ * first node without following anything. The announcement must not claim a
+ * ribbon was traversed on a keystroke that only entered the chart.
+ */
+const ENERGY: FlowPoint[] = [
+  { source: 'Coal', target: 'Losses', value: 8 },
+  { source: 'Coal', target: 'Electricity', value: 34 },
+  { source: 'Coal', target: 'Heat', value: 14 },
+  { source: 'Electricity', target: 'Homes', value: 30 },
+];
+
+function createLayer(): MaidrLayer {
+  return {
+    id: 'flow',
+    type: TraceType.SANKEY,
+    title: 'Energy flow',
+    axes: { x: { label: 'Node' }, y: { label: 'Petajoules' } },
+    data: ENERGY,
+  };
+}
+
+function nonEmptyState(trace: FlowTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+function alongOf(trace: FlowTrace): string | undefined {
+  return nonEmptyState(trace).text.asides?.find(aside => aside.label === 'Along')?.value;
+}
+
+describe('entering a flow chart', () => {
+  test('does not announce a ribbon the reader never followed', () => {
+    const trace = new FlowTrace(createLayer());
+
+    trace.moveOnce('FORWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe('Coal');
+    expect(alongOf(trace)).toBeUndefined();
+  });
+
+  test('announces the ribbon once a move actually follows one', () => {
+    const trace = new FlowTrace(createLayer());
+    trace.moveOnce('FORWARD');
+
+    trace.moveOnce('FORWARD');
+
+    expect(alongOf(trace)).toMatch(/^Coal to /);
+  });
+});

--- a/test/model/instructionLayerIndex.test.ts
+++ b/test/model/instructionLayerIndex.test.ts
@@ -1,0 +1,49 @@
+import type { Maidr } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+
+jest.mock('hotkeys-js', () => ({
+  __esModule: true,
+  default: { setScope: jest.fn() },
+}));
+
+/**
+ * The instruction for a multi-layer subplot names the layer the reader is on.
+ * It is rebuilt whenever the display re-attaches it -- after a live update,
+ * for instance -- so the layer number has to follow the active layer rather
+ * than always claiming the first.
+ */
+function twoLayerMaidr(): Maidr {
+  return {
+    id: 'layers',
+    subplots: [[{
+      layers: [
+        { id: 'bars', type: TraceType.BAR, data: [{ x: 'A', y: 1 }, { x: 'B', y: 2 }] },
+        { id: 'line', type: TraceType.LINE, data: [[{ x: 'A', y: 3 }, { x: 'B', y: 4 }]] },
+      ],
+    }]],
+  };
+}
+
+describe('the layer instruction', () => {
+  test('names the first layer on entry', () => {
+    const context = new Context(new Figure(twoLayerMaidr()));
+
+    const instruction = context.getInstruction(false);
+
+    expect(instruction).toMatch(/layer 1 of 2: [a-z ]*bar plot/);
+  });
+
+  test('names the layer the reader has switched to', () => {
+    const context = new Context(new Figure(twoLayerMaidr()));
+    context.moveOnce('FORWARD');
+
+    context.stepTrace('UPWARD');
+    const instruction = context.getInstruction(false);
+
+    expect(instruction).toMatch(/layer 2 of 2: [a-z ]*line plot/);
+    expect(instruction).not.toContain('layer 1 of 2');
+  });
+});

--- a/test/model/lineIntersectionNames.test.ts
+++ b/test/model/lineIntersectionNames.test.ts
@@ -1,0 +1,54 @@
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { TextState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { LineTrace } from '@model/line';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Two lines that meet at their first point, neither of them named.
+ */
+function layer(data: LinePoint[][]): MaidrLayer {
+  return {
+    id: 'lines',
+    type: TraceType.LINE,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  };
+}
+
+function textOf(trace: LineTrace): TextState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.text;
+}
+
+describe('an intersection of unnamed lines', () => {
+  test('names the lines the way every other announcement does', () => {
+    const trace = new LineTrace(layer([
+      [{ x: 1, y: 1 }, { x: 2, y: 2 }],
+      [{ x: 1, y: 1 }, { x: 2, y: 3 }],
+    ]));
+    trace.moveToIndex(0, 0);
+
+    const { z } = textOf(trace);
+
+    // The position announcement, the description table and the intersection
+    // label all say "Line 1"; the summary must not switch to an abbreviation
+    // the reader has never been given.
+    expect(z?.value).toBe('intersection at (Line 1, Line 2)');
+  });
+
+  test('keeps an authored name when the series has one', () => {
+    const trace = new LineTrace(layer([
+      [{ x: 1, y: 1, z: 'Control' }, { x: 2, y: 2, z: 'Control' }],
+      [{ x: 1, y: 1, z: 'Treated' }, { x: 2, y: 3, z: 'Treated' }],
+    ]));
+    trace.moveToIndex(0, 0);
+
+    const { z } = textOf(trace);
+
+    expect(z?.value).toBe('intersection at (Control, Treated)');
+  });
+});

--- a/test/model/moveToNearestInitialEntry.test.ts
+++ b/test/model/moveToNearestInitialEntry.test.ts
@@ -1,0 +1,113 @@
+import type { Dimension, NearestPoint } from '@model/abstract';
+import type { ExtremaTarget } from '@type/extrema';
+import type { MaidrLayer } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type {
+  AudioState,
+  BrailleState,
+  DescriptionState,
+  TextState,
+  TraceState,
+} from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+import { AbstractTrace } from '@model/abstract';
+import { MovableGrid } from '@model/movable';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A fresh trace parks its cursor on (0, 0) with `isInitialEntry` set: nothing
+ * has been announced yet and the highlight is deliberately withheld. Pointing
+ * at the first mark has to count as entering the chart, exactly as the first
+ * arrow key does -- otherwise the first bar is the one point on the chart a
+ * pointer cannot reach until the reader has hovered some other one.
+ */
+
+const FIRST_POINT: NearestPoint = {
+  element: {} as SVGElement,
+  row: 0,
+  col: 0,
+  centerX: 10,
+  centerY: 10,
+};
+
+class PointerTrace extends AbstractTrace {
+  protected readonly supportsExtrema = false;
+  protected readonly movable: Movable;
+
+  constructor() {
+    super({
+      id: 'pointer',
+      type: TraceType.BAR,
+      title: 'Test',
+    } as MaidrLayer);
+    this.movable = new MovableGrid<number>([[1, 2, 3]]);
+  }
+
+  protected get dimension(): Dimension {
+    return { rows: 1, cols: 3 };
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: { min: 0, max: 1, raw: 0 },
+      panning: { x: this.col, y: 0, rows: 1, cols: 3 },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    return { empty: true, type: 'trace', traceType: TraceType.BAR, audio: { x: 0, y: 0, rows: 1, cols: 3 } };
+  }
+
+  protected get text(): TextState {
+    return { main: { label: 'x', value: this.col }, cross: { label: 'y', value: 0 } };
+  }
+
+  public get description(): DescriptionState {
+    return { chartType: 'Bar Plot', title: 'Test', axes: {}, stats: [], dataTable: { headers: [], rows: [] } };
+  }
+
+  protected get highlightValues(): null {
+    return null;
+  }
+
+  protected get values(): number[][] {
+    return [[1, 2, 3]];
+  }
+
+  protected findNearestPoint(_x: number, _y: number): NearestPoint | null {
+    return FIRST_POINT;
+  }
+
+  public override isPointInBounds(): boolean {
+    return true;
+  }
+
+  public override getExtremaTargets(): ExtremaTarget[] {
+    return [];
+  }
+}
+
+describe('pointing at the first mark of a fresh trace', () => {
+  it('enters the chart and announces the mark', () => {
+    const trace = new PointerTrace();
+    const update = jest.fn<(state: TraceState) => void>();
+    trace.addObserver({ update });
+
+    const guidance = trace.moveToPointAndGetPointerGuidance(10, 10);
+
+    expect(guidance).toEqual({ onCurve: true });
+    expect(trace.isInitialEntry).toBe(false);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-announce a mark the cursor already sits on once entered', () => {
+    const trace = new PointerTrace();
+    trace.moveToIndex(0, 0);
+    const update = jest.fn<(state: TraceState) => void>();
+    trace.addObserver({ update });
+
+    trace.moveToPointAndGetPointerGuidance(10, 10);
+
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/test/model/originalElements.test.ts
+++ b/test/model/originalElements.test.ts
@@ -1,0 +1,113 @@
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { Heatmap } from '@model/heatmap';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * `getAllOriginalElements` is what the high-contrast service asks for the
+ * chart's data marks, so it can tell data from furniture.
+ *
+ * A trace whose highlight values are hidden clones reaches the mark through
+ * `previousElementSibling`, because the clone is inserted straight after it.
+ * A trace that highlights the chart's live geometry in place -- a heatmap
+ * cell, a box part, a bar addressed by a list of selectors -- holds the mark
+ * itself, and its previous sibling is the *neighbouring* mark. Read the same
+ * way, the list comes back shifted by one: the last mark is missing and
+ * whatever same-tag element precedes the first mark is styled as data.
+ */
+
+function installDom(html: string): void {
+  const dom = new JSDOM(html);
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.document = dom.window.document;
+  g.SVGElement = dom.window.SVGElement;
+  g.SVGRectElement = dom.window.SVGRectElement ?? dom.window.SVGElement;
+  g.SVGPathElement = dom.window.SVGPathElement ?? class SVGPathElementStub {};
+  g.SVGImageElement = dom.window.SVGImageElement ?? class SVGImageElementStub {};
+}
+
+function uninstallDom(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.document;
+  delete g.SVGElement;
+  delete g.SVGRectElement;
+  delete g.SVGPathElement;
+  delete g.SVGImageElement;
+}
+
+/** A background rect the chart drew before its cells, then a 1x3 grid. */
+const HEATMAP_SVG = '<!doctype html><svg xmlns="http://www.w3.org/2000/svg">'
+  + '<rect id="background"/>'
+  + '<rect id="c0" class="cell"/><rect id="c1" class="cell"/><rect id="c2" class="cell"/>'
+  + '</svg>';
+
+function heatmapLayer(): MaidrLayer {
+  return {
+    id: 'hm',
+    type: TraceType.HEATMAP,
+    title: 'test',
+    axes: { x: { label: 'X' }, y: { label: 'Y' }, z: { label: 'Z' } },
+    selectors: '.cell',
+    data: {
+      x: ['a', 'b', 'c'],
+      y: ['row'],
+      points: [[1, 2, 3]],
+    } satisfies HeatmapData,
+  };
+}
+
+/** Three bars, each addressed by its own selector. */
+const BAR_SVG = '<!doctype html><svg xmlns="http://www.w3.org/2000/svg">'
+  + '<rect id="frame"/>'
+  + '<rect id="b0"/><rect id="b1"/><rect id="b2"/>'
+  + '</svg>';
+
+function barLayer(selectors: string | string[]): MaidrLayer {
+  return {
+    id: 'bars',
+    type: TraceType.BAR,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    selectors,
+    data: [{ x: 'a', y: 1 }, { x: 'b', y: 2 }, { x: 'c', y: 3 }],
+  };
+}
+
+function idsOf(elements: SVGElement[]): string[] {
+  return elements.map(element => element.id);
+}
+
+describe('getAllOriginalElements', () => {
+  afterEach(uninstallDom);
+
+  test('returns the live cells of a heatmap, not their neighbours', () => {
+    installDom(HEATMAP_SVG);
+    const trace = new Heatmap(heatmapLayer());
+
+    const originals = trace.getAllOriginalElements();
+
+    // Every cell, and only the cells. Shifted by one this would read
+    // background, c0, c1: the last cell dropped and the background styled
+    // as though it were data.
+    expect(idsOf(originals)).toEqual(['c0', 'c1', 'c2']);
+  });
+
+  test('still resolves a hidden clone back to the mark it stands beside', () => {
+    installDom(BAR_SVG);
+    const trace = new BarTrace(barLayer('#b0, #b1, #b2'));
+
+    const originals = trace.getAllOriginalElements();
+
+    expect(idsOf(originals)).toEqual(['b0', 'b1', 'b2']);
+  });
+
+  test('resolves a list of per-bar selectors to the bars themselves', () => {
+    installDom(BAR_SVG);
+    const trace = new BarTrace(barLayer(['#b0', '#b1', '#b2']));
+
+    const originals = trace.getAllOriginalElements();
+
+    expect(idsOf(originals)).toEqual(['b0', 'b1', 'b2']);
+  });
+});

--- a/test/model/scatterGridStateAt.test.ts
+++ b/test/model/scatterGridStateAt.test.ts
@@ -1,0 +1,57 @@
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import type { TextState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A live-data append is announced through `getStateAt(row, col)`, which reads
+ * the state positionally. Grid mode reshapes every getter onto the grid
+ * cursor, so unless it is suspended for the read the monitor announces the
+ * cell the reader is sitting on instead of the point that just arrived.
+ */
+function gridLayer(data: ScatterPoint[]): MaidrLayer {
+  return {
+    id: 'grid-scatter',
+    type: TraceType.SCATTER,
+    title: 'Scatter',
+    axes: {
+      x: { label: 'X', min: 0, max: 4, tickStep: 2 },
+      y: { label: 'Y', min: 0, max: 4, tickStep: 2 },
+    },
+    data,
+  };
+}
+
+function textAt(trace: ScatterTrace, row: number, col: number): TextState {
+  const state = trace.getStateAt(row, col);
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.text;
+}
+
+describe('reading a position while grid mode is active', () => {
+  test('answers for that position rather than for the current cell', () => {
+    const trace = new ScatterTrace(gridLayer([{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]));
+    trace.isInitialEntry = false;
+    trace.setGridMode(true);
+
+    const text = textAt(trace, 0, 2);
+
+    expect(text.main.value).toBe(3);
+    expect(text.gridPosition).toBeUndefined();
+  });
+
+  test('restores grid mode once the read is over', () => {
+    const trace = new ScatterTrace(gridLayer([{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]));
+    trace.isInitialEntry = false;
+    trace.setGridMode(true);
+
+    textAt(trace, 0, 2);
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    expect(!state.empty && state.text.range).toBeDefined();
+  });
+});

--- a/test/model/scatterModeExtreme.test.ts
+++ b/test/model/scatterModeExtreme.test.ts
@@ -1,0 +1,104 @@
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import type { TextState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Ctrl+Arrow is bound whatever rotor mode is active. Inside point or grid
+ * mode the extreme has to be taken within that mode: jumping the base row /
+ * column cursor instead re-announces the unchanged point and leaves the
+ * reader somewhere else, unannounced, the moment they leave the mode.
+ */
+function scatterLayer(data: ScatterPoint[], withGrid = false): MaidrLayer {
+  return {
+    id: 'scatter',
+    type: TraceType.SCATTER,
+    title: 'Scatter',
+    axes: withGrid
+      ? { x: { label: 'X', min: 0, max: 4, tickStep: 2 }, y: { label: 'Y', min: 0, max: 4, tickStep: 2 } }
+      : { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  };
+}
+
+function textOf(trace: ScatterTrace): TextState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.text;
+}
+
+/** A trace sitting in point mode on its entry point. */
+function inPointMode(): ScatterTrace {
+  const trace = new ScatterTrace(scatterLayer([{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]));
+  trace.isInitialEntry = false;
+  trace.setPointMode(true);
+  return trace;
+}
+
+/** Walks a stepper to its bound and reports the point it ends on. */
+function walkToEnd(trace: ScatterTrace, step: (t: ScatterTrace) => boolean): unknown {
+  while (step(trace)) {
+    // Keep stepping; the stepper reports the bound by returning false.
+  }
+  return textOf(trace).main.value;
+}
+
+describe('an extreme jump in point mode', () => {
+  test('lands where walking right would end, and leaves the base cursor alone', () => {
+    const end = walkToEnd(inPointMode(), t => t.movePointRight());
+    const trace = inPointMode();
+    const baseRow = trace.row;
+    const baseCol = trace.col;
+
+    const moved = trace.moveToExtreme('FORWARD');
+
+    expect(moved).toBe(true);
+    expect(textOf(trace).main.value).toBe(end);
+    expect(trace.row).toBe(baseRow);
+    expect(trace.col).toBe(baseCol);
+  });
+
+  test('lands where walking left would end', () => {
+    const end = walkToEnd(inPointMode(), t => t.movePointLeft());
+    const trace = inPointMode();
+    trace.movePointRight();
+
+    expect(trace.moveToExtreme('BACKWARD')).toBe(true);
+    expect(textOf(trace).main.value).toBe(end);
+  });
+
+  test('lands where walking down would end', () => {
+    const end = walkToEnd(inPointMode(), t => t.movePointDown());
+    const trace = inPointMode();
+
+    expect(trace.moveToExtreme('DOWNWARD')).toBe(true);
+    expect(textOf(trace).main.value).toBe(end);
+  });
+});
+
+describe('an extreme jump in grid mode', () => {
+  test('reaches the last cell column and leaves the base cursor alone', () => {
+    const trace = new ScatterTrace(scatterLayer([{ x: 0.5, y: 0.5 }, { x: 3, y: 3 }], true));
+    trace.isInitialEntry = false;
+    trace.setGridMode(true);
+
+    const moved = trace.moveToExtreme('FORWARD');
+
+    expect(moved).toBe(true);
+    expect(trace.getGridPosition()).toEqual({ row: 1, col: 2 });
+    trace.setGridMode(false);
+    expect(textOf(trace).main.value).toBe(0.5);
+  });
+
+  test('reaches the top cell row', () => {
+    const trace = new ScatterTrace(scatterLayer([{ x: 0.5, y: 0.5 }, { x: 3, y: 3 }], true));
+    trace.isInitialEntry = false;
+    trace.setGridMode(true);
+
+    expect(trace.moveToExtreme('UPWARD')).toBe(true);
+    expect(trace.getGridPosition()).toEqual({ row: 2, col: 1 });
+  });
+});

--- a/test/model/scatterXValue.test.ts
+++ b/test/model/scatterXValue.test.ts
@@ -1,0 +1,73 @@
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import type { TextState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Switching layers keeps the reader at the same X, which asks the outgoing
+ * trace for its current X. A scatter reads it off whichever axis the reader
+ * is walking: the column's x in COL mode, and in ROW mode the x it would land
+ * on when switching back to columns -- never a y value dressed up as an x,
+ * and never nothing.
+ */
+function scatterLayer(data: ScatterPoint[]): MaidrLayer {
+  return {
+    id: 'scatter',
+    type: TraceType.SCATTER,
+    title: 'Scatter',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  };
+}
+
+function textOf(trace: ScatterTrace): TextState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.text;
+}
+
+/** Three points stacked at x=1, then a row y=3 spanning x=1, 5 and 9. */
+const POINTS: ScatterPoint[] = [
+  { x: 1, y: 1 },
+  { x: 1, y: 2 },
+  { x: 1, y: 3 },
+  { x: 5, y: 3 },
+  { x: 9, y: 3 },
+];
+
+describe('the current x of a scatter', () => {
+  test('is the column x in COL mode', () => {
+    const trace = new ScatterTrace(scatterLayer(POINTS));
+    trace.moveToIndex(0, 1);
+
+    expect(trace.getCurrentXValue()).toBe(5);
+  });
+
+  test('is an x of the row, not its y, in ROW mode', () => {
+    const trace = new ScatterTrace(scatterLayer(POINTS));
+    // Entry, then a toggle into ROW mode at the column's middle y (2), then
+    // one row up to y=3 -- whose x values are 1, 5 and 9.
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('UPWARD');
+    expect(textOf(trace).main.value).toBe(3);
+
+    const x = trace.getCurrentXValue();
+
+    expect(x).toBe(5);
+  });
+
+  test('moving to an x lands on that column in COL mode', () => {
+    const trace = new ScatterTrace(scatterLayer(POINTS));
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('UPWARD');
+
+    expect(trace.moveToXValue(9)).toBe(true);
+    expect(textOf(trace).main.value).toBe(9);
+    expect(textOf(trace).cross?.value).toEqual([3]);
+  });
+});

--- a/test/model/survival.test.ts
+++ b/test/model/survival.test.ts
@@ -139,12 +139,18 @@ describe('a censored time is not an event', () => {
 });
 
 describe('the band travels with the estimate', () => {
-  test('announces the interval at this time', () => {
+  test('announces the interval alongside the estimate at this time', () => {
     // How wide the interval is at a time is how much the curve is worth
     // there, and it is the comparison a reader makes when two arms look
-    // separated.
-    expect(nonEmptyState(survival(0, 2)).text.crossRange)
-      .toEqual({ min: 0.59, max: 0.83 });
+    // separated. It travels as `interval`, which the text service reads
+    // *after* the estimate; a `crossRange` would replace the estimate with
+    // the band, and the survival probability -- the number the curve is
+    // read for -- would never be spoken.
+    const { text } = nonEmptyState(survival(0, 2));
+
+    expect(text.cross?.value).toBe(0.71);
+    expect(text.interval).toEqual({ min: 0.59, max: 0.83 });
+    expect(text.crossRange).toBeUndefined();
   });
 
   test('says nothing when the chart draws no band', () => {
@@ -152,6 +158,7 @@ describe('the band travels with the estimate', () => {
       [{ x: 0, y: 1, z: 'Only' }, { x: 1, y: 0.4, z: 'Only' }],
     ];
 
+    expect(nonEmptyState(survival(0, 1, bare)).text.interval).toBeUndefined();
     expect(nonEmptyState(survival(0, 1, bare)).text.crossRange).toBeUndefined();
   });
 });

--- a/test/model/violinKdePanning.test.ts
+++ b/test/model/violinKdePanning.test.ts
@@ -1,0 +1,84 @@
+import type { MaidrLayer, ViolinKdePoint } from '@type/grammar';
+import type { AudioState, TraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { ViolinKdeTrace } from '@model/violin';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Stereo panning follows the on-screen x position. On a vertical violin the
+ * violins sit side by side along x, so switching violins is what pans left to
+ * right; climbing the density curve of one violin is a vertical movement and
+ * must not move the pan at all. On a horizontal violin the curve runs along
+ * x, so the position on it pans.
+ *
+ * `AudioService.stereoSlotOf` reads only `panning.x` against `panning.cols`,
+ * which is why those two are what the tests pin.
+ */
+
+function violinKdeLayer(orientation: Orientation): MaidrLayer {
+  const curve = (offset: number): ViolinKdePoint[] => [
+    { x: 'g', y: offset, density: 0.1 },
+    { x: 'g', y: offset + 1, density: 0.5 },
+    { x: 'g', y: offset + 2, density: 0.2 },
+  ];
+  return {
+    id: 'kde',
+    type: TraceType.VIOLIN_KDE,
+    orientation,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    selectors: [],
+    data: [curve(0), curve(10), curve(20)],
+  };
+}
+
+function audioOf(trace: { state: TraceState }): AudioState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state.audio;
+}
+
+describe('vertical violin kde panning', () => {
+  test('pans across the violins', () => {
+    const trace = new ViolinKdeTrace(violinKdeLayer(Orientation.VERTICAL));
+
+    // Violins are rows and curve positions are columns.
+    trace.moveToIndex(0, 0);
+    const first = audioOf(trace).panning;
+    trace.moveToIndex(2, 0);
+    const last = audioOf(trace).panning;
+
+    expect(first.x).toBe(0);
+    expect(last.x).toBe(2);
+    expect(first.cols).toBe(3);
+    expect(last.cols).toBe(3);
+  });
+
+  test('holds the pan while climbing one violin', () => {
+    const trace = new ViolinKdeTrace(violinKdeLayer(Orientation.VERTICAL));
+
+    trace.moveToIndex(1, 0);
+    const bottom = audioOf(trace).panning;
+    trace.moveToIndex(1, 2);
+    const higher = audioOf(trace).panning;
+
+    expect(higher.x).toBe(bottom.x);
+    expect(higher.cols).toBe(bottom.cols);
+  });
+});
+
+describe('horizontal violin kde panning', () => {
+  test('pans along the curve', () => {
+    const trace = new ViolinKdeTrace(violinKdeLayer(Orientation.HORIZONTAL));
+
+    trace.moveToIndex(0, 0);
+    const first = audioOf(trace).panning;
+    trace.moveToIndex(0, 2);
+    const last = audioOf(trace).panning;
+
+    expect(first.x).toBe(0);
+    expect(last.x).toBe(2);
+    expect(last.cols).toBe(3);
+  });
+});

--- a/test/service/navigationLayerSwitch.test.ts
+++ b/test/service/navigationLayerSwitch.test.ts
@@ -1,0 +1,86 @@
+import type { Maidr } from '@type/grammar';
+import type { PlotState, SubplotState, TraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { NavigationService } from '@service/navigation';
+import { TraceType } from '@type/grammar';
+
+/**
+ * PageUp / PageDown at the edge of a subplot's layers has one answer: the
+ * trace's boundary tone and the subplot's "no additional layer". Every extra
+ * empty notification is another overlapping tone and a repeated sentence.
+ */
+function twoLayerFigure(): Figure {
+  const maidr: Maidr = {
+    id: 'layers',
+    subplots: [[{
+      layers: [
+        { id: 'bars', type: TraceType.BAR, data: [{ x: 'A', y: 1 }, { x: 'B', y: 2 }] },
+        { id: 'line', type: TraceType.LINE, data: [[{ x: 'A', y: 3 }, { x: 'B', y: 4 }]] },
+      ],
+    }]],
+  };
+  return new Figure(maidr);
+}
+
+/** Records every state each observed element emits, tagged by its source. */
+function record(figure: Figure): { log: string[] } {
+  const log: string[] = [];
+  const subplot = figure.activeSubplot;
+  subplot.addObserver({
+    update: (state: SubplotState) => log.push(`subplot:${state.empty ? 'empty' : 'ok'}`),
+  });
+  subplot.traces.flat().forEach((trace, index) => {
+    trace.addObserver({
+      update: (state: TraceState | PlotState) => log.push(`trace${index}:${state.empty ? 'empty' : 'ok'}`),
+    });
+  });
+  return { log };
+}
+
+describe('stepping between layers', () => {
+  test('announces a boundary exactly once for the trace and once for the subplot', () => {
+    const figure = twoLayerFigure();
+    const subplot = figure.activeSubplot;
+    const service = new NavigationService();
+    service.stepTraceInSubplot(subplot, 'UPWARD');
+    const { log } = record(figure);
+
+    const result = service.stepTraceInSubplot(subplot, 'UPWARD');
+
+    expect(result).toBe(subplot.traces[1][0]);
+    expect(log.filter(entry => entry.endsWith(':empty'))).toEqual(['trace1:empty', 'subplot:empty']);
+    expect(log.filter(entry => entry.endsWith(':ok'))).toEqual([]);
+  });
+
+  test('a successful switch emits no boundary notification', () => {
+    const figure = twoLayerFigure();
+    const subplot = figure.activeSubplot;
+    const service = new NavigationService();
+    const { log } = record(figure);
+
+    const result = service.stepTraceInSubplot(subplot, 'UPWARD');
+
+    expect(result).toBe(subplot.traces[1][0]);
+    expect(log.filter(entry => entry.endsWith(':empty'))).toEqual([]);
+    expect(log).toContain('trace1:ok');
+    // The switch is announced from the positioned trace; a subplot state at
+    // this point would describe the new trace at its stale column.
+    expect(log.filter(entry => entry.startsWith('subplot'))).toEqual([]);
+  });
+
+  test('a single-layer subplot cannot switch and reports the boundary once each', () => {
+    const figure = new Figure({
+      id: 'single',
+      subplots: [[{ layers: [{ id: 'bars', type: TraceType.BAR, data: [{ x: 'A', y: 1 }] }] }]],
+    });
+    const subplot = figure.activeSubplot;
+    const { log } = record(figure);
+    const service = new NavigationService();
+
+    const result = service.stepTraceInSubplot(subplot, 'DOWNWARD');
+
+    expect(result).toBe(subplot.traces[0][0]);
+    expect(log).toEqual(['trace0:empty', 'subplot:empty']);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Fourteen places where a trace announced the wrong thing, dropped a highlight, swallowed a keypress, or panned the wrong way. Found in a codebase audit; each has a test that failed before the change.

## Related Issues

None.

## Changes Made

**Announcements**

- **survival**: the estimate is announced alongside its band. The trace set `crossRange` on top of the band `LineTrace` already carries as `interval`, so a point read as "Y is 0.79 through 0.97, interval 0.79 through 0.97" and the survival probability itself was never spoken.
- **flow**: a ribbon is not announced on the keypress that only enters the chart.
- **context**: the subplot instruction names the active layer instead of always saying "layer 1 of N".
- **line**: an unnamed series is named "Line 1" in the intersection summary, as it is everywhere else, instead of "l1".

**Navigation**

- **model**: a rotor compare jump clears the initial-entry flag, so the jump highlights and the next arrow key is not swallowed. Bar, histogram, pie and line all lacked this; candlestick already had it and documents why.
- **model**: pointing at the first mark of a fresh trace moves and announces, instead of returning early because the cursor already sat there with nothing announced.
- **waterfall, error bar, dumbbell**: these store points flat, so `getCurrentXValue` always answered null and the rotor's compare keys were silent. They now answer with their own x and search along the row.
- **navigation**: a layer boundary reports once. The subplot notified its own boundary and the service then notified the trace and the subplot again, so a reader heard two overlapping empty tones and two identical announcements. A successful switch now steps the layer silently, so the only states observers see are the positioned trace and the layer switch.
- **scatter**: `moveToExtreme` respects the active rotor mode instead of rewriting the base cursor behind it; `getStateAt` suspends grid mode so a live-data announcement describes the appended point rather than the cell the reader is sitting on; `getCurrentXValue` answers in terms of the active mode.

**Sonification and highlighting**

- **box, violin box**: a vertical box pans by box rather than by section, so moving between boxes moves the stereo image and moving up through sections does not.
- **violin (KDE)**: a vertical violin pans by violin; both orientation branches were the same object.
- **model**: `getAllOriginalElements` returns live chart geometry as itself. It assumed every entry was a hidden clone and reached for the previous sibling, which for heatmap cells, box parts and list-selector bars is the neighbouring mark: the whole list came back shifted by one, so high contrast styled the last mark as furniture and a non-data element as data.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`test/model/survival.test.ts` asserted the double reading; it now asserts the estimate, the interval and the absence of `crossRange`, as the commit body explains. `Subplot` gained a public `stepLayer` used by the layer-switch path, and `AbstractTrace` a protected `compareSearchAlongRow` shared by the three flat-point traces.

`npm run lint`, `npm run type-check`, `npm test` (6606 + 158) and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_