### PR TITLE
fix(command): read the violin position from the navigation frame, not the pan

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -610,10 +610,10 @@ export class AnnouncePointCommand extends AnnounceCommand {
  * Whether a braille state carries a row-of-rows grid, the shape
  * {@link AnnouncePositionCommand.navigationPosition} reads a position out of.
  *
- * Checked rather than asserted: every trace in {@link BAR_FAMILY} is
- * registered against the bar encoder today, but nothing in the type system
- * ties the two lists together, and a trace added to one and not the other
- * would otherwise read a position out of a state that has no grid in it.
+ * Checked rather than asserted: every trace in {@link GRID_FRAME_TRACES}
+ * builds such a grid today, but nothing in the type system ties the two
+ * together, and a trace added to one and not the other would otherwise read a
+ * position out of a state that has no grid in it.
  * @param braille - The trace's braille state
  * @returns True when the state has a `values` grid to index
  */
@@ -624,12 +624,22 @@ function isGridBrailleState(braille: BrailleState): braille is BarBrailleState {
 }
 
 /**
- * The traces built on `AbstractBarPlot`, whose braille state is
- * `values[row][col]` normalised to the bar axis and whose audio panning swaps
- * for a horizontal chart. The position announcement reads the former for
- * these; see {@link AnnouncePositionCommand.navigationPosition}.
+ * The traces whose position announcement reads the braille grid rather than
+ * the audio panning.
+ *
+ * `audio.panning` answers a question about the loudspeakers: where the point
+ * sits on screen, so a trace is free to re-orient it and let the pan follow
+ * the x axis. Which mark of how many the reader is on is a different
+ * question, and for these traces the two answers differ. The bar family
+ * swaps its pan for a horizontal chart; a vertical violin pans by violin,
+ * holding the pan still while the reader climbs one curve. Their braille
+ * state carries the navigation frame verbatim as `values[row][col]`, so the
+ * announcement reads that; see
+ * {@link AnnouncePositionCommand.navigationPosition}.
  */
-const BAR_FAMILY: ReadonlySet<TraceType> = new Set([
+const GRID_FRAME_TRACES: ReadonlySet<TraceType> = new Set([
+  // Built on `AbstractBarPlot`, whose braille grid is normalised to the bar
+  // axis while the pan swaps with the orientation.
   TraceType.BAR,
   TraceType.DOT,
   TraceType.LOLLIPOP,
@@ -640,6 +650,9 @@ const BAR_FAMILY: ReadonlySet<TraceType> = new Set([
   TraceType.DODGED,
   TraceType.DIVERGING,
   TraceType.MOSAIC,
+  // Braille grid is `densityValues[violin][sample]`, which is the frame the
+  // reader navigates; the vertical pan is by violin instead.
+  TraceType.VIOLIN_KDE,
 ]);
 
 /**
@@ -811,7 +824,7 @@ export class AnnouncePositionCommand extends AnnounceCommand {
   private navigationPosition(
     state: NonEmptyTraceState,
   ): { x: number; y: number; rows: number; cols: number } {
-    if (BAR_FAMILY.has(state.traceType) && isGridBrailleState(state.braille)) {
+    if (GRID_FRAME_TRACES.has(state.traceType) && isGridBrailleState(state.braille)) {
       return {
         x: state.braille.col,
         y: state.braille.row,

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -762,13 +762,19 @@ describe('AnnouncePositionCommand on a violin box', () => {
  *
  * @param violin Zero-based index of the violin the cursor is on
  * @param sample Zero-based index of the density sample within it
+ * @param orientation Which way the violins are laid out
  * @returns The trace's state with the cursor there
  */
-function violinKdeTraceState(violin: number, sample: number): PlotState {
+function violinKdeTraceState(
+  violin: number,
+  sample: number,
+  orientation = Orientation.VERTICAL,
+): PlotState {
   const trace = TraceFactory.create({
     id: 'position-violin-kde',
     type: TraceType.VIOLIN_KDE,
     title: 'Violins',
+    orientation,
     axes: { x: { label: 'Group' }, y: { label: 'Value' } },
     data: ['A', 'B', 'C'].map(x =>
       [1, 2, 3, 4, 5].map(y => ({ x, y, density: 0.1 * y })),
@@ -796,6 +802,29 @@ describe('AnnouncePositionCommand on a multi-violin KDE', () => {
     command.execute();
 
     expect(textViewModel.update).toHaveBeenCalledWith('Violin 2 of 3, 50%');
+  });
+
+  /**
+   * The cursor is on the same violin and the same sample either way round, so
+   * the announcement is too. It is the stereo pan that turns with the layout:
+   * a vertical violin pans by violin and holds still while the reader climbs
+   * one curve, a horizontal one pans along the curve. Reading the position out
+   * of that pan is what made the vertical case answer with its two numbers
+   * swapped.
+   */
+  test('reads the same violin and sample whichever way the violins are laid out', () => {
+    const vertical = createCommand(violinKdeTraceState(1, 2, Orientation.VERTICAL));
+    const horizontal = createCommand(violinKdeTraceState(1, 2, Orientation.HORIZONTAL));
+
+    vertical.command.execute();
+    horizontal.command.execute();
+
+    expect(vertical.textViewModel.update).toHaveBeenCalledWith(
+      'Violin 2 of 3, Position is 3 of 5',
+    );
+    expect(horizontal.textViewModel.update).toHaveBeenCalledWith(
+      'Violin 2 of 3, Position is 3 of 5',
+    );
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Description

`main` is red. `test/command/announce-position.test.ts` fails its two multi-violin KDE cases:

```
Expected: "Violin 2 of 3, Position is 3 of 5"
Received: "Violin 3 of 5, Position is 2 of 3"
```

A reader on the second violin's third density sample is told they are on violin 3 of 5, which is a violin that does not exist.

Neither of the two changes that produced this is wrong on its own. #1219 added the announcement, reading the position out of `audio.panning`. #1220 then re-oriented a vertical violin's panning so the stereo image follows the on-screen x: the violins sit side by side, so switching violins pans left to right and climbing one curve holds the pan still. That puts the violin index in `panning.x` and the sample in `panning.y`, and the announcement went on reading them as a column and a row.

Both landed green and the pair is red, so nothing before the merge could have caught it.

## Related Issues

None.

## Changes Made

`navigationPosition` reads the braille grid for a violin KDE rather than falling through to the pan. The braille state already carries the navigation frame verbatim as `densityValues[violin][sample]` with the trace's own `row` and `col`.

This is the same reason the bar family is already read that way — its pan swaps with the orientation while its braille grid stays normalised to the bar axis — so the set gains the violin KDE and is renamed from `BAR_FAMILY` to `GRID_FRAME_TRACES`, for what it means at the call site rather than for the one family that first needed it. The distinction is now written down: panning answers where the point sits on screen, and which mark of how many the reader is on is a different question.

No model or service change. `SMOOTH`, the other trace routed to the multi-violin announcement, pans identically to its braille frame (it is a `LineTrace`), so it is deliberately left reading the pan rather than moved for symmetry.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

The two failing cases were already in the suite, so the reproduction is the failure itself. A third case is added: the announcement is identical whichever way the violins are laid out, since it is the pan and not the reader's position that turns with the layout. That is the invariant whose loss caused this.

`npm run lint:fix` and `npm run type-check` pass. `test/command/announce-position.test.ts` goes from 2 failed / 41 passed to 43 passed. The full suite is running locally but the machine is heavily loaded, so CI here is the trustworthy signal for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun