### PR TITLE
fix(service): sound the data tones a suspended context swallowed, and four more service defects

### DIFF
--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -316,6 +316,43 @@ export class AudioService implements Observer<PlotState>, Disposable {
       return;
     }
 
+    // A suspended context reports currentTime === 0, so a data tone scheduled
+    // against it starts and stops at the same frozen instant and is simply
+    // never heard — the context is created from a timeout after focus-in, and
+    // when that focus is programmatic (a screen reader's virtual cursor,
+    // `autofocus`, a host page calling `.focus()`) it is born suspended and
+    // stays that way. The cue paths defer behind resume() one level down; the
+    // data tones defer here, so the first point of a chart is heard rather
+    // than dropped. Keyboard navigation is the user gesture resume() needs.
+    if (this.audioContext.state !== 'running') {
+      // At volume 0 the update is silent whichever branch it takes, so it must
+      // neither trigger resume() nor claim the shared deferred-cue slot —
+      // mirroring the outer guards in playEmptyTone and playMenuTone.
+      if (this.volume > 0) {
+        this.scheduleWhenRunning(() => this.playState(state));
+      }
+      return;
+    }
+
+    this.playState(state);
+  }
+
+  /**
+   * Sounds one plot state on a running {@link AudioContext}.
+   *
+   * Split out of {@link update} so the whole path — cue tones and data tones
+   * alike — can be deferred behind {@link AudioContext.resume} as a unit.
+   * Re-checks mode and context state because it can run after that async gap,
+   * by which point the user may have turned sound off or the context may have
+   * been closed on disposal.
+   *
+   * @param state - The plot state to sonify
+   */
+  private playState(state: PlotState): void {
+    if (this.mode === AudioMode.OFF || this.audioContext.state !== 'running') {
+      return;
+    }
+
     if (state.empty) {
       if (state.warning) {
         this.playWarningTone();

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -478,6 +478,12 @@ export class AudioService implements Observer<PlotState>, Disposable {
           const chainId = setTimeout(() => {
             this.activeAudioIds.delete(chainId);
             this.chordChainId = null;
+            // Sound may have been turned off since this step was queued. The
+            // echo timers make the same check for the same reason: OFF must
+            // silence what is already in flight, not just what comes next.
+            if (this.mode === AudioMode.OFF) {
+              return;
+            }
             playNext();
           }, playRate);
           this.activeAudioIds.set(chainId, []);
@@ -1700,6 +1706,14 @@ export class AudioService implements Observer<PlotState>, Disposable {
       case AudioMode.COMBINED:
         this.mode = AudioMode.SEPARATE;
         break;
+    }
+
+    if (this.mode === AudioMode.OFF) {
+      // Silence what is already queued for the current point: the chord chain
+      // would otherwise keep sounding tones — and queueing their echoes —
+      // over the "Sound is off" announcement.
+      this.cancelChordChain();
+      this.cancelPendingEchoes();
     }
 
     const mode

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1462,7 +1462,48 @@ implements Observer<SubplotState | TraceState>, Disposable {
     }
 
     const { row, col } = this.cache.indexToCell[index];
+    if (this.isRowSentinel(index, row, col)) {
+      return;
+    }
+
     this.context.moveToIndex(row, col);
+  }
+
+  /**
+   * Whether an index addresses a row's virtual sentinel rather than a cell.
+   *
+   * A single-line row ends in a `\n` whose `indexToCell` entry is
+   * `{row, col: cols}` — one past the row's last data column — so that the
+   * emitted cursor index can round-trip through `cellToIndex`. It is a
+   * separator, not a cell the reader can stand on, and End, a click past the
+   * last cell, or a display's cursor-routing key all land the caret on it.
+   * Forwarding it hands the model a column that does not exist: traces backed
+   * by a movable grid answer with an "out of bounds" cue for a move the reader
+   * never made, and a trace that trusts the column instead follows it out of
+   * its own data.
+   *
+   * Every other newline in the output maps back to a real cell — a mid-row
+   * wrap points at the last cell before the wrap, a box row terminator at its
+   * final section — so those stay forwarded and End still lands on the last
+   * cell of the line. Hence all three conditions: the character is a newline,
+   * it is the row's last `cellToIndex` entry, and that entry is this index.
+   *
+   * @param index - Index into the emitted braille string
+   * @param row - Row the index maps to
+   * @param col - Column the index maps to
+   * @returns Whether the index is the row's out-of-data sentinel
+   */
+  private isRowSentinel(index: number, row: number, col: number): boolean {
+    if (this.cache === null || this.cache.value[index] !== Constant.NEW_LINE) {
+      return false;
+    }
+
+    const rowCells = this.cache.cellToIndex[row];
+    if (rowCells === undefined) {
+      return false;
+    }
+
+    return col === rowCells.length - 1 && rowCells[col] === index;
   }
 
   /**

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -628,24 +628,58 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
       if (hasAdjustable) {
         let diff = displaySize - totalChars;
         let adjustIndex = 0;
+        let adjustedThisPass = false;
         while (diff !== 0) {
           const section = lenData[adjustIndex % lenData.length];
           if (
             section.type !== this.BLANK
             && section.type !== this.Q2
             && section.length > 0
+            // Never squeeze a summary section out of existence. At zero it
+            // renders nothing while still claiming a cursor cell, so the
+            // minimum's cell becomes the quartile's glyph, and a row that is
+            // still too wide pushes the cells that follow past its end.
+            && (diff > 0 || section.numChars > 1)
           ) {
             section.numChars += diff > 0 ? 1 : -1;
             diff += diff > 0 ? -1 : 1;
+            adjustedThisPass = true;
           }
           adjustIndex++;
+          if (adjustIndex % lenData.length === 0) {
+            // A full pass that changed nothing cannot make progress on the
+            // next one either: every section is already at its floor, and the
+            // remaining width has to come out of the outlier runs below.
+            if (!adjustedThisPass) {
+              break;
+            }
+            adjustedThisPass = false;
+          }
+        }
+      }
+
+      // Outliers are one cell each and a box can carry more of them than the
+      // display is wide. Collapsing the run — dropping cells from the end of
+      // it, never all of them — keeps the five-number summary readable and
+      // still leaves the reader a cell to navigate the outliers by, which is
+      // the better of the two readings a narrow display can give.
+      let overflow
+        = lenData.reduce((sum, l) => sum + l.numChars, 0) - displaySize;
+      for (const outlierType of [this.LOWER_OUTLIER, this.UPPER_OUTLIER]) {
+        const run = lenData.filter(section => section.type === outlierType);
+        for (let i = run.length - 1; i > 0 && overflow > 0; i--) {
+          overflow -= run[i].numChars;
+          run[i].numChars = 0;
         }
       }
 
       let col = -1;
       for (const section of lenData) {
+        // Only a section that renders may claim a cell: an empty one would
+        // hand its column the index of whatever is emitted next.
         if (
-          section.type !== this.BLANK
+          section.numChars > 0
+          && section.type !== this.BLANK
           && section.type !== this.GLOBAL_MIN
           && section.type !== this.GLOBAL_MAX
         ) {

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -910,6 +910,29 @@ export class TextService implements Observer<PlotState>, Disposable {
       return;
     }
 
+    // Layer-level out-of-bounds: Page Up or Page Down at the first or last
+    // layer, and every such press on a single-layer chart, which
+    // Context.stepTrace answers with this state. The cue is unchanged — it
+    // still goes out as a notification with format()'s "No additional layer"
+    // wording — but like the two branches above it must return before the
+    // bookkeeping below, because the reader never moved: overwriting
+    // `currentState` with an empty one left getCoordinateText() null, so the
+    // AI chat's "current position" went blank on a keypress that did nothing.
+    if (
+      state
+      && state.empty
+      && state.type === 'subplot'
+      && !state.warning
+    ) {
+      if (this.mode !== TextMode.OFF) {
+        const text = this.format(state);
+        if (text) {
+          this.notification.notify(text);
+        }
+      }
+      return;
+    }
+
     // Store the current state for access by ViewModels. This bookkeeping runs
     // regardless of text mode so the AI chat's "current position" stays fresh
     // even after the user toggles text mode OFF and keeps navigating.

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -107,19 +107,32 @@ export const formatters = {
    * formatters.currency('USD', 2)(1234.5) // "$1,234.50"
    * formatters.currency('EUR', 0, 'de-DE')(1234) // "1.234 EUR"
    */
-  currency: (currency = 'USD', decimals = 2, locale = 'en-US'): FormatFunction =>
-    (value: number | string): string => {
+  currency: (currency = 'USD', decimals = 2, locale = 'en-US'): FormatFunction => {
+    // One Intl object per axis, not per announced value. The factory runs once
+    // per layer and axis, so the options are already fixed; constructing an
+    // Intl formatter costs orders of magnitude more than formatting with one,
+    // and this sits on the keypress path — several values per move, whole
+    // arrays of them for a scatter row or a box's outliers.
+    //
+    // Built on first use rather than here so a currency code or locale the
+    // chart got wrong still fails where it always did — at format time, where
+    // `wrapFormat` turns it into a fallback — instead of taking the layer's
+    // initialisation down with it.
+    let formatter: Intl.NumberFormat | undefined;
+    return (value: number | string): string => {
       const num = asFiniteNumber(value);
       if (num === null) {
         return String(value);
       }
-      return new Intl.NumberFormat(locale, {
+      formatter ??= new Intl.NumberFormat(locale, {
         style: 'currency',
         currency,
         minimumFractionDigits: decimals,
         maximumFractionDigits: decimals,
-      }).format(num);
-    },
+      });
+      return formatter.format(num);
+    };
+  },
 
   /**
    * Creates a percentage formatter.
@@ -151,8 +164,10 @@ export const formatters = {
    * formatters.date({ month: 'short', day: 'numeric' })('2023-01-15') // "Jan 15"
    * formatters.date({ year: 'numeric', month: 'long' })(1704067200000) // "January 2024"
    */
-  date: (options?: Intl.DateTimeFormatOptions, locale = 'en-US'): FormatFunction =>
-    (value: number | string): string => {
+  date: (options?: Intl.DateTimeFormatOptions, locale = 'en-US'): FormatFunction => {
+    // See `currency`: one Intl object per axis, built on first use.
+    let formatter: Intl.DateTimeFormat | undefined;
+    return (value: number | string): string => {
       // `Intl.DateTimeFormat.format` *throws* a RangeError on an invalid
       // date rather than returning a NaN-ish string, and nothing between
       // here and the announcement catches it -- so a date format on a named
@@ -161,8 +176,10 @@ export const formatters = {
       if (Number.isNaN(date.getTime())) {
         return String(value);
       }
-      return new Intl.DateTimeFormat(locale, options).format(date);
-    },
+      formatter ??= new Intl.DateTimeFormat(locale, options);
+      return formatter.format(date);
+    };
+  },
 
   /**
    * Creates a number formatter with optional decimal places and grouping.
@@ -175,17 +192,21 @@ export const formatters = {
    * formatters.number(2)(1234567.89) // "1,234,567.89"
    * formatters.number(0, 'de-DE')(1234567) // "1.234.567"
    */
-  number: (decimals = 0, locale = 'en-US'): FormatFunction =>
-    (value: number | string): string => {
+  number: (decimals = 0, locale = 'en-US'): FormatFunction => {
+    // See `currency`: one Intl object per axis, built on first use.
+    let formatter: Intl.NumberFormat | undefined;
+    return (value: number | string): string => {
       const num = asFiniteNumber(value);
       if (num === null) {
         return String(value);
       }
-      return new Intl.NumberFormat(locale, {
+      formatter ??= new Intl.NumberFormat(locale, {
         minimumFractionDigits: decimals,
         maximumFractionDigits: decimals,
-      }).format(num);
-    },
+      });
+      return formatter.format(num);
+    };
+  },
 
   /**
    * Creates a scientific notation formatter.

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -324,8 +324,23 @@ export abstract class FormatUtil {
         return missingText;
       }
 
-      // Normal case: apply the format function
-      return format(value);
+      // Normal case: apply the format function.
+      //
+      // A chart's own `format.function` body is compiled here with `new
+      // Function` and can throw on a value the axis carries but its author did
+      // not have in mind — `value.toFixed(2)` meeting a category label, say.
+      // Nothing above catches it: the throw leaves TextService.update, which
+      // observes the trace before the review, highlight and tactile services,
+      // so a single bad value costs the reader all three for that keypress,
+      // and from the braille textarea's selectionchange handler it escapes
+      // uncaught entirely. This is the one choke point every axis formatter
+      // passes through, so the fallback belongs here.
+      try {
+        return format(value);
+      } catch (error) {
+        console.warn('[FormatUtil] Format function threw; using the default format:', error);
+        return defaultFormat(value);
+      }
     };
   }
 

--- a/test/service/audio.chordChain.test.ts
+++ b/test/service/audio.chordChain.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the chord chain — the self-rescheduling timer that sounds one tone
+ * per tick when a point carries several magnitudes (a scatter column, a grid
+ * cell). Turning sound off must silence what is still queued, the way the echo
+ * timers already do: the toggle announces "Sound is off" while the chain would
+ * otherwise keep playing the point the reader has just muted.
+ *
+ * AudioContext doesn't exist in the node test environment, so we install a
+ * minimal global mock that records createOscillator calls (the visible side
+ * effect), mirroring test/service/audio.emptyTone.test.ts.
+ */
+import type { NotificationService } from '@service/notification';
+import type { SettingsService } from '@service/settings';
+import type { PlotState } from '@type/state';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+interface MockOscillator {
+  type: string;
+  frequency: { value: number; setValueAtTime: jest.Mock; exponentialRampToValueAtTime: jest.Mock };
+  connect: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+interface MockAudioContext {
+  currentTime: number;
+  state: string;
+  destination: object;
+  oscillators: MockOscillator[];
+  createOscillator: () => MockOscillator;
+  createGain: () => unknown;
+  createStereoPanner: () => unknown;
+  createDynamicsCompressor: () => unknown;
+  resume: () => Promise<void>;
+  close: () => void;
+}
+
+function makeOscillator(): MockOscillator {
+  return {
+    type: '',
+    frequency: {
+      value: 0,
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makeGain(): unknown {
+  return {
+    gain: {
+      value: 0,
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+      linearRampToValueAtTime: jest.fn(),
+      setValueCurveAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makePanner(): unknown {
+  return { pan: { value: 0 }, connect: jest.fn(), disconnect: jest.fn() };
+}
+
+function makeCompressor(): unknown {
+  return {
+    threshold: { value: 0 },
+    knee: { value: 0 },
+    ratio: { value: 0 },
+    attack: { value: 0 },
+    release: { value: 0 },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function installAudioContextMock(): MockAudioContext {
+  const ctx: MockAudioContext = {
+    currentTime: 0,
+    state: 'running',
+    destination: {},
+    oscillators: [],
+    createOscillator() {
+      const osc = makeOscillator();
+      this.oscillators.push(osc);
+      return osc;
+    },
+    createGain: makeGain,
+    createStereoPanner: makePanner,
+    createDynamicsCompressor: makeCompressor,
+    resume() {
+      this.state = 'running';
+      return Promise.resolve();
+    },
+    close: jest.fn(),
+  };
+  const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };
+  audioGlobal.AudioContext = function () {
+    return ctx;
+  } as unknown as new () => MockAudioContext;
+  return ctx;
+}
+
+function createSettings(): SettingsService {
+  return {
+    get: <T>(key: string) => (key === 'general.volume' ? 100 : 100) as unknown as T,
+    onChange: () => {},
+  } as unknown as SettingsService;
+}
+
+function createNotification(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+const INITIAL_STATE: PlotState = { empty: true, type: 'figure' };
+
+// One tone per 50 ms tick in SEPARATE mode.
+const CHORD_TICK_MS = 50;
+
+/**
+ * A point carrying several magnitudes, which update() sounds as a chord.
+ * `hasMultiPoints` stays false so the service keeps the SEPARATE mode that
+ * staggers the tones; COMBINED plays them all on the same tick.
+ * @param values - The magnitudes the point reports
+ * @returns A non-empty trace state for update()
+ */
+function chordState(values: number[]): PlotState {
+  return {
+    empty: false,
+    type: 'trace',
+    traceType: 'point',
+    hasMultiPoints: false,
+    audio: {
+      freq: { min: 0, max: 100, raw: values },
+      panning: { x: 0, y: 0, rows: 1, cols: 1 },
+    },
+  } as unknown as PlotState;
+}
+
+describe('audioService chord chain', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('sounds one tone per tick while the chord plays out', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(chordState([10, 20, 30, 40, 50]));
+    jest.advanceTimersByTime(CHORD_TICK_MS * 2 + 20);
+
+    expect(ctx.oscillators.length).toBe(3);
+    service.dispose();
+  });
+
+  it('stops sounding the rest of a chord once sound is turned off', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(chordState([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]));
+    jest.advanceTimersByTime(CHORD_TICK_MS * 2 + 20);
+    const sounded = ctx.oscillators.length;
+    service.toggle(); // SEPARATE -> OFF, mid-chord
+
+    jest.advanceTimersByTime(CHORD_TICK_MS * 20);
+
+    expect(ctx.oscillators.length).toBe(sounded);
+    service.dispose();
+  });
+
+  it('still plays a chord in full when sound stays on', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(chordState([10, 20, 30, 40, 50]));
+    jest.advanceTimersByTime(CHORD_TICK_MS * 10);
+
+    expect(ctx.oscillators.length).toBe(5);
+    service.dispose();
+  });
+});

--- a/test/service/audio.dataTone.test.ts
+++ b/test/service/audio.dataTone.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the AudioService data-tone path on a suspended AudioContext.
+ *
+ * The context is constructed when the controller is built, which happens from
+ * a timeout after focus-in. When that focus is programmatic — a screen
+ * reader's virtual cursor, `autofocus`, a host page calling `.focus()` — the
+ * context is created `suspended` and its clock is frozen at 0, so a tone
+ * scheduled against it is never heard. The cue paths (empty, warning, menu)
+ * already defer behind `resume()`; the data tones every arrow key plays must
+ * do the same, and must play exactly once when it settles.
+ *
+ * AudioContext doesn't exist in the node test environment, so we install a
+ * minimal global mock that records createOscillator calls (the visible side
+ * effect), mirroring test/service/audio.emptyTone.test.ts.
+ */
+import type { NotificationService } from '@service/notification';
+import type { SettingsService } from '@service/settings';
+import type { PlotState } from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+
+interface MockOscillator {
+  type: string;
+  frequency: { value: number; setValueAtTime: jest.Mock; exponentialRampToValueAtTime: jest.Mock };
+  connect: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+interface MockAudioContext {
+  currentTime: number;
+  state: string;
+  destination: object;
+  oscillators: MockOscillator[];
+  resumeCalls: number;
+  createOscillator: () => MockOscillator;
+  createGain: () => unknown;
+  createStereoPanner: () => unknown;
+  createDynamicsCompressor: () => unknown;
+  resume: () => Promise<void>;
+  close: () => void;
+}
+
+function makeOscillator(): MockOscillator {
+  return {
+    type: '',
+    frequency: {
+      value: 0,
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makeGain(): unknown {
+  return {
+    gain: {
+      value: 0,
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+      linearRampToValueAtTime: jest.fn(),
+      setValueCurveAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makePanner(): unknown {
+  return { pan: { value: 0 }, connect: jest.fn(), disconnect: jest.fn() };
+}
+
+function makeCompressor(): unknown {
+  return {
+    threshold: { value: 0 },
+    knee: { value: 0 },
+    ratio: { value: 0 },
+    attack: { value: 0 },
+    release: { value: 0 },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+/**
+ * Installs a global AudioContext mock in the requested initial state.
+ * `resume()` flips the state only when the returned promise settles, the way
+ * a real context does, so a cue requested while suspended is still suspended
+ * at the moment it is requested.
+ * @param state - Initial context state
+ * @returns The single context every `new AudioContext()` returns
+ */
+function installAudioContextMock(state: string = 'running'): MockAudioContext {
+  const ctx: MockAudioContext = {
+    currentTime: 0,
+    state,
+    destination: {},
+    oscillators: [],
+    resumeCalls: 0,
+    createOscillator() {
+      const osc = makeOscillator();
+      this.oscillators.push(osc);
+      return osc;
+    },
+    createGain: makeGain,
+    createStereoPanner: makePanner,
+    createDynamicsCompressor: makeCompressor,
+    resume() {
+      this.resumeCalls += 1;
+      return Promise.resolve().then(() => {
+        this.state = 'running';
+      });
+    },
+    close: jest.fn(),
+  };
+  const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };
+  audioGlobal.AudioContext = function () {
+    return ctx;
+  } as unknown as new () => MockAudioContext;
+  return ctx;
+}
+
+function createSettings(volume: number = 100): SettingsService {
+  return {
+    get: <T>(key: string) => (key === 'general.volume' ? volume : 100) as unknown as T,
+    onChange: () => {},
+  } as unknown as SettingsService;
+}
+
+function createNotification(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+const INITIAL_STATE: PlotState = { empty: true, type: 'figure' };
+
+/**
+ * A populated single-bar trace state carrying the given magnitude.
+ * @param raw - The magnitude the bar reports
+ * @returns A non-empty trace state for update()
+ */
+function barState(raw: number): PlotState {
+  return {
+    empty: false,
+    type: 'trace',
+    traceType: 'bar',
+    audio: {
+      freq: { min: 40, max: 120, raw },
+      panning: { x: 0, y: 0, rows: 1, cols: 1 },
+    },
+  } as unknown as PlotState;
+}
+
+describe('audioService data tones on a suspended context', () => {
+  it('plays a data tone straight away when the context is already running', async () => {
+    const ctx = installAudioContextMock('running');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(barState(60));
+
+    expect(ctx.oscillators.length).toBeGreaterThan(0);
+    expect(ctx.resumeCalls).toBe(0);
+    service.dispose();
+  });
+
+  it('resumes a suspended context and plays the data tone once it is running', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(barState(60));
+
+    // Nothing yet: scheduling against a frozen clock would start and stop the
+    // oscillator at the same instant, so the point would simply be silent.
+    expect(ctx.oscillators.length).toBe(0);
+    expect(ctx.resumeCalls).toBe(1);
+
+    // Two microtask hops: the state flip, then the deferred scheduling.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.state).toBe('running');
+    expect(ctx.oscillators.length).toBeGreaterThan(0);
+    service.dispose();
+  });
+
+  it('plays a deferred data tone exactly once', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(barState(60));
+    await Promise.resolve();
+    await Promise.resolve();
+    const afterResume = ctx.oscillators.length;
+
+    // A second point on the now-running context adds one more tone's worth of
+    // oscillators, not two: the deferred first tone must not replay.
+    service.update(barState(90));
+
+    expect(ctx.oscillators.length).toBe(afterResume * 2);
+    service.dispose();
+  });
+
+  it('drops a data tone still waiting on resume() when audio is toggled off', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(barState(60));
+    service.toggle(); // SEPARATE -> OFF during the async resume() gap
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.oscillators.length).toBe(0);
+    service.dispose();
+  });
+
+  it('drops a data tone still waiting on resume() when the service is disposed', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    service.update(barState(60));
+    service.dispose();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.oscillators.length).toBe(0);
+  });
+});

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -250,6 +250,46 @@ function createBoxTraceState(
   };
 }
 
+// Section columns a box braille row is navigated by.
+const BOX_LOWER_OUTLIER = 0;
+const BOX_MIN = 1;
+const BOX_Q1 = 2;
+const BOX_Q2 = 3;
+const BOX_Q3 = 4;
+const BOX_MAX = 5;
+
+/**
+ * Encodes one box and reports the cell each of its seven sections maps to.
+ *
+ * The cursor index is only emitted for the section the state sits on, so the
+ * box is encoded once per section — the way the reader reaches them, one
+ * arrow key at a time.
+ * @param box - The box to encode
+ * @param displaySize - Braille display width in cells
+ * @returns The row's characters and the emitted index per section column
+ */
+function encodeBoxSectionCells(
+  box: { lowerOutliers: number[]; min: number; q1: number; q2: number; q3: number; max: number; upperOutliers: number[] },
+  displaySize: number,
+): { row: string; indices: number[] } {
+  const indices = new Array<number>();
+  let row = '';
+  for (let col = 0; col < 7; col++) {
+    const { service } = createBrailleService(displaySize);
+    const state = createBoxTraceState([box], 0, 100, 0, col);
+    const disposable = service.onChange((event) => {
+      row = event.value.split('\n')[0];
+      indices[col] = event.index;
+    });
+
+    service.toggle(state);
+
+    disposable.dispose();
+    service.dispose();
+  }
+  return { row, indices };
+}
+
 /**
  * Creates a settings mock and exposes a helper to emit display-size change events.
  * @param displaySize - Initial display width used by the encoder
@@ -1070,6 +1110,107 @@ describe('BrailleService display-size encoding', () => {
     disposable.dispose();
     service.dispose();
   }, 5000);
+
+  test('keeps every box section on a display narrower than its outliers', () => {
+    // A 14-cell display (the Focus 14 preset) against a box with more
+    // outliers than it has cells. The row used to be squeezed by driving
+    // min/q1/q3/max to zero characters each: the sections vanished from the
+    // display while still claiming a cursor cell, so the minimum's cell was
+    // the quartile's glyph, and once the row still overran the display those
+    // cells pointed past its end — in multiline mode, into the next box's
+    // line. The outlier run is the part that collapses instead.
+    const box = {
+      lowerOutliers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      min: 30,
+      q1: 40,
+      q2: 50,
+      q3: 60,
+      max: 70,
+      upperOutliers: [] as number[],
+    };
+
+    const { row, indices } = encodeBoxSectionCells(box, 14);
+
+    expect(row.length).toBe(14);
+    expect(indices.every(index => index >= 0 && index < row.length)).toBe(true);
+    expect(row[indices[BOX_LOWER_OUTLIER]]).toBe('⠂');
+    expect(row[indices[BOX_MIN]]).toBe('⠒');
+    expect(row[indices[BOX_Q1]]).toBe('⠿');
+    expect(row[indices[BOX_Q2]]).toBe('⠸');
+    expect(row[indices[BOX_Q3]]).toBe('⠿');
+    expect(row[indices[BOX_MAX]]).toBe('⠒');
+  });
+
+  test('gives the minimum a cell of its own when outliers just fill the row', () => {
+    // Nine outliers on a 14-cell display is one cell over: the single
+    // decrement used to come out of the minimum, which then shared the first
+    // quartile's cell.
+    const box = {
+      lowerOutliers: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      min: 30,
+      q1: 40,
+      q2: 50,
+      q3: 60,
+      max: 70,
+      upperOutliers: [] as number[],
+    };
+
+    const { row, indices } = encodeBoxSectionCells(box, 14);
+
+    expect(row.length).toBe(14);
+    expect(row[indices[BOX_MIN]]).toBe('⠒');
+    expect(indices[BOX_MIN]).not.toBe(indices[BOX_Q1]);
+  });
+
+  test('leaves a box that fits the display unchanged', () => {
+    const box = {
+      lowerOutliers: [] as number[],
+      min: 30,
+      q1: 40,
+      q2: 50,
+      q3: 60,
+      max: 70,
+      upperOutliers: [95],
+    };
+
+    const { row } = encodeBoxSectionCells(box, 14);
+
+    expect(row).toBe('⠀⠀⠒⠿⠿⠸⠇⠿⠿⠒⠒⠂⠀⠀');
+  });
+
+  test('multiline mode: an overflowing box keeps its cells on its own line', () => {
+    // Two boxes on a two-line display. Rows are encoded last-to-first, so row
+    // 0 occupies the second physical line; a cell index that escaped the row
+    // would move the hardware cursor onto the other box.
+    const box = {
+      lowerOutliers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      min: 30,
+      q1: 40,
+      q2: 50,
+      q3: 60,
+      max: 70,
+      upperOutliers: [] as number[],
+    };
+
+    const indices = new Array<number>();
+    let emitted = '';
+    for (let col = 0; col < 7; col++) {
+      const { service } = createMultilineBrailleService(14, 2);
+      const state = createBoxTraceState([box, box], 0, 100, 0, col);
+      const disposable = service.onChange((event) => {
+        emitted = event.value;
+        indices[col] = event.index;
+      });
+
+      service.toggle(state);
+
+      disposable.dispose();
+      service.dispose();
+    }
+
+    expect(emitted.length).toBe(28);
+    expect(indices.every(index => index >= 14 && index < 28)).toBe(true);
+  });
 
   test('horizontal windowing: multi-row plot with cols > displaySize produces displaySize chars per row', () => {
     const { service } = createMultilineBrailleService(3, 2);

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -250,6 +250,17 @@ function createBoxTraceState(
   };
 }
 
+/** The five-number summary and outliers of one box, as the fixtures build it. */
+interface BoxSummary {
+  lowerOutliers: number[];
+  min: number;
+  q1: number;
+  q2: number;
+  q3: number;
+  max: number;
+  upperOutliers: number[];
+}
+
 // Section columns a box braille row is navigated by.
 const BOX_LOWER_OUTLIER = 0;
 const BOX_MIN = 1;
@@ -269,7 +280,7 @@ const BOX_MAX = 5;
  * @returns The row's characters and the emitted index per section column
  */
 function encodeBoxSectionCells(
-  box: { lowerOutliers: number[]; min: number; q1: number; q2: number; q3: number; max: number; upperOutliers: number[] },
+  box: BoxSummary,
   displaySize: number,
 ): { row: string; indices: number[] } {
   const indices = new Array<number>();

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -509,7 +509,7 @@ describe('BrailleService display-size encoding', () => {
 
   test('navigates to correct cell for non-multiple row lengths', () => {
     const { service, contextMoveToIndex } = createBrailleService(2);
-    const state = createLineTraceState([[1, 2, 3]], 0, 3);
+    const state = createLineTraceState([[1, 2, 3]], 0, 2);
 
     let lastIndex = -1;
     const disposable = service.onChange((event) => {
@@ -519,7 +519,7 @@ describe('BrailleService display-size encoding', () => {
     service.toggle(state);
 
     service.moveToIndex(lastIndex);
-    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 3);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 2);
 
     disposable.dispose();
     service.dispose();
@@ -527,21 +527,21 @@ describe('BrailleService display-size encoding', () => {
 
   test('no double newline when row length is exactly divisible by display size', () => {
     const { service, contextMoveToIndex } = createBrailleService(2);
-    const state = createLineTraceState([[1, 2, 3, 4]], 0, 4);
+    const state = createLineTraceState([[1, 2, 3, 4]], 0, 3);
 
     let emitted = '';
-    let sentinelIndex = -1;
+    let cursorIndex = -1;
     const disposable = service.onChange((event) => {
       emitted = event.value;
-      sentinelIndex = event.index;
+      cursorIndex = event.index;
     });
 
     service.toggle(state);
 
     expect(emitted.includes('\n\n')).toBe(false);
 
-    service.moveToIndex(sentinelIndex);
-    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 4);
+    service.moveToIndex(cursorIndex);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 3);
 
     disposable.dispose();
     service.dispose();
@@ -594,6 +594,53 @@ describe('BrailleService display-size encoding', () => {
 
     service.moveToIndex(mappedIndex);
     expect(contextMoveToIndex).toHaveBeenCalledWith(0, 3);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('ignores a caret landing on the row-ending newline', () => {
+    // The trailing `\n` of a single-line row maps to `{row, col: cols}` — one
+    // past the last column — so the emitted cursor index can round-trip
+    // through cellToIndex. It is a separator, not a cell the reader can stand
+    // on: End, a click past the last cell, or a display's cursor-routing key
+    // lands there, and forwarding it hands the model a column that does not
+    // exist.
+    const { service, contextMoveToIndex } = createBrailleService(2);
+    const state = createLineTraceState([[1, 2, 3]], 0, 1);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+    contextMoveToIndex.mockClear();
+    service.moveToIndex(emitted.length - 1);
+
+    expect(emitted.endsWith('\n')).toBe(true);
+    expect(contextMoveToIndex).not.toHaveBeenCalled();
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('follows a caret on a mid-row wrap newline to the cell before it', () => {
+    // A wrap newline is not a sentinel: its entry points back at the last cell
+    // of the visual line, which is where End should land.
+    const { service, contextMoveToIndex } = createBrailleService(2);
+    const state = createLineTraceState([[1, 2, 3]], 0, 1);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+    contextMoveToIndex.mockClear();
+    service.moveToIndex(emitted.indexOf('\n'));
+
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 1);
 
     disposable.dispose();
     service.dispose();
@@ -663,7 +710,7 @@ describe('BrailleService display-size encoding', () => {
 
   test('wraps bar braille output based on configured display size', () => {
     const { service, contextMoveToIndex } = createBrailleService(2);
-    const state = createBarTraceState([[1, 2, 3, 4, 5]], 0, 5);
+    const state = createBarTraceState([[1, 2, 3, 4, 5]], 0, 4);
 
     let emitted = '';
     let lastIndex = -1;
@@ -679,7 +726,7 @@ describe('BrailleService display-size encoding', () => {
     expect(newlineCount).toBe(3);
 
     service.moveToIndex(lastIndex);
-    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 5);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 4);
 
     disposable.dispose();
     service.dispose();
@@ -708,7 +755,7 @@ describe('BrailleService display-size encoding', () => {
 
   test('wraps heatmap braille output based on configured display size', () => {
     const { service, contextMoveToIndex } = createBrailleService(2);
-    const state = createHeatmapTraceState([[1, 2, 3, 4, 5]], 0, 5);
+    const state = createHeatmapTraceState([[1, 2, 3, 4, 5]], 0, 4);
 
     let emitted = '';
     let lastIndex = -1;
@@ -723,7 +770,7 @@ describe('BrailleService display-size encoding', () => {
     expect(newlineCount).toBe(3);
 
     service.moveToIndex(lastIndex);
-    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 5);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 4);
 
     disposable.dispose();
     service.dispose();

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -91,6 +91,19 @@ function createWarningState(): TraceState {
   };
 }
 
+/**
+ * Builds the empty subplot state a subplot pushes from notifyOutOfBounds():
+ * Page Up or Page Down at the first or last layer, and every such press on a
+ * single-layer chart.
+ * @returns An out-of-bounds subplot-type PlotState.
+ */
+function createNoMoreLayersState(): PlotState {
+  return {
+    empty: true,
+    type: 'subplot',
+  } as PlotState;
+}
+
 describe('textService first-navigation announcement gate', () => {
   test('fires first_navigation on the first trace-level navigation', () => {
     const text = new TextService(createMockNotificationService());
@@ -308,5 +321,34 @@ describe('textService out-of-bounds edge alert', () => {
     // The out-of-bounds event must NOT overwrite currentState, so the AI chat
     // still reports the user's last valid coordinate rather than null.
     expect(text.getCoordinateText()).toBe(coordinateAtPoint);
+  });
+
+  test('preserves the last valid currentState at a layer boundary', () => {
+    const notification = createMockNotificationService();
+    const text = new TextService(notification);
+
+    // Page Up on a single-layer chart: the reader never moves, so the cue must
+    // not cost them the position the AI chat reports.
+    text.update(createTraceState());
+    const coordinateAtPoint = text.getCoordinateText();
+    expect(coordinateAtPoint).not.toBeNull();
+
+    text.update(createNoMoreLayersState());
+
+    expect(text.getCoordinateText()).toBe(coordinateAtPoint);
+    expect(notification.notify).toHaveBeenCalledWith('No additional layer');
+  });
+
+  test('stays silent at a layer boundary while text mode is off', () => {
+    const notification = createMockNotificationService();
+    const text = new TextService(notification);
+    text.toggle(); // VERBOSE -> TERSE
+    text.toggle(); // TERSE -> OFF
+    expect(text.isOff()).toBe(true);
+    (notification.notify as jest.Mock).mockClear();
+
+    text.update(createNoMoreLayersState());
+
+    expect(notification.notify).not.toHaveBeenCalled();
   });
 });

--- a/test/util/format.test.ts
+++ b/test/util/format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { defaultFormat, formatters, FormatUtil } from '@util/format';
 
 describe('defaultFormat', () => {
@@ -135,5 +135,104 @@ describe('a numeric format meeting a value it cannot express', () => {
   it('still formats a real date', () => {
     expect(formatters.date({ month: 'short', day: 'numeric' })('2023-01-15'))
       .toBe('Jan 15');
+  });
+});
+
+describe('a user format function that throws', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to the default format instead of taking the reading out', () => {
+    // A body that is right for the numbers on an axis and wrong for the
+    // category labels the same axis also carries. It throws from
+    // TextService.update, which runs before the review, highlight and tactile
+    // observers, so one bad value cost the reader all three.
+    const format = FormatUtil.resolveFormat({ function: 'return value.toFixed(2);' });
+    const wrapped = FormatUtil.wrapFormat(format);
+
+    expect(wrapped(1.5)).toBe('1.50');
+    expect(wrapped('Cherries')).toBe('Cherries');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps announcing every later value rather than stopping at the first', () => {
+    const wrapped = FormatUtil.wrapFormat(() => {
+      throw new Error('boom');
+    });
+
+    expect(wrapped(1.5)).toBe('1.5');
+    expect(wrapped(2)).toBe('2');
+  });
+});
+
+describe('the Intl formatters an axis is announced through', () => {
+  /**
+   * Counts how many times an Intl constructor runs while `run` executes.
+   * @param key - The Intl constructor to count
+   * @param run - Work to perform with the counter installed
+   * @returns Number of constructions observed
+   */
+  function countConstructions(
+    key: 'NumberFormat' | 'DateTimeFormat',
+    run: () => void,
+  ): number {
+    const real = Intl[key];
+    let constructions = 0;
+    const counting = ((...args: unknown[]) => {
+      constructions += 1;
+      return new (real as unknown as new (...a: unknown[]) => object)(...args);
+    }) as unknown as typeof real;
+
+    Intl[key] = counting;
+    try {
+      run();
+    } finally {
+      Intl[key] = real;
+    }
+    return constructions;
+  }
+
+  it('builds one currency formatter for the whole axis', () => {
+    // The options are fixed when the factory runs, but the Intl object was
+    // rebuilt for every announced value — and TextService formats several per
+    // keypress, whole arrays of them for a scatter row or a box's outliers.
+    const format = formatters.currency('USD', 2);
+
+    const constructions = countConstructions('NumberFormat', () => {
+      expect(format(1234.5)).toBe('$1,234.50');
+      expect(format(2)).toBe('$2.00');
+      expect(format(3)).toBe('$3.00');
+    });
+
+    expect(constructions).toBe(1);
+  });
+
+  it('builds one number formatter for the whole axis', () => {
+    const format = formatters.number(2);
+
+    const constructions = countConstructions('NumberFormat', () => {
+      expect(format(1234567.89)).toBe('1,234,567.89');
+      expect(format(2)).toBe('2.00');
+    });
+
+    expect(constructions).toBe(1);
+  });
+
+  it('builds one date formatter for the whole axis', () => {
+    const format = formatters.date({ month: 'short', day: 'numeric' });
+
+    const constructions = countConstructions('DateTimeFormat', () => {
+      expect(format('2023-01-15')).toBe('Jan 15');
+      expect(format('2023-02-16')).toBe('Feb 16');
+    });
+
+    expect(constructions).toBe(1);
   });
 });

--- a/test/util/format.test.ts
+++ b/test/util/format.test.ts
@@ -183,18 +183,20 @@ describe('the Intl formatters an axis is announced through', () => {
     key: 'NumberFormat' | 'DateTimeFormat',
     run: () => void,
   ): number {
-    const real = Intl[key];
+    const intl = Intl as unknown as Record<string, unknown>;
+    const RealCtor = intl[key] as new (...args: unknown[]) => object;
     let constructions = 0;
-    const counting = ((...args: unknown[]) => {
+    // A plain function, not an arrow: the code under test calls it with `new`.
+    const counting = function (...args: unknown[]): object {
       constructions += 1;
-      return new (real as unknown as new (...a: unknown[]) => object)(...args);
-    }) as unknown as typeof real;
+      return new RealCtor(...args);
+    };
 
-    Intl[key] = counting;
+    intl[key] = counting;
     try {
       run();
     } finally {
-      Intl[key] = real;
+      intl[key] = RealCtor;
     }
     return constructions;
   }


### PR DESCRIPTION
# Pull Request

## Description

Seven defects in the audio, braille, text and format services, found in a codebase audit. The first is the one a reader would notice immediately: an `AudioContext` created while the page has programmatic focus is born suspended, and only the cue paths ever call `resume()`. Every data tone was scheduled against a frozen clock and simply never heard, so navigation was silent until the reader happened to hit a boundary or open a dialog.

Each fix has a test that failed before the change.

## Related Issues

None.

## Changes Made

- **audio**: a data tone defers behind `resume()` when the context is not running, the way the cue tones already do. The sonification body moved into a private method so the whole path can be deferred as a unit; it re-checks the mode and the context state after the async gap. A volume-0 update still neither resumes nor claims the shared cue slot.
- **audio**: turning sound off cancels the chord chain and its queued echoes, and the chain's own timer re-checks the mode. A 30-point scatter column used to keep playing for a second and a half over the "Sound is off" announcement.
- **braille**: the caret cannot be forwarded to a row's newline sentinel, which maps one past the last data column. End, a click past the last cell or a display's cursor-routing key used to hand the model a column that does not exist. The guard is deliberately narrow: only a newline that is the row's last cell entry and is this index, so a mid-row wrap and a box row terminator still map back to their real cells and End still lands on the last cell of the line.
- **braille**: the box encoder never squeezes a summary section out of existence. On a narrow display a box with many outliers drove min, max, q1 and q3 to zero cells: they rendered nothing while still claiming a cursor cell, so the minimum's cell became the quartile's glyph and later cells pointed past the end of the row, onto the next box's line. Overflow now comes out of the outlier runs instead.
- **text**: a layer-level out-of-bounds cue no longer overwrites the stored state. Page Up on a single-layer chart left `getCoordinateText()` null, so the AI chat's "current position" went blank on a keypress that did nothing.
- **format**: a chart-supplied `format.function` body is called inside a try/catch and falls back to the default format. A body that threw for one value on the axis took the rest of the observer chain with it, so the reader got the tone but no text, no highlight and no review update.
- **format**: the `Intl` formatters are built once per axis instead of once per announced value. They are constructed on first use rather than eagerly, so a currency code or locale the chart got wrong still fails where the new guard can turn it into a fallback.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Four existing braille tests placed the cursor on the sentinel and asserted the model was moved there; they now sit on the row's last real column and assert the same round trip, as the commit body explains.

`npm run lint`, `npm run type-check`, `npm test` (6578 + 158) and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_