### PR TITLE
docs(seo): give reference managers real bibliographic metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,75 @@
+cff-version: 1.2.0
+title: "MAIDR: Multimodal Access and Interactive Data Representation"
+message: >-
+  If you use this software, please cite both the software itself and the
+  MAIDR paper below.
+type: software
+authors:
+  - family-names: Seo
+    given-names: JooYoung
+    email: jseo1005@illinois.edu
+    affiliation: University of Illinois Urbana-Champaign
+repository-code: "https://github.com/xability/maidr"
+url: "https://maidr.ai/"
+abstract: >-
+  A TypeScript library that makes any SVG chart explorable by keyboard,
+  sonification, braille, text and AI description, and the engine behind
+  py-maidr and maidr for R.
+keywords:
+  - accessibility
+  - data visualization
+  - sonification
+  - braille
+  - screen reader
+  - blind
+  - low vision
+license: GPL-3.0-or-later
+preferred-citation:
+  type: conference-paper
+  title: >-
+    MAIDR: Making Statistical Visualizations Accessible with Multimodal Data
+    Representation
+  authors:
+    - family-names: Seo
+      given-names: JooYoung
+    - family-names: Xia
+      given-names: Yilin
+    - family-names: Lee
+      given-names: Bongshin
+    - family-names: Mccurry
+      given-names: Sean
+    - family-names: Yam
+      given-names: "Yu Jun"
+  collection-title: >-
+    Proceedings of the CHI Conference on Human Factors in Computing Systems
+    (CHI '24)
+  year: 2024
+  publisher:
+    name: Association for Computing Machinery
+  doi: 10.1145/3613904.3642730
+  isbn: "9798400703300"
+references:
+  - type: conference-paper
+    title: >-
+      Designing Born-Accessible Courses in Data Science and Visualization:
+      Challenges and Opportunities of a Remote Curriculum Taught by Blind
+      Instructors to Blind Students
+    authors:
+      - family-names: Seo
+        given-names: JooYoung
+      - family-names: O'Modhrain
+        given-names: Sile
+      - family-names: Xia
+        given-names: Yilin
+      - family-names: Kamath
+        given-names: Sanchita
+      - family-names: Lee
+        given-names: Bongshin
+      - family-names: Coughlan
+        given-names: "James M."
+    collection-title: "EuroVis 2024 - Education Papers"
+    year: 2024
+    publisher:
+      name: The Eurographics Association
+    doi: 10.2312/eved.20241053
+    isbn: "978-3-03868-257-8"

--- a/docs/template.html
+++ b/docs/template.html
@@ -21,6 +21,7 @@
   <meta name="twitter:description" content="{{DESCRIPTION}}" />
   <meta name="twitter:image" content="https://maidr.ai/media/logo.jpg" />
   <meta name="twitter:image:alt" content="MAIDR - Multimodal Access and Interactive Data Representation logo" />
+  {{DUBLIN_CORE}}
   <title>{{SEO_TITLE}}</title>
   <link rel="icon" type="image/svg+xml" href="{{BASE_PATH}}media/logo.svg" />
   <script type="application/ld+json">

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -309,6 +309,7 @@ function generatePage({ title, content, activePage, basePath = '', slug = '', og
     // documentation about it, so only the home page is typed as Software.
     .replace(/\{\{DUBLIN_CORE\}\}/g, () => dublinCoreTags({
       title: seoTitle,
+      siteName: 'MAIDR',
       description,
       identifier: canonicalUrl,
       date: dateModified,

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -13,6 +13,7 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { dublinCoreTags } from './dublinCore.js';
 import { buildGallery, listExamplePages, renderGallery } from './examplesGallery.js';
 import { firstCommitDate as firstCommit, lastCommitDate as lastCommit } from './gitDates.js';
 import { inlineJson } from './jsonLd.js';
@@ -304,6 +305,15 @@ function generatePage({ title, content, activePage, basePath = '', slug = '', og
     .replace(/\{\{SOFTWARE_CITATION\}\}/g, () => softwareCitation)
     .replace(/\{\{HOME_GRAPH_NODES\}\}/g, () => homeGraphNodes)
     .replace(/\{\{OG_TYPE\}\}/g, () => ogType)
+    // The home page stands for the library itself; every other page is
+    // documentation about it, so only the home page is typed as Software.
+    .replace(/\{\{DUBLIN_CORE\}\}/g, () => dublinCoreTags({
+      title: seoTitle,
+      description,
+      identifier: canonicalUrl,
+      date: dateModified,
+      type: isHome ? 'Software' : 'Text',
+    }))
     .replace(/\{\{PAGE_SCHEMA\}\}/g, () => allPageSchemas)
     .replace(/\{\{BREADCRUMB\}\}/g, () => isHome ? '' : buildBreadcrumbNav(title, dateModified))
     .replace(/\{\{CONTENT\}\}/g, () => content)
@@ -352,6 +362,11 @@ const indexPage = generatePage({
   content: readmeHtml,
   activePage: 'home',
   slug: '',
+  // The home page is the README; its commit date is the page's date. Unlike
+  // the docs pages this is not shown as a "Last updated" line, because the
+  // home page has no breadcrumb to hang it under — it is here so the Dublin
+  // Core block carries a date for reference managers.
+  dateModified: lastCommitDate('README.md'),
 });
 fs.writeFileSync(path.join(SITE_DIR, 'index.html'), indexPage);
 

--- a/scripts/dublinCore.d.ts
+++ b/scripts/dublinCore.d.ts
@@ -1,0 +1,37 @@
+/**
+ * Hand-written declarations for `dublinCore.js`.
+ *
+ * The module is plain JS so `scripts/build-site.js` (run directly by node) and
+ * `scripts/typedoc-seo-plugin.mjs` (loaded by TypeDoc) can import it;
+ * `tsconfig.json` sets `allowJs: false`, so a TypeScript test needs these to
+ * import it too. Keep both files in sync.
+ */
+
+/** Publisher of all three MAIDR sites. */
+export const PUBLISHER: string;
+
+/** Authors, surname-first so Zotero splits them into first and last names. */
+export const CREATORS: string[];
+
+/** SPDX identifier, matching `license` in package.json. */
+export const RIGHTS: string;
+
+/** Dublin Core `[name, content]` pairs for one page, in document order. */
+export function dublinCorePairs(opts: {
+  title: string;
+  description: string;
+  identifier: string;
+  date?: string;
+  type?: 'Software' | 'Text';
+  creators?: string[];
+}): [string, string][];
+
+/** The same tags rendered as HTML, newline-joined and indented. */
+export function dublinCoreTags(opts: {
+  title: string;
+  description: string;
+  identifier: string;
+  date?: string;
+  type?: 'Software' | 'Text';
+  creators?: string[];
+}): string;

--- a/scripts/dublinCore.d.ts
+++ b/scripts/dublinCore.d.ts
@@ -16,11 +16,15 @@ export const CREATORS: string[];
 /** SPDX identifier, matching `license` in package.json. */
 export const RIGHTS: string;
 
+/** `title` without a trailing `separator + siteName`. */
+export function stripSiteName(title: string, siteName: string): string;
+
 /** Dublin Core `[name, content]` pairs for one page, in document order. */
 export function dublinCorePairs(opts: {
   title: string;
   description: string;
   identifier: string;
+  siteName?: string;
   date?: string;
   type?: 'Software' | 'Text';
   creators?: string[];
@@ -31,6 +35,7 @@ export function dublinCoreTags(opts: {
   title: string;
   description: string;
   identifier: string;
+  siteName?: string;
   date?: string;
   type?: 'Software' | 'Text';
   creators?: string[];

--- a/scripts/dublinCore.js
+++ b/scripts/dublinCore.js
@@ -1,0 +1,103 @@
+/**
+ * Dublin Core meta tags for the documentation site.
+ *
+ * Reference managers read a page's bibliographic details from embedded meta
+ * tags. Zotero's Embedded Metadata translator looks for Highwire Press
+ * `citation_*` tags first, then Dublin Core, then Open Graph, and finally
+ * falls back to `<title>` with no author and no date.
+ *
+ * We deliberately do not emit `citation_*`. Google Scholar's inclusion
+ * guidelines reserve those tags for scholarly articles and say the tags must
+ * not be used for a repository or a site name, so putting them on software
+ * documentation misrepresents the page and risks the site being dropped from
+ * Scholar. Dublin Core carries the same facts without claiming the page is a
+ * paper, and it is what Zotero reads next.
+ *
+ * The MAIDR papers stay where they belong: cited by DOI in the page's JSON-LD
+ * and in the visible citation section, indexed in Scholar through their
+ * publishers.
+ */
+
+/** Publisher of all three MAIDR sites. */
+export const PUBLISHER
+  = '(x)Ability Design Lab, University of Illinois Urbana-Champaign';
+
+/**
+ * Authors, surname-first so Zotero splits them into first and last names
+ * rather than treating the whole string as a single-field name.
+ */
+export const CREATORS = ['Seo, JooYoung'];
+
+/** SPDX identifier, matching `license` in package.json. */
+export const RIGHTS = 'GPL-3.0-or-later';
+
+/**
+ * Escape a value for an HTML attribute.
+ *
+ * @param {string} value
+ * @returns {string} `value` with `&`, `<`, `>` and `"` replaced by entities.
+ */
+function attr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Build the Dublin Core name/value pairs for one page.
+ *
+ * `type` is a Dublin Core Type Vocabulary term. The home page describes the
+ * library itself and so is `Software`; every other page is documentation about
+ * it and is `Text`. Claiming `Software` site-wide would tell a reference
+ * manager that a guide page is the program.
+ *
+ * @param {object} opts
+ * @param {string} opts.title        Page title, without the site-name suffix.
+ * @param {string} opts.description  Same text as the meta description.
+ * @param {string} opts.identifier   Canonical URL of the page.
+ * @param {string} [opts.date]       ISO date the page was last changed.
+ * @param {'Software' | 'Text'} [opts.type]
+ * @param {string[]} [opts.creators]
+ * @returns {[string, string][]} `[name, content]` pairs in document order.
+ */
+export function dublinCorePairs({
+  title,
+  description,
+  identifier,
+  date = '',
+  type = 'Text',
+  creators = CREATORS,
+}) {
+  const pairs = [
+    ['DC.title', title],
+    ...creators.map(creator => ['DC.creator', creator]),
+    ['DC.publisher', PUBLISHER],
+    ['DC.description', description],
+    ['DC.identifier', identifier],
+    ['DC.type', type],
+    ['DC.format', 'text/html'],
+    ['DC.language', 'en'],
+    ['DC.rights', RIGHTS],
+  ];
+  if (date) {
+    pairs.push(['DC.date', date]);
+  }
+  return pairs;
+}
+
+/**
+ * The same tags rendered as HTML, for the string-templated site pages.
+ *
+ * TypeDoc builds its head with JSX instead, so that renderer consumes
+ * {@link dublinCorePairs} directly rather than parsing this back.
+ *
+ * @param {Parameters<typeof dublinCorePairs>[0]} opts
+ * @returns {string} Newline-joined `<meta>` tags, indented for the template.
+ */
+export function dublinCoreTags(opts) {
+  return dublinCorePairs(opts)
+    .map(([name, content]) => `<meta name="${name}" content="${attr(content)}" />`)
+    .join('\n  ');
+}

--- a/scripts/dublinCore.js
+++ b/scripts/dublinCore.js
@@ -31,6 +31,38 @@ export const CREATORS = ['Seo, JooYoung'];
 /** SPDX identifier, matching `license` in package.json. */
 export const RIGHTS = 'GPL-3.0-or-later';
 
+/** Separators the page titles put between a page name and the site name. */
+const TITLE_SEPARATORS = [' - ', ' | ', ' – ', ' — ', ' • '];
+
+/**
+ * Drop the trailing site name from a page title.
+ *
+ * `<title>`, `og:title` and `twitter:title` all carry the suffix, which is
+ * right for a browser tab and a link preview. A bibliographic record is not
+ * either of those: a reference manager should file the page under its own
+ * title, the way it does for the sibling py-maidr and r-maidr sites, whose
+ * generators append their own suffixes.
+ *
+ * Only an exact `<separator><siteName>` ending is removed, so a title that
+ * merely contains a separator keeps all of it.
+ *
+ * @param {string} title
+ * @param {string} siteName
+ * @returns {string} `title` without its trailing site name.
+ */
+export function stripSiteName(title, siteName) {
+  if (!siteName) {
+    return title;
+  }
+  for (const separator of TITLE_SEPARATORS) {
+    const suffix = `${separator}${siteName}`;
+    if (title.endsWith(suffix) && title.length > suffix.length) {
+      return title.slice(0, -suffix.length);
+    }
+  }
+  return title;
+}
+
 /**
  * Escape a value for an HTML attribute.
  *
@@ -54,9 +86,11 @@ function attr(value) {
  * manager that a guide page is the program.
  *
  * @param {object} opts
- * @param {string} opts.title        Page title, without the site-name suffix.
+ * @param {string} opts.title        Page title as it appears in `<title>`;
+ *   any trailing `opts.siteName` is stripped for the record.
  * @param {string} opts.description  Same text as the meta description.
  * @param {string} opts.identifier   Canonical URL of the page.
+ * @param {string} [opts.siteName]   Site name the title is suffixed with.
  * @param {string} [opts.date]       ISO date the page was last changed.
  * @param {'Software' | 'Text'} [opts.type]
  * @param {string[]} [opts.creators]
@@ -66,12 +100,13 @@ export function dublinCorePairs({
   title,
   description,
   identifier,
+  siteName = '',
   date = '',
   type = 'Text',
   creators = CREATORS,
 }) {
   const pairs = [
-    ['DC.title', title],
+    ['DC.title', stripSiteName(title, siteName)],
     ...creators.map(creator => ['DC.creator', creator]),
     ['DC.publisher', PUBLISHER],
     ['DC.description', description],

--- a/scripts/typedoc-seo-plugin.mjs
+++ b/scripts/typedoc-seo-plugin.mjs
@@ -28,12 +28,25 @@
  * which TypeDoc resolves against the config file.
  */
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Comment, JSX, ReflectionKind } from 'typedoc';
+import { dublinCorePairs } from './dublinCore.js';
+import { lastCommitDate } from './gitDates.js';
 import { inlineJson } from './jsonLd.js';
 import { fallbackDescription, PROJECT_PAGES, truncate } from './typedocSeo.js';
 
 const SITE_URL = 'https://maidr.ai/';
 const API_URL = 'https://maidr.ai/api/';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The API reference is generated from `src`, so the last commit touching it
+ * dates every page. Resolved once: the hook below runs for each of ~1,600
+ * pages and shelling out to git that many times would dominate the build.
+ */
+const SRC_DATE = lastCommitDate(ROOT, 'src', new Date().toISOString().slice(0, 10));
 
 /** Minimal stubs of the nodes docs/template.html declares in full. */
 const SITE_NODES = [
@@ -175,6 +188,12 @@ export function load(app) {
       JSX.createElement('meta', { property: 'og:url', content: canonical }),
       JSX.createElement('meta', { property: 'og:type', content: 'article' }),
       JSX.createElement('meta', { property: 'og:site_name', content: 'MAIDR' }),
+      ...dublinCorePairs({
+        title: headline,
+        description,
+        identifier: canonical,
+        date: SRC_DATE,
+      }).map(([name, content]) => JSX.createElement('meta', { name, content })),
       ldScript(graph),
       breadcrumb ? ldScript(breadcrumb) : null,
     );

--- a/scripts/typedoc-seo-plugin.mjs
+++ b/scripts/typedoc-seo-plugin.mjs
@@ -190,6 +190,7 @@ export function load(app) {
       JSX.createElement('meta', { property: 'og:site_name', content: 'MAIDR' }),
       ...dublinCorePairs({
         title: headline,
+        siteName: project.name,
         description,
         identifier: canonical,
         date: SRC_DATE,

--- a/test/scripts/siteSeo.esm-test.ts
+++ b/test/scripts/siteSeo.esm-test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
 import { describe, expect, it } from '@jest/globals';
-import { CREATORS, dublinCorePairs, dublinCoreTags, PUBLISHER, RIGHTS } from '../../scripts/dublinCore';
+import { CREATORS, dublinCorePairs, dublinCoreTags, PUBLISHER, RIGHTS, stripSiteName } from '../../scripts/dublinCore';
 import { firstCommitDate, lastCommitDate } from '../../scripts/gitDates';
 import { inlineJson } from '../../scripts/jsonLd';
 import { findOffenders, HARD_LIMIT, limitFor, SOFT_LIMIT } from '../../scripts/pageSizes';
@@ -210,6 +210,33 @@ describe('dublinCore', () => {
     const rendered = dublinCoreTags({ ...base, title: 'A "quoted" <b>title</b> & more' });
     expect(rendered).toContain('content="A &quot;quoted&quot; &lt;b&gt;title&lt;/b&gt; &amp; more"');
     expect(rendered).not.toContain('<b>');
+  });
+
+  it('files the page under its own title, not the browser-tab one', () => {
+    // <title>, og:title and twitter:title keep the suffix; a bibliographic
+    // record should not, and the sibling sites strip theirs too.
+    const suffixed = { ...base, title: 'React Accessibility Integration - MAIDR', siteName: 'MAIDR' };
+    expect(byName(suffixed)['DC.title']).toEqual(['React Accessibility Integration']);
+
+    const api = { ...base, title: 'HighlightOverlay | MAIDR JavaScript API', siteName: 'MAIDR JavaScript API' };
+    expect(byName(api)['DC.title']).toEqual(['HighlightOverlay']);
+  });
+
+  it('leaves a title that only contains a separator intact', () => {
+    // The home page's own title carries no suffix, and a colon or a dash
+    // inside a title is not a site name.
+    const home = 'MAIDR: Accessible Data Visualization with Sonification, Braille and Text';
+    expect(stripSiteName(home, 'MAIDR')).toBe(home);
+    expect(stripSiteName('Braille - Text - MAIDR', 'MAIDR')).toBe('Braille - Text');
+  });
+
+  it('never strips a title down to nothing', () => {
+    expect(stripSiteName('MAIDR', 'MAIDR')).toBe('MAIDR');
+    expect(stripSiteName(' - MAIDR', 'MAIDR')).toBe(' - MAIDR');
+  });
+
+  it('leaves the title alone when no site name is given', () => {
+    expect(stripSiteName('Anything - MAIDR', '')).toBe('Anything - MAIDR');
   });
 
   it('renders one meta tag per pair', () => {

--- a/test/scripts/siteSeo.esm-test.ts
+++ b/test/scripts/siteSeo.esm-test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
 import { describe, expect, it } from '@jest/globals';
+import { CREATORS, dublinCorePairs, dublinCoreTags, PUBLISHER, RIGHTS } from '../../scripts/dublinCore';
 import { firstCommitDate, lastCommitDate } from '../../scripts/gitDates';
 import { inlineJson } from '../../scripts/jsonLd';
 import { findOffenders, HARD_LIMIT, limitFor, SOFT_LIMIT } from '../../scripts/pageSizes';
@@ -13,8 +14,9 @@ import { fallbackDescription, MAX_DESCRIPTION, PROJECT_PAGES, truncate } from '.
  * Tests for the pieces of the site build that decide what search engines see:
  * the git-derived dates behind sitemap `<lastmod>` and TechArticle
  * `datePublished`/`dateModified` (`scripts/gitDates.js`), the Googlebot page
- * budget (`scripts/pageSizes.js`), and the description text on TypeDoc pages
- * (`scripts/typedocSeo.js`).
+ * budget (`scripts/pageSizes.js`), the description text on TypeDoc pages
+ * (`scripts/typedocSeo.js`), and the Dublin Core block reference managers
+ * read (`scripts/dublinCore.js`).
  *
  * `scripts/build-site.js` itself writes `_site/` and shells out on import, so
  * these modules hold the logic it delegates to, and are tested here directly.
@@ -149,5 +151,70 @@ describe('jsonLd', () => {
     expect(inlineJson({ '@id': 'https://maidr.ai/#software' }, 2)).toBe(
       '{\n  "@id": "https://maidr.ai/#software"\n}',
     );
+  });
+});
+
+describe('dublinCore', () => {
+  const base = {
+    title: 'A Page',
+    description: 'What the page is about.',
+    identifier: 'https://maidr.ai/a-page.html',
+  };
+
+  /** The pairs for `opts`, collapsed to a name -> values lookup. */
+  function byName(opts: Parameters<typeof dublinCorePairs>[0]): Record<string, string[]> {
+    const out: Record<string, string[]> = {};
+    for (const [name, content] of dublinCorePairs(opts)) {
+      (out[name] ??= []).push(content);
+    }
+    return out;
+  }
+
+  it('carries the facts Zotero needs when a page has no citation_ tags', () => {
+    const tags = byName(base);
+    expect(tags['DC.title']).toEqual(['A Page']);
+    expect(tags['DC.creator']).toEqual(CREATORS);
+    expect(tags['DC.publisher']).toEqual([PUBLISHER]);
+    expect(tags['DC.identifier']).toEqual([base.identifier]);
+    expect(tags['DC.rights']).toEqual([RIGHTS]);
+    expect(tags['DC.language']).toEqual(['en']);
+  });
+
+  it('never emits citation_ tags, which Google Scholar reserves for papers', () => {
+    const names = dublinCorePairs(base).map(([name]) => name);
+    expect(names.every(name => name.startsWith('DC.'))).toBe(true);
+  });
+
+  it('writes surname-first creators so Zotero splits the name', () => {
+    for (const creator of CREATORS) {
+      expect(creator).toMatch(/^[^,]+, .+$/);
+    }
+  });
+
+  it('gives one DC.creator tag per author rather than one joined string', () => {
+    const creators = ['Seo, JooYoung', 'Venkatesh, Saairam'];
+    expect(byName({ ...base, creators })['DC.creator']).toEqual(creators);
+  });
+
+  it('types the home page as Software and other pages as Text', () => {
+    expect(byName({ ...base, type: 'Software' })['DC.type']).toEqual(['Software']);
+    expect(byName(base)['DC.type']).toEqual(['Text']);
+  });
+
+  it('omits DC.date rather than emitting an empty one', () => {
+    expect(byName(base)['DC.date']).toBeUndefined();
+    expect(byName({ ...base, date: '2026-09-06' })['DC.date']).toEqual(['2026-09-06']);
+  });
+
+  it('escapes a title that would otherwise close the content attribute', () => {
+    const rendered = dublinCoreTags({ ...base, title: 'A "quoted" <b>title</b> & more' });
+    expect(rendered).toContain('content="A &quot;quoted&quot; &lt;b&gt;title&lt;/b&gt; &amp; more"');
+    expect(rendered).not.toContain('<b>');
+  });
+
+  it('renders one meta tag per pair', () => {
+    const opts = { ...base, date: '2026-09-06' };
+    const rendered = dublinCoreTags(opts);
+    expect(rendered.match(/<meta /g)).toHaveLength(dublinCorePairs(opts).length);
   });
 });


### PR DESCRIPTION
## Description

Saving any page of maidr.ai to Zotero produced a Web Page item with **no author and no date**. The site emitted only Open Graph and Twitter tags, and Zotero's Embedded Metadata translator looks for Highwire Press `citation_*` first, then Dublin Core, then Open Graph — finding neither of the first two, it fell back to the `<title>` alone.

## Changes Made

**`scripts/dublinCore.js`** (new, with hand-written `.d.ts` matching the `jsonLd.js` / `gitDates.js` convention) builds the block; `docs/template.html` gains a `{{DUBLIN_CORE}}` slot, and `scripts/typedoc-seo-plugin.mjs` emits the same pairs as JSX so the API reference is covered too.

Each page now carries title, creator, publisher, description, identifier, type, format, language, rights and its own git commit date.

- **Creators are surname-first** (`Seo, JooYoung`) so Zotero splits them into first and last names instead of storing one opaque string.
- **`DC.type` is per page**: the home page is `Software` because it stands for the library; the guides and the API reference are `Text`. Claiming `Software` site-wide would tell a reference manager that a guide page is the program.
- **`DC.title` drops the site name**, which `<title>`, `og:title` and `twitter:title` keep. `stripSiteName` removes only an exact trailing `<separator><siteName>`, so `React Accessibility Integration - MAIDR` is filed as `React Accessibility Integration` while a title that merely contains a separator keeps all of it. This matches the sibling py-maidr and r-maidr sites, whose generators append their own suffixes.
- **The home page gains a date** from `README.md`'s commit, which it did not have before — it has no breadcrumb to hang a visible "Last updated" line under, so the date existed nowhere.
- The plugin resolves the `src` commit date **once**, not once per page; the hook runs for ~1,600 API pages.

**`CITATION.cff`** gives GitHub its "Cite this repository" button, naming the CHI 2024 paper as the preferred citation and the EuroVis 2024 paper as a reference.

## Deliberately no `citation_*` tags

Google Scholar's [inclusion guidelines](https://scholar.google.com/intl/en/scholar/inclusion.html) reserve those tags for scholarly articles, require that a site consist "primarily of scholarly articles", and say explicitly that `citation_title` must not carry the name of a repository. Putting them on software documentation misrepresents the page and risks the site being dropped from Scholar, without gaining indexing — Scholar does not index documentation sites. The two MAIDR papers stay cited by DOI in the JSON-LD and the visible citation section, and reach Scholar through ACM and Eurographics.

The reasoning is recorded in the module docstring so it is not quietly undone later, and a test asserts no emitted tag name falls outside `DC.`.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Verification

- `npm run lint:fix`, `npm run type-check` and `npm run docs` clean.
- `npm test`: the `esm` project's 12 suites and 170 tests pass, which is where every test this PR adds lives. **The `unit` project is red on `main` and red here for the same reason** — see below.
- Built site checked: home emits `DC.type` `Software` dated from `README.md`; `react.html` emits `Text` dated `2026-08-23` from its own source; an API symbol page is filed as `HighlightOverlay` rather than `HighlightOverlay | MAIDR JavaScript API`.
- 12 cases in `test/scripts/siteSeo.esm-test.ts` cover the type split, the per-author tags, the surname-first shape, attribute escaping, omitting an empty date, the no-`citation_*` invariant, and the suffix stripping including the cases that must *not* strip.

### Correction to an earlier version of this description

This section previously claimed `npm test` was clean at "166 passed, 12 suites". That figure is the **`esm` project alone**. `scripts/test.js` runs one process per project and returns the first non-zero code; I read only the tail of its output and reported the last project's summary as the whole run. The real exit code was 1.

### The `Unit Tests` failure is not this PR's

`test/command/announce-position.test.ts` fails two multi-violin KDE cases:

```
Expected: "Violin 2 of 3, Position is 3 of 5"
Received: "Violin 3 of 5, Position is 2 of 3"
```

I checked out `origin/main` with none of this branch applied and it fails identically there (2 failed / 6627 passed). This branch touches `scripts/`, `docs/template.html`, `CITATION.cff` and one file under `test/scripts/`; it does not touch `src/command`, `src/model`, or anything the announcement reads.

#1223 fixes it against the same base commit, so this PR goes green when that merges. I have not ported it: a `src/command` change does not belong in a documentation PR, and both of us editing that file gains nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqUywJzoCqyMGLFp8De1mn