### PR TITLE
fix(d3): rebind after a remount, and seven more defects in the d3 adapter

### DIFF
--- a/src/adapters/d3/binders/box.ts
+++ b/src/adapters/d3/binders/box.ts
@@ -173,6 +173,13 @@ export function buildBoxLayer(root: Element, config: D3BoxConfig, panel?: D3Pane
     //                       whiskers = vertical lines (above/below rect center)
     //   Horizontal boxplot: median = vertical line   (|dy| > |dx|)
     //                       whiskers = horizontal lines (left/right of rect center)
+    //
+    // Shape alone will not do it: a capped whisker finishes in a short
+    // crossbar drawn the same way round as the median, and stamping those
+    // `q2` too made the median selector resolve to whichever came first in
+    // the DOM -- announcing the median while outlining the maximum. A cap
+    // sits at the end of a whisker, outside the IQR body; the median crosses
+    // it. So the span the line lies across has to agree as well.
     const lines = children.filter(c => c.localName === 'line') as SVGLineElement[];
     for (const line of lines) {
       const x1 = Number(line.getAttribute('x1') ?? 0);
@@ -188,19 +195,17 @@ export function buildBoxLayer(root: Element, config: D3BoxConfig, panel?: D3Pane
 
       let part: 'q2' | 'lower-whisker' | 'upper-whisker';
       if (isHorizontal) {
-        if (dy > dx) {
-          part = 'q2';
-        } else {
-          part = midX < rectCx ? 'lower-whisker' : 'upper-whisker';
-        }
+        const crossesBody = dy > dx && midX >= rectX && midX <= rectX + rectW;
+        part = crossesBody
+          ? 'q2'
+          : (midX < rectCx ? 'lower-whisker' : 'upper-whisker');
       } else {
-        if (dx > dy) {
-          part = 'q2';
-        } else {
-          // SVG y grows downward, so a larger midpoint y is visually below
-          // the rect center ⇒ lower whisker.
-          part = midY > rectCy ? 'lower-whisker' : 'upper-whisker';
-        }
+        const crossesBody = dx > dy && midY >= rectY && midY <= rectY + rectH;
+        // SVG y grows downward, so a larger midpoint y is visually below
+        // the rect center ⇒ lower whisker.
+        part = crossesBody
+          ? 'q2'
+          : (midY > rectCy ? 'lower-whisker' : 'upper-whisker');
       }
       line.setAttribute('data-maidr-box-part', part);
     }

--- a/src/adapters/d3/binders/candlestick.ts
+++ b/src/adapters/d3/binders/candlestick.ts
@@ -107,7 +107,12 @@ export function buildCandlestickLayer(root: Element, config: D3CandlestickConfig
       trend = 'Neutral';
     }
 
-    const volumeVal = resolveAccessorOptional<number>(datum, volumeAccessor, index) ?? 0;
+    // `CandlestickPoint.volume` is optional so that "absent" and "zero" stay
+    // apart, and `Candlestick.description` renders a blank cell for absent.
+    // Filling it with `0` turns an OHLC chart with no volume column into a
+    // table saying no shares traded on any day, which a reader quotes back as
+    // a finding rather than as something the chart never said.
+    const volumeVal = resolveAccessorOptional<number>(datum, volumeAccessor, index);
 
     return {
       value: resolveAccessor<string>(datum, valueAccessor, index),
@@ -115,7 +120,9 @@ export function buildCandlestickLayer(root: Element, config: D3CandlestickConfig
       high: highVal,
       low: lowVal,
       close: closeVal,
-      volume: volumeVal,
+      ...(typeof volumeVal === 'number' && Number.isFinite(volumeVal)
+        ? { volume: volumeVal }
+        : {}),
       trend,
       volatility: highVal - lowVal,
     };

--- a/src/adapters/d3/binders/heatmap.ts
+++ b/src/adapters/d3/binders/heatmap.ts
@@ -52,8 +52,14 @@ import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart
  *
  * @param svg - The SVG element containing the D3 heatmap.
  * @param config - Configuration specifying the selector and data accessors.
+ * @remarks
+ * **A grid the join does not fill is read, not refused.** A tidy array with no
+ * row for one label pair simply draws no rect there, and the schema spells
+ * that cell `null` rather than `0` -- a value the chart never drew (#1191).
+ * Its slot in the selector grid is a hole too, so every drawn cell's selector
+ * stays aligned with the value it names.
+ *
  * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
- * @throws Error if any cell coordinate pair is missing from the extracted data.
  *
  * @example
  * ```ts
@@ -201,20 +207,17 @@ export function buildHeatmapLayer(root: Element, config: D3HeatmapConfig, panel?
     row.set(cell.x, cell.value);
   }
 
-  const points: number[][] = [];
+  // A grid is a rectangle and a join need not fill it: a tidy array with no
+  // row for one label pair simply draws no rect there. `HeatmapData.points`
+  // spells that cell `null` -- not `0`, which is a value the chart never drew
+  // (#1191) -- so the gap is emitted rather than aborting the whole bind.
+  const points: (number | null)[][] = [];
   for (const yLabel of yLabels) {
-    const row: number[] = [];
+    const row: (number | null)[] = [];
     const rowMap = cellMap.get(yLabel);
     for (const xLabel of xLabels) {
       const value = rowMap?.get(xLabel);
-      if (value === undefined) {
-        throw new Error(
-          `Missing heatmap cell for y="${yLabel}", x="${xLabel}". `
-          + `Expected a complete grid of ${yLabels.length} x ${xLabels.length} cells `
-          + `but found ${cells.length} elements.`,
-        );
-      }
-      row.push(value);
+      row.push(value === undefined ? null : value);
     }
     points.push(row);
   }
@@ -236,22 +239,27 @@ export function buildHeatmapLayer(root: Element, config: D3HeatmapConfig, panel?
   for (const cell of cells) {
     byCell.set(`${cell.y}\u0000${cell.x}`, cell.element);
   }
-  const ordered: Element[] = [];
+  // A cell the join drew no mark for keeps its slot as `null`, which the grid
+  // explicitly permits. Dropping it instead would shift every later cell's
+  // selector one place left of the value it names.
+  const ordered: (Element | null)[] = [];
   for (let r = 0; r < yLabels.length; r++) {
     const yLabel = yLabels[yLabels.length - 1 - r];
     for (const xLabel of xLabels) {
-      const element = byCell.get(`${yLabel}\u0000${xLabel}`);
-      if (element) {
-        ordered.push(element);
-      }
+      ordered.push(byCell.get(`${yLabel}\u0000${xLabel}`) ?? null);
     }
   }
-  const flat = ordered.length === cells.length
-    ? stampOrderedSelectors(root, selector, CELL_ATTRIBUTE, ordered, panel)
+  const drawn = ordered.filter((element): element is Element => element !== null);
+  const flat = drawn.length === cells.length
+    ? stampOrderedSelectors(root, selector, CELL_ATTRIBUTE, drawn, panel)
     : null;
-  const selectors = flat === null
+  let stamped = 0;
+  const grid = flat === null
+    ? null
+    : ordered.map(element => element === null ? null : flat[stamped++]);
+  const selectors = grid === null
     ? scopeSelector(root, selector, panel)
-    : yLabels.map((_, r) => flat.slice(r * xLabels.length, (r + 1) * xLabels.length));
+    : yLabels.map((_, r) => grid.slice(r * xLabels.length, (r + 1) * xLabels.length));
 
   const layer: MaidrLayer = {
     id: generateId(),

--- a/src/adapters/d3/binders/histogram.ts
+++ b/src/adapters/d3/binders/histogram.ts
@@ -61,6 +61,49 @@ export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3Bind
 }
 
 /**
+ * The bin edge to use when neither the caller nor the datum states one.
+ *
+ * A pre-aggregated histogram is read as a zero-width bin at its x value, which
+ * works while that value is a number. Bin labels very often are not — a bar
+ * bound to `{ label: '0-10', count: 5 }` coerces to `NaN`, and
+ * `HistogramPoint` has nowhere to say the edge was never known: `Histogram`
+ * puts both bounds straight into the range it announces on every arrow
+ * keypress, and repeats them in the bin-range stat and two data-table columns.
+ * So the reader is told the bin runs NaN to NaN, on every bin, for as long as
+ * the chart exists. Saying so at bind time is the only place the author can
+ * still act on it.
+ *
+ * @param xValue - The bar's x value
+ * @param datum - The bar's bound datum, named in the error
+ * @param index - The bar's index within the selection
+ * @param selector - The user-provided selector, named in the error
+ * @returns The x value as a number
+ * @throws Error when the x value is not a number a bin could be placed at
+ */
+function zeroWidthBinEdge(
+  xValue: string | number,
+  datum: unknown,
+  index: number,
+  selector: string,
+): number {
+  const at = Number(xValue);
+  if (Number.isFinite(at)) {
+    return at;
+  }
+
+  const keys = typeof datum === 'object' && datum !== null ? Object.keys(datum) : [];
+  throw new Error(
+    `Histogram bar ${index} matched by "${selector}" states no bin bounds: its `
+    + `datum carries no \`x0\` / \`x1\`, and its x value "${String(xValue)}" is `
+    + `not a number the bin could be placed at. Bind \`d3.bin()\` output, which `
+    + `carries \`x0\` / \`x1\`, or pass \`xMin\` / \`xMax\` accessors reading the `
+    + `bin's own edges, e.g. \`xMin: d => d.from, xMax: d => d.to\`. Without `
+    + `them every bin range the reader hears would be NaN. `
+    + `Available keys on the datum: ${keys.join(', ') || '(none)'}.`,
+  );
+}
+
+/**
  * Pure extraction core for histograms. See {@link buildBarLayer} for the
  * single-chart vs multi-panel contract.
  *
@@ -104,10 +147,12 @@ export function buildHistogramLayer(root: Element, config: D3HistogramConfig, pa
 
     const xMin = userSetXMin
       ? resolveAccessor<number>(datum, xMinAccessor, index)
-      : (resolveAccessorOptional<number>(datum, xMinAccessor, index) ?? Number(xValue));
+      : (resolveAccessorOptional<number>(datum, xMinAccessor, index)
+        ?? zeroWidthBinEdge(xValue, datum, index, selector));
     const xMax = userSetXMax
       ? resolveAccessor<number>(datum, xMaxAccessor, index)
-      : (resolveAccessorOptional<number>(datum, xMaxAccessor, index) ?? Number(xValue));
+      : (resolveAccessorOptional<number>(datum, xMaxAccessor, index)
+        ?? zeroWidthBinEdge(xValue, datum, index, selector));
 
     const yMin = resolveAccessor<number>(datum, yMinAccessor, index);
     const yMax = yMaxAccessor

--- a/src/adapters/d3/binders/line.ts
+++ b/src/adapters/d3/binders/line.ts
@@ -272,8 +272,17 @@ export function buildLineLayer(
           rowPaths.push(element);
         }
       }
-    } else {
-      // Pattern B: shared parent – query all points once and group by fill
+    }
+
+    // Pattern B: shared parent – query all points once and group by fill.
+    // Also the fallback when Pattern A collected nothing, which is what the
+    // ordinary `g.series-0 > path`, `g.series-1 > path`, `g.dots > circle`
+    // idiom produces: the paths do have distinct parents, so Pattern A is
+    // chosen, but none of those parents holds a marker. Falling through reads
+    // the chart off the markers' own fill, and when there are no markers at
+    // all the throw below says so — either way the reader never gets a line
+    // plot announcing an empty trace.
+    if (data.length === 0) {
       const allPoints = queryD3Elements(root, pointSelector);
       if (allPoints.length === 0) {
         throw new Error(

--- a/src/adapters/d3/binders/line.ts
+++ b/src/adapters/d3/binders/line.ts
@@ -512,6 +512,9 @@ function drawsRightToLeft(
   return true;
 }
 
+/** The attribute each series' `<path>` is stamped with, so one selector names one line. */
+const SERIES_ATTRIBUTE = 'data-maidr-line-index';
+
 /**
  * Emits one highlight selector per series, by stamping each series' `<path>`
  * with a MAIDR-owned `data-maidr-line-index` attribute and pinning it.
@@ -565,12 +568,23 @@ export function stampSeriesSelectors(
   // mirroring `scopeSelector`'s behaviour, and appends the `data-maidr-panel`
   // segment on multi-panel binds.
   const prefix = selectorPrefix(root, panel);
+
+  // Clear every stamp under this root before laying down the new ones, the
+  // way `stampOrderedSelectors` does. Clearing only the paths about to be
+  // re-stamped would leave a series that has dropped out of the payload --
+  // a rebind after a D3 update that empties its points while `.join()` keeps
+  // its path -- carrying its old index, and the emitted selector would then
+  // resolve to two paths for one row. `Svg.selectElement` takes the first in
+  // document order, so the highlight would land on the emptied path and the
+  // row's geometry be parsed from it. Scoped to the root, so a panel never
+  // clears its siblings' stamps.
+  for (const stale of Array.from(root.querySelectorAll(`[${SERIES_ATTRIBUTE}]`))) {
+    stale.removeAttribute(SERIES_ATTRIBUTE);
+  }
+
   return paths.map((element, rowIndex) => {
-    // Clear any prior stamp so rebinding after a D3 data update produces a
-    // clean, deterministic state.
-    element.removeAttribute('data-maidr-line-index');
-    element.setAttribute('data-maidr-line-index', String(rowIndex));
-    return `${prefix} ${selector}[data-maidr-line-index="${rowIndex}"]`;
+    element.setAttribute(SERIES_ATTRIBUTE, String(rowIndex));
+    return `${prefix} ${selector}[${SERIES_ATTRIBUTE}="${rowIndex}"]`;
   });
 }
 

--- a/src/adapters/d3/binders/survival.ts
+++ b/src/adapters/d3/binders/survival.ts
@@ -69,22 +69,47 @@ function readBound(
 }
 
 /**
- * Merges one censoring tick into the arm it belongs to.
+ * What one arm needs to know while its ticks are read.
  *
- * A tick whose time is already a vertex of the curve just flags that vertex.
- * Otherwise a vertex is inserted at that time, carrying the probability — and
- * the band — the curve holds across the interval it falls in, which is what
- * the estimate says there: a censored time is a subject leaving, not a step.
+ * Both maps are built once for the arm rather than per tick: the whole point
+ * of the pass is that no tick rescans the curve.
+ */
+interface ArmMerge {
+  /** The curve's vertices by time, so a tick landing on one just flags it. */
+  byTime: Map<number | string, SurvivalPoint>;
+  /** The times already queued, so two ticks at one time are one point. */
+  queued: Set<number | string>;
+  /** The times to insert, in the order the ticks were read. */
+  times: number[];
+}
+
+/**
+ * Flags the vertex a censoring tick lands on, or queues the tick for
+ * insertion.
  *
- * @param arm - The curve to merge into, in ascending time order
+ * A tick whose time is already a vertex of the curve just flags that vertex —
+ * including one an earlier tick queued, so two ticks at the same time are one
+ * censored point rather than two. Anything else has to be placed between two
+ * vertices, which {@link mergeCensoredTimes} does for the whole arm at once.
+ *
+ * @param arm - The curve the tick belongs to, in ascending time order
+ * @param merge - What has been read for this arm so far
  * @param time - The censored time
  * @param index - The tick's index within its selection, for the error message
  * @throws Error when the arm's times cannot be compared with the tick's
  */
-function mergeCensoredTime(arm: SurvivalPoint[], time: number | string, index: number): void {
-  const existing = arm.findIndex(point => point.x === time);
-  if (existing !== -1) {
-    arm[existing].censored = true;
+function placeCensoredTime(
+  arm: SurvivalPoint[],
+  merge: ArmMerge,
+  time: number | string,
+  index: number,
+): void {
+  const existing = merge.byTime.get(time);
+  if (existing !== undefined) {
+    existing.censored = true;
+    return;
+  }
+  if (merge.queued.has(time)) {
     return;
   }
 
@@ -97,37 +122,68 @@ function mergeCensoredTime(arm: SurvivalPoint[], time: number | string, index: n
       + `curve's samples carry.`,
     );
   }
-
-  // The last vertex at or before the tick: the estimate holds from there.
-  let previous = -1;
-  for (let position = 0; position < arm.length; position++) {
-    const vertex = Number(arm[position].x);
-    if (Number.isFinite(vertex) && vertex <= at) {
-      previous = position;
-    }
-  }
-
-  // A tick before the curve's first vertex takes that vertex's probability,
-  // which on a Kaplan-Meier curve is the 1.0 it starts at.
-  const held = arm[previous === -1 ? 0 : previous];
-  if (held === undefined) {
+  if (arm.length === 0) {
     throw new Error(
       `The censoring tick at index ${index} has no curve to merge into: the `
       + `arm it names carries no samples.`,
     );
   }
 
-  const inserted: SurvivalPoint = { x: at, y: held.y, censored: true };
-  if (held.z !== undefined) {
-    inserted.z = held.z;
+  merge.queued.add(at);
+  merge.times.push(at);
+}
+
+/**
+ * Rebuilds one arm with its queued censoring times merged in.
+ *
+ * Both sequences run in ascending time order — the arm because it is the
+ * curve's own vertex order, the times because they are sorted here — so one
+ * cursor walks them together. Splicing each tick into the row instead
+ * rescanned and re-shifted the whole arm per tick, which on a registry-scale
+ * curve is millions of comparisons and element moves inside a synchronous
+ * bind that re-runs on every React re-bind.
+ *
+ * Each inserted vertex carries the probability — and the band — the curve
+ * holds across the interval it falls in, which is what the estimate says
+ * there: a censored time is a subject leaving, not a step. A tick before the
+ * curve's first vertex takes that vertex's probability, which on a
+ * Kaplan-Meier curve is the 1.0 it starts at.
+ *
+ * @param arm - The curve to merge into, in ascending time order
+ * @param times - The times to insert, none of them already a vertex
+ * @returns The merged curve, or the arm itself when there is nothing to insert
+ */
+function mergeCensoredTimes(arm: SurvivalPoint[], times: number[]): SurvivalPoint[] {
+  if (times.length === 0) {
+    return arm;
   }
-  if (held.yMin !== undefined) {
-    inserted.yMin = held.yMin;
+
+  const merged: SurvivalPoint[] = [];
+  let cursor = 0;
+  let held: SurvivalPoint | undefined;
+  for (const at of [...times].sort((a, b) => a - b)) {
+    while (cursor < arm.length && Number(arm[cursor].x) <= at) {
+      held = arm[cursor];
+      merged.push(arm[cursor]);
+      cursor += 1;
+    }
+    const source = held ?? arm[0];
+    const inserted: SurvivalPoint = { x: at, y: source.y, censored: true };
+    if (source.z !== undefined) {
+      inserted.z = source.z;
+    }
+    if (source.yMin !== undefined) {
+      inserted.yMin = source.yMin;
+    }
+    if (source.yMax !== undefined) {
+      inserted.yMax = source.yMax;
+    }
+    merged.push(inserted);
   }
-  if (held.yMax !== undefined) {
-    inserted.yMax = held.yMax;
+  for (; cursor < arm.length; cursor += 1) {
+    merged.push(arm[cursor]);
   }
-  arm.splice(previous + 1, 0, inserted);
+  return merged;
 }
 
 /**
@@ -174,6 +230,12 @@ function mergeCensoredTicks(
     sample,
   );
 
+  // Read in DOM order, so a chart with more than one unreadable tick still
+  // reports the first of them. Each arm is indexed once, on the first tick
+  // that names it, and the times to insert are collected rather than spliced
+  // in one at a time; the arms are rebuilt below.
+  const merges = new Map<number, ArmMerge>();
+
   for (const { datum, index } of ticks) {
     const time = resolveAccessor<number | string>(datum, xAccessor, index);
     const fill = resolveAccessorOptional<string>(datum, fillAccessor, index);
@@ -197,7 +259,23 @@ function mergeCensoredTicks(
       );
     }
 
-    mergeCensoredTime(arms[row], time, index);
+    let merge = merges.get(row);
+    if (merge === undefined) {
+      const byTime = new Map<number | string, SurvivalPoint>();
+      for (const point of arms[row]) {
+        if (!byTime.has(point.x)) {
+          byTime.set(point.x, point);
+        }
+      }
+      merge = { byTime, queued: new Set<number | string>(), times: [] };
+      merges.set(row, merge);
+    }
+
+    placeCensoredTime(arms[row], merge, time, index);
+  }
+
+  for (const [row, merge] of merges) {
+    arms[row] = mergeCensoredTimes(arms[row], merge.times);
   }
 }
 

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -349,11 +349,22 @@ export function useD3Adapter(
   const specRef = useRef(spec);
   specRef.current = spec;
 
+  // The node the last bind read. A binder writes its state onto the live SVG —
+  // `ensureContainerId` stamps the `id` every emitted selector is anchored to,
+  // and the ordered stampers write the `data-maidr-*` attributes the per-mark
+  // selectors key off — so a schema is only valid for the node it was read
+  // from. `<MaidrD3>` renders its children bare until the first bind and then
+  // wraps them in `<Maidr>`, whose `<article><figure><div>` changes the element
+  // type at that position: React unmounts the bare subtree and mounts a fresh
+  // `<svg>`, taking the id and every stamp with it.
+  const boundSvgRef = useRef<SVGElement | null>(null);
+
   useEffect(() => {
     const svg = svgRef.current;
     if (!svg) {
       return;
     }
+    boundSvgRef.current = svg;
     try {
       const result = runBinder(svg, specRef.current);
       setMaidrData(result.maidr);
@@ -365,6 +376,32 @@ export function useD3Adapter(
       setError(asError);
     }
   }, deps ?? []);
+
+  // Bind again whenever the SVG that carried the last bind has been replaced,
+  // so the node the reader can actually see is the one the emitted selectors
+  // resolve against. The `<Maidr>` swap is the case that always happens; any
+  // other remount of the host `<svg>` lands here too.
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!maidrData || !svg || svg === boundSvgRef.current) {
+      return;
+    }
+    // Claim the node before binding: a binder that throws must not be retried
+    // on every commit, and the schema already on screen still reads correctly
+    // for everything but highlighting, so it is kept rather than withdrawn.
+    boundSvgRef.current = svg;
+    try {
+      const result = runBinder(svg, specRef.current);
+      // Keep the figure id the first bind published — it anchors the article
+      // and figure element ids a screen reader may already have reached.
+      setMaidrData({ ...result.maidr, id: maidrData.id });
+      setError(null);
+    } catch (err) {
+      const asError = err instanceof Error ? err : new Error(String(err));
+      console.error('[MaidrD3] Re-bind after the SVG remounted failed:', asError);
+      setError(asError);
+    }
+  }, [maidrData]);
 
   return { maidrData, error };
 }

--- a/test/adapters/d3/boxWhiskerCaps.test.ts
+++ b/test/adapters/d3/boxWhiskerCaps.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * A d3 box plot drawn with whisker caps.
+ *
+ * Every `<line>` in a box group was classified by aspect ratio alone: in a
+ * vertical box anything wider than it is tall was the median. A great many
+ * hand-rolled d3 box plots draw the whisker **caps** — the short crossbars at
+ * min and max — as `<line>` siblings of the rect, and those are wider than
+ * they are tall too, so all of them were stamped `q2` alongside the real
+ * median.
+ *
+ * `Box.mapToSvgElements` resolves `selector.q2` with `Svg.selectElement`,
+ * which takes the first match in document order, so a group appended in the
+ * usual order — rect, caps, whiskers, median — made the median section
+ * highlight the upper cap: the reader is told "median 3" while the outline
+ * sits at the maximum. The horizontal orientation has the mirror-image
+ * problem with vertical caps.
+ *
+ * A cap sits at the end of a whisker, outside the IQR body; the median
+ * crosses it. That is what separates them.
+ */
+import type { BoxSelector } from '@type/grammar';
+import { bindD3Box } from '@adapters/d3/binders/box';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { Orientation } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Appends a `<line>` to a group.
+ * @param group - The box group to append to
+ * @param coords - The line's `x1,y1,x2,y2`
+ */
+function line(group: Element, coords: [number, number, number, number]): void {
+  const element = document.createElementNS(SVG_NS, 'line');
+  element.setAttribute('x1', String(coords[0]));
+  element.setAttribute('y1', String(coords[1]));
+  element.setAttribute('x2', String(coords[2]));
+  element.setAttribute('y2', String(coords[3]));
+  group.appendChild(element);
+}
+
+/**
+ * A vertical box with capped whiskers, appended rect-caps-whiskers-median.
+ *
+ * The IQR body spans y 50..70 across x 50..70; the whiskers run to y=20 and
+ * y=100, each finished with a crossbar.
+ *
+ * @returns The SVG root
+ */
+function buildCappedVerticalBox(): SVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.id = 'bx';
+  const group = document.createElementNS(SVG_NS, 'g');
+  group.setAttribute('class', 'box');
+  (group as unknown as { __data__: unknown }).__data__ = {
+    fill: 'A',
+    min: 1,
+    q1: 2,
+    q2: 3,
+    q3: 4,
+    max: 5,
+  };
+
+  const rect = document.createElementNS(SVG_NS, 'rect');
+  rect.setAttribute('x', '50');
+  rect.setAttribute('y', '50');
+  rect.setAttribute('width', '20');
+  rect.setAttribute('height', '20');
+  group.appendChild(rect);
+
+  line(group, [55, 20, 65, 20]); // cap at the maximum
+  line(group, [55, 100, 65, 100]); // cap at the minimum
+  line(group, [60, 20, 60, 50]); // upper whisker
+  line(group, [60, 70, 60, 100]); // lower whisker
+  line(group, [50, 60, 70, 60]); // median, crossing the body
+
+  svg.appendChild(group);
+  document.body.appendChild(svg);
+  return svg;
+}
+
+/**
+ * A horizontal box with capped whiskers, appended the same way.
+ *
+ * The IQR body spans x 50..70 across y 50..70; the whiskers run to x=20 and
+ * x=100.
+ *
+ * @returns The SVG root
+ */
+function buildCappedHorizontalBox(): SVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.id = 'bx';
+  const group = document.createElementNS(SVG_NS, 'g');
+  group.setAttribute('class', 'box');
+  (group as unknown as { __data__: unknown }).__data__ = {
+    fill: 'A',
+    min: 1,
+    q1: 2,
+    q2: 3,
+    q3: 4,
+    max: 5,
+  };
+
+  const rect = document.createElementNS(SVG_NS, 'rect');
+  rect.setAttribute('x', '50');
+  rect.setAttribute('y', '50');
+  rect.setAttribute('width', '20');
+  rect.setAttribute('height', '20');
+  group.appendChild(rect);
+
+  line(group, [20, 55, 20, 65]); // cap at the minimum
+  line(group, [100, 55, 100, 65]); // cap at the maximum
+  line(group, [20, 60, 50, 60]); // lower whisker
+  line(group, [70, 60, 100, 60]); // upper whisker
+  line(group, [60, 50, 60, 70]); // median, crossing the body
+
+  svg.appendChild(group);
+  document.body.appendChild(svg);
+  return svg;
+}
+
+describe('a d3 box plot with whisker caps', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('points the vertical median selector at the line crossing the body', () => {
+    const svg = buildCappedVerticalBox();
+
+    const selectors = bindD3Box(svg, {
+      selector: 'g.box',
+      orientation: Orientation.VERTICAL,
+    }).layer.selectors as BoxSelector[];
+
+    const median = document.querySelectorAll(selectors[0].q2);
+    expect(median).toHaveLength(1);
+    expect(median[0].getAttribute('y1')).toBe('60');
+  });
+
+  it('points the horizontal median selector at the line crossing the body', () => {
+    const svg = buildCappedHorizontalBox();
+
+    const selectors = bindD3Box(svg, {
+      selector: 'g.box',
+      orientation: Orientation.HORIZONTAL,
+    }).layer.selectors as BoxSelector[];
+
+    const median = document.querySelectorAll(selectors[0].q2);
+    expect(median).toHaveLength(1);
+    expect(median[0].getAttribute('x1')).toBe('60');
+  });
+
+  it('reads a cap as part of the whisker it finishes', () => {
+    const svg = buildCappedVerticalBox();
+
+    bindD3Box(svg, { selector: 'g.box', orientation: Orientation.VERTICAL });
+
+    const parts = Array.from(svg.querySelectorAll('line')).map(element => ({
+      y1: element.getAttribute('y1'),
+      part: element.getAttribute('data-maidr-box-part'),
+    }));
+    expect(parts).toEqual([
+      { y1: '20', part: 'upper-whisker' },
+      { y1: '100', part: 'lower-whisker' },
+      { y1: '20', part: 'upper-whisker' },
+      { y1: '70', part: 'lower-whisker' },
+      { y1: '60', part: 'q2' },
+    ]);
+  });
+});

--- a/test/adapters/d3/candlestickVolume.test.ts
+++ b/test/adapters/d3/candlestickVolume.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A d3 candlestick chart drawn from OHLC alone.
+ *
+ * `CandlestickPoint.volume` is optional precisely so "absent" and "zero" stay
+ * distinguishable, and `Candlestick.description` renders `c.volume ?? ''` — a
+ * blank cell for a period the chart never stated a volume for. The binder
+ * coerced a missing volume to `0`, so a chart drawn from
+ * `{date, open, high, low, close}` produced a data table whose Volume column
+ * read 0 for every period. A reader quotes that back as "no shares traded"
+ * rather than "the chart never said". Two sibling adapters (amCharts, Google
+ * Charts) already leave it undefined.
+ */
+import type { CandlestickPoint } from '@type/grammar';
+import { bindD3Candlestick } from '@adapters/d3/binders/candlestick';
+import { describe, expect, test } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * An SVG holding one `g.candle` per period, bound the way a join leaves it.
+ * @param data - The data to bind, one datum per candle
+ * @returns The SVG root
+ */
+function buildSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="ohlc"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const group = doc.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'candle');
+    (group as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(group);
+  }
+  return svg;
+}
+
+const OHLC = [
+  { date: '2024-01-02', open: 10, high: 12, low: 9, close: 11 },
+  { date: '2024-01-03', open: 11, high: 13, low: 10, close: 10 },
+];
+
+const CONFIG = {
+  selector: 'g.candle',
+  value: 'date',
+} as const;
+
+describe('a d3 candlestick chart with no volume column', () => {
+  test('leaves the volume out rather than reporting none traded', () => {
+    const svg = buildSvg(OHLC);
+
+    const points = bindD3Candlestick(svg, CONFIG).layer.data as CandlestickPoint[];
+
+    expect(points.map(point => point.volume)).toEqual([undefined, undefined]);
+    expect(Object.hasOwn(points[0], 'volume')).toBe(false);
+  });
+
+  test('keeps a stated volume of zero, which is a reading', () => {
+    const svg = buildSvg([{ ...OHLC[0], volume: 0 }, { ...OHLC[1], volume: 4200 }]);
+
+    const points = bindD3Candlestick(svg, CONFIG).layer.data as CandlestickPoint[];
+
+    expect(points.map(point => point.volume)).toEqual([0, 4200]);
+  });
+});

--- a/test/adapters/d3/heatmapAbsentCell.test.ts
+++ b/test/adapters/d3/heatmapAbsentCell.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * A d3 heatmap cell the join never drew (#1191).
+ *
+ * `HeatmapData.points` spells a cell the chart drew no value at as `null`,
+ * because a grid is a rectangle and an adapter whose data does not fill it has
+ * to be able to say so. The d3 binder instead threw
+ * "Missing heatmap cell for y=…, x=…" the moment the cross-product of the
+ * observed labels was not fully covered — a sparse tidy array, which is the
+ * ordinary shape for a d3 join, aborted the whole bind. In the React path
+ * `useD3Adapter` catches that and publishes nothing, so the chart gets no
+ * accessible layer at all.
+ *
+ * The per-cell selectors are keyed to `points[row][col]`, so the hole has to
+ * be spelled there too: a `null` in the row keeps every drawn cell's selector
+ * aligned with the value it names.
+ */
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import { bindD3Heatmap } from '@adapters/d3/binders/heatmap';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** One cell of the tidy array a d3 heatmap joins over. */
+interface Cell {
+  day: string;
+  slot: string;
+  value: number;
+}
+
+const COMPLETE: Cell[] = [
+  { day: 'Mon', slot: 'AM', value: 5 },
+  { day: 'Tue', slot: 'AM', value: 7 },
+  { day: 'Mon', slot: 'PM', value: 2 },
+  { day: 'Tue', slot: 'PM', value: 4 },
+];
+
+/** The same chart with `Tue`/`PM` never recorded, so no rect is drawn for it. */
+const SPARSE: Cell[] = COMPLETE.filter(cell => !(cell.day === 'Tue' && cell.slot === 'PM'));
+
+/**
+ * A d3-joined heatmap: one `<rect>` per drawn cell, carrying its `__data__`.
+ * @param cells - The tidy rows the join ran over
+ * @returns The SVG root
+ */
+function buildSvg(cells: Cell[]): SVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.id = 'chart';
+  for (const cell of cells) {
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('class', 'cell');
+    (rect as unknown as { __data__: unknown }).__data__ = cell;
+    svg.appendChild(rect);
+  }
+  document.body.appendChild(svg);
+  return svg;
+}
+
+/**
+ * The layer a joined heatmap converts to.
+ * @param cells - The tidy rows the join ran over
+ * @returns The emitted layer
+ */
+function layerFor(cells: Cell[]): MaidrLayer {
+  const svg = buildSvg(cells);
+  return bindD3Heatmap(svg, {
+    selector: 'rect.cell',
+    x: 'day',
+    y: 'slot',
+    value: 'value',
+    yOrder: ['AM', 'PM'],
+    xOrder: ['Mon', 'Tue'],
+  }).layer;
+}
+
+describe('a d3 heatmap missing a cell', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('reads the chart instead of aborting the bind', () => {
+    const points = (layerFor(SPARSE).data as HeatmapData).points;
+
+    expect(points).toEqual([[5, 7], [2, null]]);
+  });
+
+  it('keeps the absent cell distinguishable from one drawn as zero', () => {
+    const zeroed = COMPLETE.map(cell =>
+      cell.day === 'Tue' && cell.slot === 'PM' ? { ...cell, value: 0 } : cell,
+    );
+
+    const absent = (layerFor(SPARSE).data as HeatmapData).points;
+    const drawnZero = (layerFor(zeroed).data as HeatmapData).points;
+
+    expect(absent).not.toEqual(drawnZero);
+  });
+
+  it('leaves a hole in the selector grid so the rest stay aligned', () => {
+    const layer = layerFor(SPARSE);
+
+    // The payload runs top-first while the selector grid is laid out the way
+    // `Heatmap` indexes it, bottom row first — so the hole in the `PM` row
+    // sits at `selectors[0][1]`.
+    const selectors = layer.selectors as (string | null)[][];
+    expect(selectors.map(row => row.length)).toEqual([2, 2]);
+    expect(selectors[0][1]).toBeNull();
+    for (const selector of selectors.flat().filter((one): one is string => one !== null)) {
+      expect(document.querySelectorAll(selector)).toHaveLength(1);
+    }
+  });
+});

--- a/test/adapters/d3/histogramBinBounds.test.ts
+++ b/test/adapters/d3/histogramBinBounds.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Bin bounds a pre-aggregated d3 histogram never stated.
+ *
+ * Without `xMin`/`xMax` accessors and without `x0`/`x1` on the datum, the
+ * binder treats the bin as a zero-width point at the x value — which works
+ * while that value is a number. Pre-aggregated histogram data very often
+ * carries a string bin label instead (`{ label: '0-10', count: 5 }` bound with
+ * `x: 'label'`), and `Number('0-10')` is `NaN`.
+ *
+ * `HistogramPoint` declares both bounds as numbers, and `Histogram.text` puts
+ * them straight into the range it announces on every arrow keypress, with
+ * `description` repeating them in the bin-range stat and two data-table
+ * columns. The reader heard a NaN bin range for every bin, and nothing
+ * anywhere said the bounds were never known — so the failure is invisible to
+ * the author too.
+ */
+import type { HistogramPoint } from '@type/grammar';
+import { bindD3Histogram } from '@adapters/d3/binders/histogram';
+import { describe, expect, test } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * An SVG holding one `rect.bar` per datum, bound the way a join leaves it.
+ * @param data - The data to bind, one datum per bar
+ * @returns The SVG root
+ */
+function buildSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="hist"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('class', 'bar');
+    (rect as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(rect);
+  }
+  return svg;
+}
+
+const LABELLED = [
+  { label: '0-10', count: 5 },
+  { label: '10-20', count: 9 },
+];
+
+describe('a d3 histogram whose bins carry no numeric bounds', () => {
+  test('says which accessors are missing instead of announcing NaN', () => {
+    const svg = buildSvg(LABELLED);
+
+    expect(() => bindD3Histogram(svg, {
+      selector: 'rect.bar',
+      x: 'label',
+      y: 'count',
+    })).toThrow(/xMin.*xMax|`xMin`/s);
+  });
+
+  test('names the keys the datum does carry, so the fix is obvious', () => {
+    const svg = buildSvg(LABELLED);
+
+    expect(() => bindD3Histogram(svg, {
+      selector: 'rect.bar',
+      x: 'label',
+      y: 'count',
+    })).toThrow(/label, count/);
+  });
+
+  test('reads the bounds the caller supplies', () => {
+    const svg = buildSvg(LABELLED);
+
+    const layer = bindD3Histogram(svg, {
+      selector: 'rect.bar',
+      x: 'label',
+      y: 'count',
+      xMin: (datum: unknown) => Number((datum as { label: string }).label.split('-')[0]),
+      xMax: (datum: unknown) => Number((datum as { label: string }).label.split('-')[1]),
+    }).layer;
+
+    const points = layer.data as HistogramPoint[];
+    expect(points.map(point => [point.xMin, point.xMax])).toEqual([[0, 10], [10, 20]]);
+  });
+
+  test('still reads a numeric bin label as a zero-width bin', () => {
+    const svg = buildSvg([{ x: 3, y: 7 }]);
+
+    const points = bindD3Histogram(svg, { selector: 'rect.bar' }).layer.data as HistogramPoint[];
+
+    expect(points[0]).toEqual({ x: 3, y: 7, xMin: 3, xMax: 3, yMin: 0, yMax: 7 });
+  });
+});

--- a/test/adapters/d3/lineDetachedPoints.test.ts
+++ b/test/adapters/d3/lineDetachedPoints.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * A line chart whose markers are drawn in their own layer.
+ *
+ * `g.series-0 > path`, `g.series-1 > path`, `g.dots > circle` is an ordinary
+ * d3 drawing idiom: the lines go down first, the markers on top, so the
+ * markers are not children of any line's parent. The binder chose its
+ * per-parent point query on `parents.size >= lineElements.length` alone, and
+ * every one of those queries came back empty — leaving the loop to end with
+ * nothing collected.
+ *
+ * The result was a layer announcing itself as a line plot and containing no
+ * data at all: `data: []`, `selectors: []`. Unlike the shared-parent branch,
+ * which throws `No point elements found for selector "…"`, nothing said so.
+ *
+ * The markers carry the series they belong to, which is exactly what the
+ * shared-parent branch groups by, so the chart is readable — it just has to
+ * be read that way rather than declared empty.
+ */
+import type { LinePoint } from '@type/grammar';
+import { bindD3Line } from '@adapters/d3/binders/line';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** One marker's bound datum. */
+interface Marker {
+  x: number;
+  y: number;
+  series: string;
+}
+
+const MARKERS: Marker[] = [
+  { x: 1, y: 10, series: 'north' },
+  { x: 2, y: 12, series: 'north' },
+  { x: 1, y: 4, series: 'south' },
+  { x: 2, y: 7, series: 'south' },
+];
+
+/**
+ * Two lines in two groups, with every marker in a third group of its own.
+ * @param markers - The markers to draw, in the order they are appended
+ * @returns The SVG root
+ */
+function buildSvg(markers: Marker[]): SVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.id = 'chart';
+  for (const series of ['north', 'south']) {
+    const group = document.createElementNS(SVG_NS, 'g');
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'line');
+    (path as unknown as { __data__: unknown }).__data__ = { series };
+    group.appendChild(path);
+    svg.appendChild(group);
+  }
+  const dots = document.createElementNS(SVG_NS, 'g');
+  dots.setAttribute('class', 'dots');
+  for (const marker of markers) {
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('class', 'dot');
+    (circle as unknown as { __data__: unknown }).__data__ = marker;
+    dots.appendChild(circle);
+  }
+  svg.appendChild(dots);
+  document.body.appendChild(svg);
+  return svg;
+}
+
+describe('a d3 line whose markers live outside the line groups', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('reads the markers instead of emitting an empty trace', () => {
+    const svg = buildSvg(MARKERS);
+
+    const layer = bindD3Line(svg, {
+      selector: 'path.line',
+      pointSelector: 'circle.dot',
+      fill: 'series',
+    }).layer;
+
+    expect(layer.data as LinePoint[][]).toEqual([
+      [{ x: 1, y: 10, z: 'north' }, { x: 2, y: 12, z: 'north' }],
+      [{ x: 1, y: 4, z: 'south' }, { x: 2, y: 7, z: 'south' }],
+    ]);
+  });
+
+  it('says so rather than announcing an empty line plot when nothing matches', () => {
+    const svg = buildSvg([]);
+
+    expect(() => bindD3Line(svg, {
+      selector: 'path.line',
+      pointSelector: 'circle.dot',
+      fill: 'series',
+    })).toThrow(/No point elements found for selector "circle\.dot"/);
+  });
+});

--- a/test/adapters/d3/lineStaleStamp.test.ts
+++ b/test/adapters/d3/lineStaleStamp.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * A `<path>` that stops contributing a row keeps its old stamp.
+ *
+ * `stampSeriesSelectors` cleared `data-maidr-line-index` only on the paths it
+ * was about to re-stamp, so a path that carried a stamp on a previous bind and
+ * produces no row on this one keeps it. A D3 update that empties one series'
+ * points while `.join()` leaves its path in the DOM is exactly that: the two
+ * remaining series are stamped 0 and 1, and the emptied path still says 0.
+ *
+ * `#chart path.line[data-maidr-line-index="0"]` then matches two elements, and
+ * `LineTrace` resolves it with `Svg.selectElement` — first in document order —
+ * so row 0's highlight lands on the emptied path and its geometry is parsed
+ * from it. `stampOrderedSelectors` documents the same hazard and clears every
+ * stamp under the root first; the series stamper never did.
+ */
+import { bindD3Line } from '@adapters/d3/binders/line';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Three series, each a `<path>` in its own `<g>` with its own markers.
+ * @param counts - How many markers each series is drawn with
+ * @returns The SVG root
+ */
+function buildSvg(counts: number[]): SVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.id = 'chart';
+  counts.forEach((count, series) => {
+    const group = document.createElementNS(SVG_NS, 'g');
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'line');
+    (path as unknown as { __data__: unknown }).__data__ = { series: `s${series}` };
+    group.appendChild(path);
+    for (let index = 0; index < count; index++) {
+      const circle = document.createElementNS(SVG_NS, 'circle');
+      circle.setAttribute('class', 'dot');
+      (circle as unknown as { __data__: unknown }).__data__ = {
+        x: index,
+        y: index + series,
+        series: `s${series}`,
+      };
+      group.appendChild(circle);
+    }
+    svg.appendChild(group);
+  });
+  document.body.appendChild(svg);
+  return svg;
+}
+
+/**
+ * Binds the SVG as a three-series line chart.
+ * @param svg - The SVG to bind
+ * @returns The emitted per-series selectors
+ */
+function bind(svg: SVGElement): string[] | undefined {
+  return bindD3Line(svg, {
+    selector: 'path.line',
+    pointSelector: 'circle.dot',
+    fill: 'series',
+  }).layer.selectors as string[] | undefined;
+}
+
+describe('rebinding a d3 line after a series is emptied', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('leaves no stamp on a path that no longer produces a row', () => {
+    const svg = buildSvg([2, 2, 2]);
+    bind(svg);
+
+    // The D3 update that empties the first series: `.join()` keeps its path.
+    for (const dot of Array.from(svg.querySelectorAll('g:first-of-type circle.dot'))) {
+      dot.remove();
+    }
+    const selectors = bind(svg) as string[];
+
+    expect(selectors).toHaveLength(2);
+    for (const selector of selectors) {
+      expect(document.querySelectorAll(selector)).toHaveLength(1);
+    }
+  });
+});

--- a/test/adapters/d3/maidrD3Remount.test.tsx
+++ b/test/adapters/d3/maidrD3Remount.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * What survives the `<Maidr>` swap.
+ *
+ * `MaidrD3` renders its children bare until the first bind succeeds and then
+ * re-renders them inside `<Maidr>`, which wraps them in
+ * `<article><figure><div>`. The element type at that position changes, so
+ * React unmounts the bare subtree and mounts a brand-new `<svg>` host node.
+ *
+ * Everything a binder writes onto the SVG — the container `id` every emitted
+ * selector is anchored to, and the `data-maidr-*` stamps the per-mark
+ * selectors key off — is a direct DOM mutation on the node that was just
+ * destroyed. Unless the adapter binds again against the node that replaced
+ * it, no emitted selector resolves and the chart is silently left with no
+ * highlighting at all.
+ */
+
+import type { D3AdapterSpec } from '@adapters/d3/useD3Adapter';
+import type { Maidr as MaidrData } from '@type/grammar';
+import type { JSX, ReactNode } from 'react';
+import { MaidrD3 } from '@adapters/d3/MaidrD3';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { render } from '@testing-library/react';
+import { useCallback, useRef } from 'react';
+
+/** The schema handed to `<Maidr>` on the most recent render. */
+let mockRenderedData: MaidrData | null = null;
+
+/**
+ * `<Maidr>` stands in for itself: the real component reaches `react-markdown`
+ * (ESM-only) through the chat panel, and this project compiles to CommonJS.
+ * The stub keeps the one property this file is about — the wrapping element
+ * that changes the tree shape and therefore remounts the `<svg>`.
+ */
+jest.mock('../../../src/maidr-component', () => ({
+  Maidr: (props: { data: MaidrData; children: ReactNode }): ReactNode => {
+    mockRenderedData = props.data;
+    return (
+      <article>
+        <figure>
+          <div>{props.children}</div>
+        </figure>
+      </article>
+    );
+  },
+}));
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const SALES = [
+  { quarter: 'Q1', revenue: 120 },
+  { quarter: 'Q2', revenue: 240 },
+  { quarter: 'Q3', revenue: 180 },
+];
+
+/** A `d3-hexbin` bin: the points that fell in it, carrying its centre. */
+const BINS = [
+  Object.assign([0, 1, 2, 3], { x: 2, y: 10 }),
+  Object.assign([0, 1], { x: 1, y: 10 }),
+  Object.assign([0, 1, 2], { x: 0.5, y: 20 }),
+];
+
+/**
+ * Appends one mark per datum, binding each the way
+ * `selectAll(tag).data(...).join(tag)` would leave it.
+ *
+ * @param node - The SVG to draw into.
+ * @param tag - The SVG element name to draw.
+ * @param className - The class every mark carries.
+ * @param data - The data to bind, one datum per mark.
+ */
+function draw(node: SVGSVGElement, tag: string, className: string, data: unknown[]): void {
+  node.replaceChildren();
+  for (const datum of data) {
+    const mark = node.ownerDocument.createElementNS(SVG_NS, tag);
+    mark.setAttribute('class', className);
+    (mark as unknown as { __data__: unknown }).__data__ = datum;
+    node.appendChild(mark);
+  }
+}
+
+/**
+ * The shipped usage pattern: D3 draws in a ref callback, so the redraw
+ * re-fires when the `<Maidr>` swap remounts the `<svg>`.
+ *
+ * @param props - The chart to render.
+ * @param props.spec - The binder spec to run against the SVG.
+ * @param props.onMount - The drawing to run whenever the SVG mounts.
+ * @returns The wrapped chart.
+ */
+function Chart(props: { spec: D3AdapterSpec; onMount: (node: SVGSVGElement) => void }): JSX.Element {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const { spec, onMount } = props;
+
+  const attachSvg = useCallback((node: SVGSVGElement | null) => {
+    svgRef.current = node;
+    if (node) {
+      onMount(node);
+    }
+  }, [onMount]);
+
+  return (
+    <MaidrD3 svgRef={svgRef} {...spec}>
+      <svg ref={attachSvg} />
+    </MaidrD3>
+  );
+}
+
+/**
+ * Reads the single layer of the schema `<Maidr>` was last handed.
+ *
+ * @returns The layer, or `undefined` when nothing was published.
+ */
+function publishedLayer(): MaidrData['subplots'][number][number]['layers'][number] | undefined {
+  return mockRenderedData?.subplots[0][0].layers[0];
+}
+
+describe('the D3 adapter after the <Maidr> swap', () => {
+  beforeEach(() => {
+    mockRenderedData = null;
+  });
+
+  test('resolves the emitted selector against the SVG the reader can see', () => {
+    render(
+      <Chart
+        spec={{
+          chartType: 'bar',
+          config: { selector: 'rect.bar', x: 'quarter', y: 'revenue', title: 'Sales' },
+        }}
+        onMount={node => draw(node, 'rect', 'bar', SALES)}
+      />,
+    );
+
+    const selector = publishedLayer()?.selectors;
+    expect(typeof selector).toBe('string');
+    expect(document.querySelectorAll(selector as string)).toHaveLength(SALES.length);
+  });
+
+  test('restores the per-mark stamps the ordered selectors key off', () => {
+    render(
+      <Chart
+        spec={{
+          chartType: 'hexbin',
+          config: { selector: 'path.hexagon', title: 'Density' },
+        }}
+        onMount={node => draw(node, 'path', 'hexagon', BINS)}
+      />,
+    );
+
+    // One selector per bin, each stamped onto the mark it names — the model
+    // withdraws the whole layer's highlighting when one of them resolves to
+    // anything other than exactly one element.
+    const selectors = publishedLayer()?.selectors as string[][];
+    expect(selectors.flat()).toHaveLength(BINS.length);
+    for (const selector of selectors.flat()) {
+      expect(document.querySelectorAll(selector)).toHaveLength(1);
+    }
+  });
+
+  test('keeps the figure id the first bind published', () => {
+    const seen: string[] = [];
+    const spec: D3AdapterSpec = {
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'quarter', y: 'revenue' },
+    };
+
+    render(
+      <Chart
+        spec={spec}
+        onMount={(node) => {
+          draw(node, 'rect', 'bar', SALES);
+          if (mockRenderedData) {
+            seen.push(mockRenderedData.id);
+          }
+        }}
+      />,
+    );
+
+    // The re-bind settles rather than publishing a fresh figure on every
+    // commit, and the id a screen reader may already have reached is stable.
+    expect(new Set(seen.concat(mockRenderedData?.id ?? '')).size).toBe(1);
+  });
+});

--- a/test/adapters/d3/survivalCensoredMerge.test.ts
+++ b/test/adapters/d3/survivalCensoredMerge.test.ts
@@ -91,7 +91,8 @@ describe('merging many censoring ticks', () => {
 
   test('still places every tick at its own time, in order', () => {
     const arm = (bindD3Survival(buildSvg(CURVE, TICKS), BASE)
-      .layer.data as SurvivalPoint[][])[0];
+      .layer
+      .data as SurvivalPoint[][])[0];
 
     expect(arm).toHaveLength(CURVE.length + TICKS.length);
     expect(arm.map(point => point.x)).toEqual(

--- a/test/adapters/d3/survivalCensoredMerge.test.ts
+++ b/test/adapters/d3/survivalCensoredMerge.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Merging censoring ticks into a registry-scale Kaplan-Meier curve.
+ *
+ * The merge ran once per tick, and each run scanned the whole arm twice — a
+ * `findIndex` for the time and a second full pass for the insertion point,
+ * with no early exit even though the arm is in ascending time order — and then
+ * spliced, shifting the tail. For an arm of S vertices and T ticks that is
+ * O(T x S) comparisons plus O(T x S) element moves, all inside a synchronous
+ * bind that re-runs on every React re-bind. Two thousand event times with
+ * eight hundred ticks is millions of both.
+ *
+ * The arm is already sorted, so the whole merge is one linear pass. These
+ * cases pin the shape (the tail is never shifted per tick) and the reading it
+ * has to keep producing: every tick placed at its own time, in order, holding
+ * the estimate the curve carries across the interval it falls in.
+ */
+import type { SurvivalPoint } from '@type/grammar';
+import { bindD3Survival } from '@adapters/d3/binders/survival';
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** One curve vertex, as `.data(arms).join('path')` binds it. */
+interface Sample {
+  time: number;
+  surv: number;
+}
+
+/** One censoring tick's datum. */
+interface Tick {
+  time: number;
+}
+
+const BASE = {
+  selector: 'path.km',
+  censoredSelector: 'line.censor',
+  x: 'time',
+  y: 'surv',
+} as const;
+
+/**
+ * A single-arm curve plus a separate join of censoring ticks.
+ * @param arm - The curve's vertices, in ascending time order
+ * @param ticks - The ticks, in the order the join appended them
+ * @returns The SVG root
+ */
+function buildSvg(arm: Sample[], ticks: Tick[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="km"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  const path = doc.createElementNS(SVG_NS, 'path');
+  path.setAttribute('class', 'km');
+  (path as unknown as { __data__: unknown }).__data__ = arm;
+  svg.appendChild(path);
+  for (const tick of ticks) {
+    const mark = doc.createElementNS(SVG_NS, 'line');
+    mark.setAttribute('class', 'censor');
+    (mark as unknown as { __data__: unknown }).__data__ = tick;
+    svg.appendChild(mark);
+  }
+  return svg;
+}
+
+/** A curve dropping by a hundredth at every even time. */
+const CURVE: Sample[] = Array.from({ length: 400 }, (_, index) => ({
+  time: index * 2,
+  surv: 1 - index / 1000,
+}));
+
+/** One tick between each pair of vertices, appended latest-first. */
+const TICKS: Tick[] = Array.from({ length: 399 }, (_, index) => ({
+  time: (398 - index) * 2 + 1,
+}));
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('merging many censoring ticks', () => {
+  test('does not shift the curve tail once per tick', () => {
+    const splice = jest.spyOn(Array.prototype, 'splice');
+
+    bindD3Survival(buildSvg(CURVE, TICKS), BASE);
+
+    // A per-tick `splice` is what makes the merge quadratic in element moves.
+    // Any single-pass merge builds the row instead, so the count cannot grow
+    // with the number of ticks.
+    expect(splice.mock.calls.length).toBeLessThan(TICKS.length);
+  });
+
+  test('still places every tick at its own time, in order', () => {
+    const arm = (bindD3Survival(buildSvg(CURVE, TICKS), BASE)
+      .layer.data as SurvivalPoint[][])[0];
+
+    expect(arm).toHaveLength(CURVE.length + TICKS.length);
+    expect(arm.map(point => point.x)).toEqual(
+      [...CURVE.map(sample => sample.time), ...TICKS.map(tick => tick.time)]
+        .sort((a, b) => a - b),
+    );
+    // A tick is not a step: it holds the estimate the curve carries across the
+    // interval it falls in, which is the vertex before it.
+    expect(arm[3]).toEqual({ x: 3, y: CURVE[1].surv, censored: true });
+    expect(arm[2].censored).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Eight defects in the d3 adapter, found in a codebase audit. Each was reproduced with a test that failed before the change.

The first is the one that takes the whole chart away: React swapping the `<Maidr>` child remounts the `<svg>`, and the fresh node carries none of the binder-assigned container id or `data-maidr-*` stamps. Nothing rebinds, so the chart the reader is looking at is not the chart MAIDR knows about.

## Related Issues

None.

## Changes Made

- **bind**: `useD3Adapter` binds again when `svgRef.current` is a different node than the last bind read. It keeps the first published figure id, and keeps the existing schema if the rebind throws, so drawing in `useEffect` rather than in a ref callback cannot put it in a loop.
- **heatmap**: a grid the join did not fill no longer throws and abort the entire bind. Points and the per-cell selector grid both carry `null` holes, so a sparse heatmap is readable instead of absent.
- **line**: a chart whose markers are drawn in their own layer is read rather than emitted empty. The binder falls through to the shared-parent branch when the per-parent walk collects nothing; the genuinely empty case still throws.
- **line**: stale `data-maidr-line-index` stamps are cleared before rebinding, so a redraw with fewer series cannot leave the old ones addressable.
- **box**: a whisker cap is told apart from the median. The `q2` selector previously resolved to a cap, so the reader was given a whisker end and told it was the middle.
- **survival**: censoring ticks merge in one pass instead of an `O(n)` splice per tick.
- **histogram**: a bin that states no bounds is reported instead of announced as `NaN`.
- **candlestick**: a chart that carries no volume omits the key rather than stating a volume of zero.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**The one change most likely to surface elsewhere:** the histogram binder now *throws* on a non-numeric bin label with no `x0`/`x1` and no `xMin`/`xMax` accessors, where it previously emitted `NaN`. That turns a silent bad reading into a hard failure, which is the right direction for a reader but is a behaviour change a chart in the wild could hit.

No existing test was modified. The Victory findings from the same audit sweep are deliberately not in this branch — they are a separate body of work and belong in their own pull request.

`npm run lint:fix`, `npm run type-check` and `npm test` (6650 unit across 492 suites, 158 ESM across 12) all pass on this branch with `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_