### PR TITLE
fix(chat): report an empty model reply as a failure, and three more chat defects

### DIFF
--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -140,12 +140,14 @@ interface LlmModel {
 }
 
 /**
- * Response structure from OpenAI GPT API.
+ * Response structure from OpenAI GPT API. `message.content` is null on a
+ * refusal and empty when a reasoning model spends its whole completion
+ * budget on reasoning, so it is read defensively.
  */
 interface GptResponse {
   choices: {
     message: {
-      content: string;
+      content: string | null;
     };
   }[];
 }
@@ -474,7 +476,12 @@ class Gpt extends AbstractLlmModel<GptResponse> {
    * @returns {LlmResponse} The formatted response
    */
   protected formatResponse(response: GptResponse): LlmResponse {
-    if (response.choices.length === 0) {
+    // An empty or null content is not an answer: a refusal returns null, and
+    // a reasoning model that exhausts max_completion_tokens on reasoning
+    // returns ''. Reported as a success, both put an empty bubble in the
+    // transcript with nothing for the live region to announce.
+    const content = response.choices?.[0]?.message?.content;
+    if (!content) {
       return {
         success: false,
         error: 'Invalid response format',
@@ -483,7 +490,7 @@ class Gpt extends AbstractLlmModel<GptResponse> {
 
     return {
       success: true,
-      data: response.choices[0].message.content,
+      data: content,
     };
   }
 }

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -45,6 +45,10 @@ export class ChatService {
   private data: Maidr;
   private cachedJson: string | null;
 
+  // The rasterisation one message's providers share; null when none is in
+  // flight. See getPlotImage().
+  private imagePromise: Promise<string> | null;
+
   /**
    * Creates a new ChatService instance with configured LLM models.
    * @param {DisplayService} display - The display service for managing UI focus
@@ -57,16 +61,20 @@ export class ChatService {
     this.pendingRequests = new Set();
     this.data = maidr;
     this.cachedJson = null;
+    this.imagePromise = null;
 
     // Construction-time versions are fallbacks only; the user-selected
-    // version arrives per request via LlmRequest.version. Models receive a
-    // supplier so live data updates are picked up without rebuilding them.
+    // version arrives per request via LlmRequest.version. Models receive
+    // suppliers so live data updates are picked up without rebuilding them,
+    // and so the providers answering one message share a single conversion
+    // of the plot rather than each running their own.
     const getJson = (): string => this.getDataJson();
+    const getImage = (): Promise<string> => this.getPlotImage();
     this.models = {
-      OPENAI: new Gpt(display.plot, getJson, textService, MODEL_VERSIONS.OPENAI.default),
-      ANTHROPIC_CLAUDE: new Claude(display.plot, getJson, textService, MODEL_VERSIONS.ANTHROPIC_CLAUDE.default),
-      GOOGLE_GEMINI: new Gemini(display.plot, getJson, textService, MODEL_VERSIONS.GOOGLE_GEMINI.default),
-      OLLAMA: new Ollama(display.plot, getJson, textService, MODEL_VERSIONS.OLLAMA.default),
+      OPENAI: new Gpt(getImage, getJson, textService, MODEL_VERSIONS.OPENAI.default),
+      ANTHROPIC_CLAUDE: new Claude(getImage, getJson, textService, MODEL_VERSIONS.ANTHROPIC_CLAUDE.default),
+      GOOGLE_GEMINI: new Gemini(getImage, getJson, textService, MODEL_VERSIONS.GOOGLE_GEMINI.default),
+      OLLAMA: new Ollama(getImage, getJson, textService, MODEL_VERSIONS.OLLAMA.default),
     };
   }
 
@@ -102,14 +110,45 @@ export class ChatService {
   }
 
   /**
+   * Returns the plot as a base64 JPEG, shared by every provider answering
+   * the same message.
+   *
+   * ChatViewModel sends one message to all enabled providers at once, and
+   * Svg.toBase64 serializes the plot, decodes it through an <img>, draws it
+   * to a canvas and encodes a JPEG — all on the main thread, where it
+   * blocks navigation and announcements. Running it once per provider paid
+   * that several times over for an identical image. The conversion is
+   * released as soon as it settles, so the next message is answered against
+   * the plot as it looks by then.
+   * @returns {Promise<string>} The plot image as a data URL
+   */
+  private getPlotImage(): Promise<string> {
+    if (this.imagePromise !== null) {
+      return this.imagePromise;
+    }
+
+    const conversion = Svg.toBase64(this.display.plot).finally(() => {
+      // Only if it is still the current one: updateData may have dropped it
+      // in favour of a plot showing newer data.
+      if (this.imagePromise === conversion) {
+        this.imagePromise = null;
+      }
+    });
+    this.imagePromise = conversion;
+    return conversion;
+  }
+
+  /**
    * Refreshes the chart data shared with the LLM providers after a live
    * data update, so AI answers reflect the data currently on screen.
-   * Serialization is deferred until the next LLM request.
+   * Serialization is deferred until the next LLM request, and the shared
+   * plot image is dropped so the next message rasterises the updated plot.
    * @param {Maidr} maidr - The updated MAIDR data structure
    */
   public updateData(maidr: Maidr): void {
     this.data = maidr;
     this.cachedJson = null;
+    this.imagePromise = null;
   }
 
   /**
@@ -193,7 +232,7 @@ interface OllamaResponse {
  * @template T - The response type specific to the LLM provider
  */
 abstract class AbstractLlmModel<T> implements LlmModel {
-  protected readonly svg: HTMLElement;
+  protected readonly getImage: () => Promise<string>;
   protected readonly getJson: () => string;
   protected readonly textService: TextService;
 
@@ -202,12 +241,12 @@ abstract class AbstractLlmModel<T> implements LlmModel {
 
   /**
    * Creates a new AbstractLlmModel instance.
-   * @param {HTMLElement} svg - The SVG element representing the plot
+   * @param {() => Promise<string>} getImage - Supplier of the plot as a base64 image
    * @param {() => string} getJson - Supplier of the current chart data as JSON
    * @param {TextService} textService - The text service for retrieving coordinate text
    */
-  protected constructor(svg: HTMLElement, getJson: () => string, textService: TextService) {
-    this.svg = svg;
+  protected constructor(getImage: () => Promise<string>, getJson: () => string, textService: TextService) {
+    this.getImage = getImage;
     this.getJson = getJson;
     this.textService = textService;
 
@@ -223,7 +262,7 @@ abstract class AbstractLlmModel<T> implements LlmModel {
    */
   public async getLlmResponse(request: LlmRequest, signal?: AbortSignal): Promise<LlmResponse> {
     try {
-      const image = await Svg.toBase64(this.svg);
+      const image = await this.getImage();
       // When expertise is 'custom', use 'advanced' as the base level since custom instructions will override
       const expertiseLevel = request.expertise === 'custom' ? 'advanced' : request.expertise;
 
@@ -398,13 +437,13 @@ class Gpt extends AbstractLlmModel<GptResponse> {
 
   /**
    * Creates a new GPT model instance.
-   * @param {HTMLElement} svg - The SVG element representing the plot
+   * @param {() => Promise<string>} getImage - Supplier of the plot as a base64 image
    * @param {() => string} getJson - Supplier of the current chart data as JSON
    * @param {TextService} textService - The text service for retrieving coordinate text
    * @param {GptVersion} version - The GPT model version to use
    */
-  public constructor(svg: HTMLElement, getJson: () => string, textService: TextService, version: GptVersion) {
-    super(svg, getJson, textService);
+  public constructor(getImage: () => Promise<string>, getJson: () => string, textService: TextService, version: GptVersion) {
+    super(getImage, getJson, textService);
     this.version = version;
   }
 
@@ -517,13 +556,13 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
 
   /**
    * Creates a new Claude model instance.
-   * @param {HTMLElement} svg - The SVG element representing the plot
+   * @param {() => Promise<string>} getImage - Supplier of the plot as a base64 image
    * @param {() => string} getJson - Supplier of the current chart data as JSON
    * @param {TextService} textService - The text service for retrieving coordinate text
    * @param {ClaudeVersion} version - The Claude model version to use
    */
-  public constructor(svg: HTMLElement, getJson: () => string, textService: TextService, version: ClaudeVersion) {
-    super(svg, getJson, textService);
+  public constructor(getImage: () => Promise<string>, getJson: () => string, textService: TextService, version: ClaudeVersion) {
+    super(getImage, getJson, textService);
     this.version = version;
   }
 
@@ -657,13 +696,13 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
 
   /**
    * Creates a new Gemini model instance.
-   * @param {HTMLElement} svg - The SVG element representing the plot
+   * @param {() => Promise<string>} getImage - Supplier of the plot as a base64 image
    * @param {() => string} getJson - Supplier of the current chart data as JSON
    * @param {TextService} textService - The text service for retrieving coordinate text
    * @param {GeminiVersion} version - The Gemini model version to use
    */
-  public constructor(svg: HTMLElement, getJson: () => string, textService: TextService, version: GeminiVersion) {
-    super(svg, getJson, textService);
+  public constructor(getImage: () => Promise<string>, getJson: () => string, textService: TextService, version: GeminiVersion) {
+    super(getImage, getJson, textService);
     this.version = version;
   }
 
@@ -798,13 +837,13 @@ class Ollama extends AbstractLlmModel<OllamaResponse> {
 
   /**
    * Creates a new Ollama model instance.
-   * @param {HTMLElement} svg - The SVG element representing the plot
+   * @param {() => Promise<string>} getImage - Supplier of the plot as a base64 image
    * @param {() => string} getJson - Supplier of the current chart data as JSON
    * @param {TextService} textService - The text service for retrieving coordinate text
    * @param {OllamaVersion} version - The default Ollama model to use when none is selected
    */
-  public constructor(svg: HTMLElement, getJson: () => string, textService: TextService, version: OllamaVersion) {
-    super(svg, getJson, textService);
+  public constructor(getImage: () => Promise<string>, getJson: () => string, textService: TextService, version: OllamaVersion) {
+    super(getImage, getJson, textService);
     this.version = version;
   }
 

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -4,6 +4,7 @@ import type { Maidr } from '@type/grammar';
 import type { ClaudeVersion, GeminiVersion, GptVersion, Llm, LlmRequest, LlmResponse, LlmVersion, OllamaVersion } from '@type/llm';
 import type { PromptContext } from './prompts';
 import type { TextService } from './text';
+import { HttpStatus } from '@type/api';
 import { Scope } from '@type/event';
 import { ANTHROPIC_API_VERSION } from '@type/llm';
 import { Api } from '@util/api';
@@ -266,12 +267,12 @@ abstract class AbstractLlmModel<T> implements LlmModel {
   }
 
   /**
-   * Posts the request through {@link Api.post}, resolving as soon as `signal`
-   * aborts (Controller disposal). Api.post owns its own timeout signal and
-   * exposes no external abort hook, so the underlying fetch is still bounded
-   * by LLM_REQUEST_TIMEOUT_MS; racing the abort releases this request's
-   * continuation — and the chat's waiting tone — immediately rather than after
-   * the full timeout.
+   * Posts the request through {@link Api.post}, cancelling it when `signal`
+   * aborts (Controller disposal). The signal is handed to fetch, so the
+   * socket, the response body and the JSON parse stop with it rather than
+   * running on for the remainder of LLM_REQUEST_TIMEOUT_MS; the race below
+   * additionally releases this request's continuation — and the chat's
+   * waiting tone — the moment disposal happens.
    * @param {string} url - The request URL
    * @param {string} payload - The serialized request body
    * @param {Record<string, string>} headers - The request headers
@@ -284,7 +285,20 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     headers: Record<string, string>,
     signal?: AbortSignal,
   ): Promise<ApiResponse<T>> {
-    const request = Api.post<T>(url, payload, headers, LLM_REQUEST_TIMEOUT_MS);
+    // Disposal can land while the plot is still being rasterised, which is
+    // long enough to matter on a dense chart. Sending the request anyway
+    // spends the user's tokens on an answer nothing will ever show.
+    if (signal?.aborted) {
+      return {
+        success: false,
+        error: {
+          statusCode: HttpStatus.SERVER_ERROR,
+          message: 'Chat request aborted',
+        },
+      };
+    }
+
+    const request = Api.post<T>(url, payload, headers, LLM_REQUEST_TIMEOUT_MS, signal);
     if (!signal) {
       return request;
     }

--- a/src/service/llmValidation.ts
+++ b/src/service/llmValidation.ts
@@ -160,6 +160,25 @@ export class LlmValidationService {
   }
 
   /**
+   * Describes a non-2xx model-list response. Only 401 and 403 say anything
+   * about the credential: a rate limit or an outage is the provider's
+   * problem, and reporting it as an invalid key sends the user to replace a
+   * key that works while the model dropdown stays disabled.
+   * @param status - The HTTP status the provider responded with
+   * @returns The probe result for that status
+   */
+  private static describeProbeStatus(status: number): ProviderProbeResult {
+    if (status === 401 || status === 403) {
+      return { isValid: false, models: [], error: 'Invalid API key' };
+    }
+    return {
+      isValid: false,
+      models: [],
+      error: `The provider returned ${status}. This is not a problem with your key; try again later.`,
+    };
+  }
+
+  /**
    * Probes the OpenAI models endpoint, validating the key and collecting the
    * chat-capable models it can access.
    * @param apiKey - The OpenAI API key
@@ -176,7 +195,7 @@ export class LlmValidationService {
         signal: AbortSignal.timeout(CLOUD_PROBE_TIMEOUT_MS),
       });
       if (!response.ok) {
-        return { isValid: false, models: [], error: 'Invalid API key' };
+        return this.describeProbeStatus(response.status);
       }
 
       const data = await response.json() as ModelListResponse;
@@ -218,7 +237,7 @@ export class LlmValidationService {
         signal: AbortSignal.timeout(CLOUD_PROBE_TIMEOUT_MS),
       });
       if (!response.ok) {
-        return { isValid: false, models: [], error: 'Invalid API key' };
+        return this.describeProbeStatus(response.status);
       }
 
       const data = await response.json() as ModelListResponse;
@@ -241,7 +260,7 @@ export class LlmValidationService {
         signal: AbortSignal.timeout(CLOUD_PROBE_TIMEOUT_MS),
       });
       if (!response.ok) {
-        return { isValid: false, models: [], error: 'Invalid API key' };
+        return this.describeProbeStatus(response.status);
       }
 
       const data = await response.json() as GeminiModelListResponse;

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -231,6 +231,10 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
   const { modalRef, container } = useModalContainer();
   const [isValidating, setIsValidating] = useState(false);
   const [isValid, setIsValid] = useState<boolean | null>(null);
+  // Why the last probe failed, as the probe itself described it. Kept so a
+  // rate limit or a provider outage is not reported as a bad credential:
+  // null whenever there is nothing more specific to say.
+  const [probeError, setProbeError] = useState<string | null>(null);
   // Models available to this credential, probed from the provider's models
   // API (or the local Ollama server) when the credential validates; replaces
   // the curated suggestion list so users pick from what actually exists.
@@ -248,12 +252,28 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
     if (isValidating)
       return isOllama ? 'Checking Ollama server...' : 'Validating API key...';
     if (isValid === false) {
+      if (probeError) {
+        return probeError;
+      }
       return isOllama
         ? 'Ollama server is unreachable. Make sure Ollama is running and, for non-localhost pages, that OLLAMA_ORIGINS allows this site.'
         : `${modelSettings.name} API key is invalid`;
     }
     if (isValid === true)
       return isOllama ? 'Ollama server is reachable' : `${modelSettings.name} API key is valid`;
+    return '';
+  };
+
+  // What the status region announces. The helper text beside the field is
+  // decoration by comparison: this region is what the field's
+  // `aria-describedby` points at, so it carries the same reason.
+  const getStatusLabel = (): string => {
+    if (isValidating)
+      return isOllama ? 'Checking Ollama server' : 'Validating API key';
+    if (isValid === true)
+      return isOllama ? 'Ollama server is reachable' : 'API key is valid';
+    if (isValid === false)
+      return probeError ?? (isOllama ? 'Ollama server is unreachable' : 'API key is invalid');
     return '';
   };
 
@@ -265,6 +285,7 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
     if (!modelSettings.enabled || !apiKey.trim()) {
       if (!isStale()) {
         setIsValid(null);
+        setProbeError(null);
         setAvailableModels([]);
         // Also clear the spinner: a superseded in-flight request skips its
         // own finally-cleanup as stale, so this cycle owns the state.
@@ -282,10 +303,12 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
         return;
       }
       setIsValid(probe.isValid);
+      setProbeError(probe.error ?? null);
       setAvailableModels(probe.models);
     } catch (error) {
       if (!isStale()) {
         setIsValid(false);
+        setProbeError(null);
         setAvailableModels([]);
       }
     } finally {
@@ -372,21 +395,7 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
                           id={`${modelKey}-status`}
                           role="status"
                           aria-live="polite"
-                          aria-label={
-                            isValidating
-                              ? isOllama
-                                ? 'Checking Ollama server'
-                                : 'Validating API key'
-                              : isValid === true
-                                ? isOllama
-                                  ? 'Ollama server is reachable'
-                                  : 'API key is valid'
-                                : isValid === false
-                                  ? isOllama
-                                    ? 'Ollama server is unreachable'
-                                    : 'API key is invalid'
-                                  : ''
-                          }
+                          aria-label={getStatusLabel()}
                         >
                           {isValidating
                             ? (

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -49,6 +49,13 @@ function markAnimationCompleted(key: string): void {
 }
 
 export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, messageId, onTypingUpdate }) => {
+  // The body is declared a string, but it arrives from a provider response and
+  // a null one has reached here. Every tick of the animation below reads its
+  // length, so that threw every 10 ms without ever clearing `isTyping` — and
+  // the live region stays deliberately empty while typing, so the message was
+  // never announced at all. Normalised once, so the animation, the key that
+  // remembers it and the announcement all read the same body.
+  const body = typeof text === 'string' ? text : '';
   const [displayedText, setDisplayedText] = useState('');
   const [isTyping, setIsTyping] = useState(true);
   const [mathPlugins, setMathPlugins] = useState<RehypePlugins>(NO_MATH_PLUGINS);
@@ -69,7 +76,7 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
   // Keyed off the whole message rather than what has been typed so far: the
   // fetch starts the moment the response arrives, and has the length of the
   // animation to finish before the equation is on screen.
-  const needsMath = useMemo(() => containsLatex(text), [text]);
+  const needsMath = useMemo(() => containsLatex(body), [body]);
 
   // KaTeX — ~340 kB of stylesheet and the larger part of its JS — is loaded
   // only for the messages that actually contain maths. Until it arrives the
@@ -109,9 +116,9 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
     // after the dialog is reopened) — show the full text immediately.
     // Separated by an escaped NUL, which neither a message id nor a body
     // can contain, so no pair of messages can collide on one key.
-    const animationKey = `${messageId}\0${text}`;
+    const animationKey = `${messageId}\0${body}`;
     if (isUser || inIframe || completedAnimations.has(animationKey)) {
-      setDisplayedText(text);
+      setDisplayedText(body);
       setIsTyping(false);
       return;
     }
@@ -123,8 +130,8 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
     let currentIndex = 0;
     const typingSpeed = 10; // Slightly slower for better scroll compatibility
     const typingInterval = setInterval(() => {
-      if (currentIndex <= text.length) {
-        setDisplayedText(text.slice(0, currentIndex));
+      if (currentIndex <= body.length) {
+        setDisplayedText(body.slice(0, currentIndex));
         currentIndex++;
 
         // Notify parent component about typing updates for auto-scroll
@@ -139,7 +146,7 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
     }, typingSpeed);
 
     return () => clearInterval(typingInterval);
-  }, [text, isUser, inIframe, messageId]);
+  }, [body, isUser, inIframe, messageId]);
 
   return (
     <Box style={containerStyle}>
@@ -195,7 +202,7 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
         aria-live={settings.general.ariaMode}
         aria-atomic="true"
       >
-        {isTyping ? '' : text}
+        {isTyping ? '' : body}
       </div>
       {isTyping && !inIframe && (
         <span

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -25,6 +25,7 @@ export abstract class Api {
    * @param body - The request body to send
    * @param additionalHeaders - Optional headers to merge with default headers
    * @param timeoutMs - Optional request timeout; the request aborts when exceeded
+   * @param signal - Optional caller signal; aborting it cancels the request
    * @returns A promise resolving to the API response with typed data
    */
   public static async post<T>(
@@ -32,9 +33,27 @@ export abstract class Api {
     body: BodyInit,
     additionalHeaders?: Record<string, string>,
     timeoutMs?: number,
+    signal?: AbortSignal,
   ): Promise<ApiResponse<T>> {
     const headers = { ...this.DEFAULT_HEADERS, ...additionalHeaders };
-    return this.request<T>(url, 'POST', headers, body, timeoutMs);
+    return this.request<T>(url, 'POST', headers, body, timeoutMs, signal);
+  }
+
+  /**
+   * Combines the request's own timeout with the caller's abort signal, so a
+   * caller that gives up (a disposed service, say) cancels the fetch instead
+   * of leaving the socket, the response body and the JSON parse running until
+   * the timeout expires.
+   * @param timeoutMs - Optional request timeout
+   * @param signal - Optional caller signal
+   * @returns The signal to hand to fetch, or undefined when there is neither
+   */
+  private static combineSignals(timeoutMs?: number, signal?: AbortSignal): AbortSignal | undefined {
+    const timeout = timeoutMs != null ? AbortSignal.timeout(timeoutMs) : undefined;
+    if (timeout && signal) {
+      return AbortSignal.any([signal, timeout]);
+    }
+    return timeout ?? signal;
   }
 
   /**
@@ -44,6 +63,7 @@ export abstract class Api {
    * @param headers - Headers to include in the request
    * @param body - Optional request body
    * @param timeoutMs - Optional request timeout; the request aborts when exceeded
+   * @param signal - Optional caller signal; aborting it cancels the request
    * @returns A promise resolving to the API response with typed data
    */
   private static async request<T>(
@@ -52,13 +72,15 @@ export abstract class Api {
     headers: Record<string, string>,
     body?: BodyInit,
     timeoutMs?: number,
+    signal?: AbortSignal,
   ): Promise<ApiResponse<T>> {
     try {
+      const requestSignal = this.combineSignals(timeoutMs, signal);
       const response = await fetch(url, {
         method,
         headers,
         body,
-        ...(timeoutMs != null ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
+        ...(requestSignal ? { signal: requestSignal } : {}),
       });
 
       if (!response.ok) {

--- a/test/service/chat.test.ts
+++ b/test/service/chat.test.ts
@@ -4,6 +4,9 @@ import type { Maidr } from '@type/grammar';
 import { afterAll, afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { ChatService } from '@service/chat';
 import { TraceType } from '@type/grammar';
+// The mock declared below; imported so a test can decide when the plot
+// finishes rasterising.
+import { Svg } from '@util/svg';
 
 // Svg.toBase64 needs DOM APIs unavailable under the node test environment;
 // a fixed data URL also lets the tests assert the data-URL prefix stripping.
@@ -207,6 +210,63 @@ describe('ChatService provider requests', () => {
     expect(response.success).toBe(false);
     expect(response.error).toContain('proxy');
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('does not send a request that was disposed while the plot rasterised', async () => {
+    // Rasterising a dense plot takes long enough for the plot to lose focus
+    // and the Controller to dispose mid-conversion. The request was still
+    // sent — spending the user's tokens on an answer nothing will show.
+    let finishRasterising = (_image: string): void => {};
+    jest.mocked(Svg.toBase64).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        finishRasterising = resolve;
+      }),
+    );
+    mockJsonResponse({ choices: [{ message: { content: 'Answer.' } }] });
+    const service = createService();
+
+    const pending = service.sendMessage('OPENAI', {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic',
+      apiKey: 'sk-openai-test',
+    });
+    service.dispose();
+    finishRasterising('data:image/jpeg;base64,QUJD');
+    const response = await pending;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.success).toBe(false);
+  });
+
+  test('aborts the in-flight fetch when the chat service is disposed', async () => {
+    // Without the signal reaching fetch, the socket, the response body and
+    // the JSON parse stay alive for the full request timeout after every
+    // focus change, one per disposed controller.
+    let requestSignal: AbortSignal | null = null;
+    fetchMock.mockImplementation((_input, init) => new Promise<Response>(() => {
+      requestSignal = (init as RequestInit).signal ?? null;
+    }));
+    const service = createService();
+
+    const pending = service.sendMessage('OPENAI', {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic',
+      apiKey: 'sk-openai-test',
+    });
+    for (let tick = 0; tick < 20 && fetchMock.mock.calls.length === 0; tick++) {
+      await Promise.resolve();
+    }
+    expect(requestSignal).not.toBeNull();
+    expect((requestSignal as unknown as AbortSignal).aborted).toBe(false);
+
+    service.dispose();
+
+    expect((requestSignal as unknown as AbortSignal).aborted).toBe(true);
+    await expect(pending).resolves.toEqual(
+      expect.objectContaining({ success: false }),
+    );
   });
 
   test('falls back to the provider default version when none is selected', async () => {

--- a/test/service/chat.test.ts
+++ b/test/service/chat.test.ts
@@ -269,6 +269,88 @@ describe('ChatService provider requests', () => {
     );
   });
 
+  test('rasterises the plot once for the providers answering one message', async () => {
+    // ChatViewModel fans a message out to every enabled provider at once.
+    // Svg.toBase64 serializes the whole plot, decodes it through an <img>,
+    // draws it to a canvas and encodes a JPEG, all on the main thread — so
+    // running it once per provider blocks navigation and announcements for
+    // as long as it takes, several times over.
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'Answer.' } }],
+        content: [{ type: 'text', text: 'Answer.' }],
+        candidates: [{ content: { parts: [{ text: 'Answer.' }] } }],
+      }),
+    } as Response);
+    jest.mocked(Svg.toBase64).mockClear();
+    const service = createService();
+    const request = {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic' as const,
+      apiKey: 'key',
+    };
+
+    const responses = await Promise.all([
+      service.sendMessage('OPENAI', request),
+      service.sendMessage('ANTHROPIC_CLAUDE', request),
+      service.sendMessage('GOOGLE_GEMINI', request),
+    ]);
+
+    expect(responses.every(response => response.success)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(jest.mocked(Svg.toBase64)).toHaveBeenCalledTimes(1);
+  });
+
+  test('rasterises the plot again for the next message', async () => {
+    // Coalescing is per message, not a cache: the plot the user is looking
+    // at moves with every navigation step, so a later question must be
+    // answered against a current image.
+    mockJsonResponse({ choices: [{ message: { content: 'Answer.' } }] });
+    jest.mocked(Svg.toBase64).mockClear();
+    const service = createService();
+    const request = {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic' as const,
+      apiKey: 'sk-openai-test',
+    };
+
+    await service.sendMessage('OPENAI', request);
+    await service.sendMessage('OPENAI', request);
+
+    expect(jest.mocked(Svg.toBase64)).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not answer with an image of the chart the data replaced', async () => {
+    // A live data update lands between the two messages below, so the second
+    // must not be served the conversion the first one started.
+    let finishRasterising = (_image: string): void => {};
+    jest.mocked(Svg.toBase64).mockClear();
+    jest.mocked(Svg.toBase64).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        finishRasterising = resolve;
+      }),
+    );
+    mockJsonResponse({ choices: [{ message: { content: 'Answer.' } }] });
+    const service = createService();
+    const request = {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic' as const,
+      apiKey: 'sk-openai-test',
+    };
+
+    const first = service.sendMessage('OPENAI', request);
+    service.updateData({ id: 'updated-plot' } as unknown as Maidr);
+    const second = service.sendMessage('OPENAI', request);
+    finishRasterising('data:image/jpeg;base64,QUJD');
+    await Promise.all([first, second]);
+
+    expect(jest.mocked(Svg.toBase64)).toHaveBeenCalledTimes(2);
+  });
+
   test('falls back to the provider default version when none is selected', async () => {
     mockJsonResponse({ choices: [{ message: { content: 'Answer.' } }] });
 

--- a/test/service/chat.test.ts
+++ b/test/service/chat.test.ts
@@ -116,6 +116,44 @@ describe('ChatService provider requests', () => {
     expect(options.signal).toBeInstanceOf(AbortSignal);
   });
 
+  test('OpenAI: reports an empty message as a failure, not an empty answer', async () => {
+    // A reasoning model that spends its whole completion budget on reasoning
+    // finishes with `content: ''`. Reported as a success it renders an empty
+    // bubble that the live region announces as nothing.
+    mockJsonResponse({ choices: [{ message: { content: '' } }] });
+
+    const response = await createService().sendMessage('OPENAI', {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic',
+      apiKey: 'sk-openai-test',
+      version: 'gpt-5.5',
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBeTruthy();
+    expect(response.data).toBeUndefined();
+  });
+
+  test('OpenAI: reports a null message as a failure', async () => {
+    // `message.content` is null on a refusal; the other providers all guard
+    // this, and a null reaching the transcript throws inside the typing
+    // animation instead of being announced.
+    mockJsonResponse({ choices: [{ message: { content: null } }] });
+
+    const response = await createService().sendMessage('OPENAI', {
+      message: 'Describe the chart.',
+      customInstruction: '',
+      expertise: 'basic',
+      apiKey: 'sk-openai-test',
+      version: 'gpt-5.5',
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBeTruthy();
+    expect(response.data).toBeUndefined();
+  });
+
   test('Gemini: encodes the selected model and key in the URL', async () => {
     mockJsonResponse({ candidates: [{ content: { parts: [{ text: 'Answer.' }] } }] });
 

--- a/test/service/llmValidation.test.ts
+++ b/test/service/llmValidation.test.ts
@@ -146,11 +146,42 @@ describe('LlmValidationService (Ollama)', () => {
     });
 
     test('reports invalid with no models when the provider rejects the key', async () => {
-      fetchMock.mockResolvedValue({ ok: false } as Response);
+      fetchMock.mockResolvedValue({ ok: false, status: 401 } as Response);
 
       const probe = await LlmValidationService.probeProvider('OPENAI', 'bad-key');
 
       expect(probe).toEqual({ isValid: false, models: [], error: 'Invalid API key' });
+    });
+
+    test('reports a key without model-list permission as a key problem', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 403 } as Response);
+
+      const probe = await LlmValidationService.probeProvider('ANTHROPIC_CLAUDE', 'sk-ant-test');
+
+      expect(probe).toEqual({ isValid: false, models: [], error: 'Invalid API key' });
+    });
+
+    test('reports a rate limit as the provider\'s problem, not a bad key', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 429 } as Response);
+
+      const probe = await LlmValidationService.probeProvider('OPENAI', 'sk-test');
+
+      // The user is told to fix a key that is fine, and the model dropdown
+      // stays disabled, unless the status is reported for what it is.
+      expect(probe.isValid).toBe(false);
+      expect(probe.models).toEqual([]);
+      expect(probe.error).not.toBe('Invalid API key');
+      expect(probe.error).toContain('429');
+    });
+
+    test('reports a provider outage as the provider\'s problem, not a bad key', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 503 } as Response);
+
+      const probe = await LlmValidationService.probeProvider('GOOGLE_GEMINI', 'g-key');
+
+      expect(probe.isValid).toBe(false);
+      expect(probe.error).not.toBe('Invalid API key');
+      expect(probe.error).toContain('503');
     });
 
     test('reports a network failure distinctly from an invalid key', async () => {

--- a/test/ui/settings.probeStatus.test.tsx
+++ b/test/ui/settings.probeStatus.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Component test for what the LLM credential field reports after a probe.
+ *
+ * `LlmValidationService.probeProvider` answers with a reason, and the dialog
+ * used to drop it: every failure rendered as "<Provider> API key is invalid"
+ * and disabled the model dropdown. A rate limit or a provider outage then told
+ * a user with a working key to go and replace it, and the status region — the
+ * element the credential field's `aria-describedby` points at, and the only
+ * part of this a screen reader hears — announced the same wrong thing.
+ *
+ * The assertions go through that status region rather than the visible helper
+ * text for exactly that reason.
+ */
+
+import type { CommandExecutor } from '@service/commandExecutor';
+import type { ChatViewModel } from '@state/viewModel/chatViewModel';
+import type { SettingsViewModel } from '@state/viewModel/settingsViewModel';
+import type { Settings as SettingsState } from '@type/settings';
+import { afterAll, afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { MaidrContext } from '@state/context';
+import { ViewModelRegistry } from '@state/viewModel/registry';
+import { render, screen, waitFor } from '@testing-library/react';
+import { DEFAULT_SETTINGS } from '@type/settings';
+import Settings from '@ui/component/Settings';
+// The `/jest-globals` entry point, not the bare one: it augments the `expect`
+// imported from @jest/globals rather than the ambient global.
+import '@testing-library/jest-dom/jest-globals';
+
+/** The `SettingsViewModel` surface `Settings` actually calls. */
+type SettingsStub = Pick<
+  SettingsViewModel,
+  | 'state'
+  | 'load'
+  | 'reset'
+  | 'toggle'
+  | 'saveAndClose'
+  | 'tactileDisplayState'
+  | 'onTactileDisplayStateChange'
+  | 'supportsTactileTransport'
+  | 'connectTactileDisplay'
+  | 'disconnectTactileDisplay'
+  | 'preloadTactileDisplay'
+>;
+
+/** The `ChatViewModel` surface `Settings` actually calls. */
+type ChatStub = Pick<ChatViewModel, 'updateWelcomeMessage'>;
+
+const fetchMock = jest.fn<typeof fetch>();
+const originalFetch = globalThis.fetch;
+
+/** Settings with one enabled provider, so exactly one probe runs. */
+const SETTINGS_WITH_OPENAI_KEY: SettingsState = {
+  ...DEFAULT_SETTINGS,
+  llm: {
+    ...DEFAULT_SETTINGS.llm,
+    models: {
+      ...DEFAULT_SETTINGS.llm.models,
+      OPENAI: { ...DEFAULT_SETTINGS.llm.models.OPENAI, enabled: true, apiKey: 'sk-test' },
+    },
+  },
+};
+
+/**
+ * Renders the settings dialog with stub view models.
+ *
+ * Only the leaves are stubbed: the registry is the production one, so the
+ * component reaches its view models the same way it does at runtime.
+ */
+function renderSettings(): void {
+  const settings: SettingsStub = {
+    state: SETTINGS_WITH_OPENAI_KEY,
+    load: jest.fn(),
+    reset: jest.fn(),
+    toggle: jest.fn(),
+    saveAndClose: jest.fn(),
+    // The tactile-display picker sits in the same dialog. Nothing here
+    // exercises it, but the component reads its state on every render and
+    // subscribes on mount, so the stub has to answer both.
+    tactileDisplayState: {
+      status: 'disconnected',
+      deviceName: null,
+      transport: null,
+      geometry: null,
+      message: '',
+    },
+    onTactileDisplayStateChange: jest.fn(() => ({ dispose: jest.fn() })),
+    supportsTactileTransport: jest.fn(() => false),
+    connectTactileDisplay: jest.fn(async () => ({
+      status: 'disconnected' as const,
+      deviceName: null,
+      transport: null,
+      geometry: null,
+      message: '',
+    })),
+    disconnectTactileDisplay: jest.fn(),
+    preloadTactileDisplay: jest.fn(),
+  };
+  const chat: ChatStub = {
+    updateWelcomeMessage: jest.fn(),
+  };
+
+  const registry = new ViewModelRegistry();
+  registry.register('settings', settings as SettingsViewModel);
+  registry.register('chat', chat as ChatViewModel);
+
+  render(
+    <MaidrContext.Provider
+      value={{
+        viewModelRegistry: registry,
+        commandExecutor: {} as unknown as CommandExecutor,
+      }}
+    >
+      <Settings />
+    </MaidrContext.Provider>,
+  );
+}
+
+/**
+ * Waits for the OpenAI credential status region to report a settled result.
+ *
+ * The probe is debounced by 500 ms, so the region is empty and then
+ * "Validating API key" before it carries an outcome.
+ * @returns The announcement the status region ends up carrying.
+ */
+async function settledAnnouncement(): Promise<string> {
+  // The label sits on the MUI wrapper and the description on the native
+  // input inside it, so the region is reached the way the input names it.
+  const field = await screen.findByLabelText('OpenAI API Key');
+  const statusId = field.querySelector('input')?.getAttribute('aria-describedby');
+  expect(statusId).toBeTruthy();
+
+  const status = document.getElementById(statusId as string);
+  expect(status).not.toBeNull();
+
+  await waitFor(
+    () => {
+      const label = status?.getAttribute('aria-label') ?? '';
+      expect(label).not.toBe('');
+      expect(label).not.toBe('Validating API key');
+    },
+    { timeout: 3000 },
+  );
+
+  return status?.getAttribute('aria-label') ?? '';
+}
+
+beforeEach(() => {
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+// Restore the real fetch so the mock cannot leak into other suites sharing
+// this worker environment.
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('settings LLM section: what a failed probe reports', () => {
+  it('should name the status a provider returned rather than blaming the key', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 429 } as Response);
+    renderSettings();
+
+    const announcement = await settledAnnouncement();
+
+    expect(announcement).toContain('429');
+    expect(announcement).not.toContain('invalid');
+  });
+
+  it('should still report a rejected credential as an invalid key', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 } as Response);
+    renderSettings();
+
+    const announcement = await settledAnnouncement();
+
+    expect(announcement.toLowerCase()).toContain('invalid');
+  });
+});

--- a/test/ui/typingEffect.esm-test.tsx
+++ b/test/ui/typingEffect.esm-test.tsx
@@ -113,6 +113,45 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
+describe('a message with no body', () => {
+  // A provider can report success with no text: OpenAI returns null on a
+  // refusal and '' when a reasoning model spends its budget on reasoning.
+  // The animation reads `text.length` on every 10 ms tick, so a missing body
+  // threw on each one and never cleared `isTyping` — and while `isTyping` is
+  // true the live region is deliberately empty, so nothing was announced at
+  // all. The service now reports those as failures; this is the last line of
+  // defence, because the component cannot know that.
+  it('should finish its animation rather than throwing on every tick', () => {
+    render(
+      <Provider store={createMaidrStore()}>
+        <TypingEffect text={null as unknown as string} isUser={false} messageId={`m${rendered++}`} />
+      </Provider>,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    // The cursor is rendered only while typing, so its absence is the
+    // component saying the animation completed.
+    expect(document.querySelector('.typing-cursor')).toBeNull();
+  });
+
+  it('should announce an empty body without leaving the bubble typing', () => {
+    render(
+      <Provider store={createMaidrStore()}>
+        <TypingEffect text="" isUser={false} messageId={`m${rendered++}`} />
+      </Provider>,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(document.querySelector('.typing-cursor')).toBeNull();
+  });
+});
+
 describe('a chat link\'s accessible name', () => {
   // These three are the cases #700 fixed. The override it removed built
   // `aria-label` as `Link: ${children}`, which is a string only when the link


### PR DESCRIPTION
# Pull Request

## Description

Four defects in the AI chat path, found in a codebase audit. Each has a test that failed before the change.

The first is the one a reader meets: OpenAI returning `null` or empty message content was reported as a **successful** response. The typing animation then read a null body every 10ms, threw each time, and left `isTyping` true, so nothing was ever announced. The reader was left with a chat that had visibly asked and silently never answered.

## Related Issues

None.

## Changes Made

- **chat**: an empty or null OpenAI `message.content` is a failure, matching what Claude, Gemini and Ollama already do. `GptResponse.content` is typed `string | null` so the case has to be handled rather than assumed away. `TypingEffect` also normalises a non-string body to an empty string once, as a second line of defence, and uses that for the animation, the completed-animation key and the live region.
- **settings**: a provider outage is told apart from a bad key. Only 401 and 403 now read as "Invalid API key"; any other non-2xx says the provider returned that status and that it is not a problem with the key. The message reaches the `role="status"` region the credential field's `aria-describedby` points at, not just the helper text, so a screen reader hears why the probe failed.
- **chat**: aborting on dispose now actually reaches `fetch`. `Api.post` and `Api.request` take an optional signal and combine it with their own timeout, and `ChatService.post` returns a failure before calling out when the signal is already aborted. A request could previously still be sent after the service was disposed.
- **chat**: the plot is rasterised once per message rather than once per enabled provider. `ChatService.getPlotImage()` coalesces concurrent calls behind one in-flight promise, cleared when it settles and on `updateData()`. The models now take an image supplier instead of the plot element.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Worth a reviewer's attention:** combining the caller's signal with the timeout uses `AbortSignal.any`, which needs Chrome 116, Safari 17.4 or Firefox 124. There is no browserslist in the repo and `tsconfig` targets ESNext, so nothing flags it. It is a slightly higher floor than the `AbortSignal.timeout` already in use here. Say the word if that floor is too high and it can be hand-rolled instead.

One existing test was updated: the `llmValidation` case for a rejected key mocked `{ok: false}` with no status at all. It now says 401. The intent is unchanged — the mock was simply under-specified for a change that reads the status.

`npm run lint:fix`, `npm run type-check`, and `npm test` (6642 unit across 485 suites, 160 ESM across 12) all pass on this branch with `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_