### PR TITLE
fix(scatter): announce a streamed point where the trace actually keeps it

### DIFF
--- a/docs/LIVE_DATA.md
+++ b/docs/LIVE_DATA.md
@@ -253,6 +253,7 @@ Notes for real feeds:
 On live charts (`live: true`), pressing **M** toggles **monitor mode**. While monitoring is on:
 
 - Every data point appended to the **focused layer** is **automatically sonified** (a tone at the point's pitch) and **announced** to screen readers (e.g. "Tick is 42, Reading is 3.14"). On multi-layer charts, appends to other layers stay silent — switch layers (PageUp/PageDown) to change which metric you monitor.
+- A trace that navigates sections rather than a plain list of points is announced at the one reading that stands for the new item: a **candlestick** at the new candle's close, a **box** at the new box's median.
 - The user's current position **does not move** — they can keep exploring historical data while hearing new points arrive, then jump to the live edge with `Ctrl/Cmd + Right Arrow`.
 - Toggling announces "Monitoring on" / "Monitoring off". On non-live charts, pressing M explains that monitoring is only available for live charts.
 
@@ -266,6 +267,7 @@ For unbounded streams, set `maxWidth` on the top-level maidr object. When an `ap
 
 - The window applies **per series** (each line of a multiline chart is capped independently).
 - If the user is positioned inside the trimmed series, their cursor follows the **same data point** as it shifts left (until it falls out of the window, in which case it clamps to the oldest visible point).
+- Two traces are the exception, because the axis the cursor moves along is not the data in arrival order: a **scatter** navigates its sorted unique x values, and a **horizontal box** navigates its sections. There the cursor stays where it is rather than being shifted onto a different point.
 - `setData` is not affected by `maxWidth`; it replaces data verbatim.
 
 ## Behavior Details

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -20,7 +20,7 @@ import { HelpService } from '@service/help';
 import { HighContrastService } from '@service/highContrast';
 import { HighlightService } from '@service/highlight';
 import { KeybindingService, Mousebindingservice } from '@service/keybinding';
-import { isAppendedPointFocused } from '@service/liveData';
+import { appendedPointPosition, isAppendedPointFocused } from '@service/liveData';
 import { MonitorService } from '@service/monitor';
 import { NotificationService } from '@service/notification';
 import { ReviewService } from '@service/review';
@@ -436,7 +436,10 @@ export class Controller implements Disposable {
    * @returns The column shift to apply during position restoration
    */
   private resolveActiveColShift(appended?: AppendedPointInfo): number {
-    if (!appended || appended.trimmed === 0) {
+    // `colShift` rather than `trimmed`: a trim drops points, but how far that
+    // moves the cursor along the column axis is the trace's business — zero
+    // where the columns are not the data points in arrival order.
+    if (!appended || appended.colShift === 0) {
       return 0;
     }
     try {
@@ -445,7 +448,7 @@ export class Controller implements Disposable {
       // predicate against the OLD figure is safe even for appends that start
       // a new series: the window trims per group, so a brand-new group (one
       // point) always has trimmed === 0 and returns above.
-      return isAppendedPointFocused(this.figure, appended) ? appended.trimmed : 0;
+      return isAppendedPointFocused(this.figure, appended) ? appended.colShift : 0;
     } catch (error) {
       console.warn('[maidr] Failed to resolve sliding-window shift:', error);
       return 0;
@@ -481,7 +484,10 @@ export class Controller implements Disposable {
       if (!trace) {
         return;
       }
-      const state = trace.getStateAt(appended.row, appended.col);
+      // Announce coordinates come from the trace itself where the data order
+      // is not the navigation order (a scatter groups its points by sorted x).
+      const position = appendedPointPosition(trace, appended);
+      const state = trace.getStateAt(position.row, position.col);
       this.monitorService.handleNewPoint(state);
     } catch (error) {
       console.warn('[maidr] Failed to announce appended data point:', error);

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -1,3 +1,4 @@
+import type { BoxplotSectionType } from '@type/boxplotSection';
 import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
@@ -10,6 +11,27 @@ import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 import { extremeStat, isHigher, isLower } from './boxExtremes';
 import { MovableGrid } from './movable';
+
+/**
+ * The sections a standard box carries, in navigation order.
+ *
+ * One rule with two callers, as `candlestickSectionsOf` is for a candlestick:
+ * the trace lays its values out along these, and the live data service asks
+ * where a section sits to announce a streamed box on it. They must agree — an
+ * index counted off a different list names a different section, or none.
+ *
+ * Copied into the trace rather than held by it: `dispose()` truncates the
+ * array it was given, which held by reference would empty this one.
+ */
+export const BOX_SECTIONS: readonly BoxplotSectionType[] = [
+  BoxplotSection.LOWER_OUTLIER,
+  BoxplotSection.MIN,
+  BoxplotSection.Q1,
+  BoxplotSection.Q2,
+  BoxplotSection.Q3,
+  BoxplotSection.MAX,
+  BoxplotSection.UPPER_OUTLIER,
+];
 
 /**
  * Concrete implementation of a box plot trace supporting vertical and horizontal orientations.
@@ -117,15 +139,7 @@ export class BoxTrace extends AbstractTrace {
     accessors: ((p: BoxPoint) => number | number[])[];
   } {
     return {
-      sections: [
-        BoxplotSection.LOWER_OUTLIER,
-        BoxplotSection.MIN,
-        BoxplotSection.Q1,
-        BoxplotSection.Q2,
-        BoxplotSection.Q3,
-        BoxplotSection.MAX,
-        BoxplotSection.UPPER_OUTLIER,
-      ],
+      sections: [...BOX_SECTIONS],
       accessors: [
         (p: BoxPoint) => p.lowerOutliers,
         (p: BoxPoint) => p.min,

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1204,6 +1204,39 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       : this.yPointIndices[this.row]) ?? [];
   }
 
+  /**
+   * Where one of this layer's `data` points sits in the trace's own
+   * coordinates — the inverse of {@link ScatterTrace.highlightedPointIndices}.
+   *
+   * A scatter does not navigate its points in the order they arrived: the
+   * constructor sorts by x and groups the duplicates, so a column is one
+   * unique x. A raw data index read as a column therefore names a different
+   * point, or none at all once duplicates have collapsed several into one.
+   * That is what a streamed point needs translating out of before it can be
+   * announced (`LiveDataManager.appendData` reports the new point by data
+   * index).
+   *
+   * Mode-aware, because the coordinate the state getters read is: `COL`
+   * announces the column at `col` and pans by the point's place within it,
+   * `ROW` announces the row at `row`.
+   *
+   * @param index - An index into this layer's `data` array
+   * @returns The position to read that point at, or null when the index is
+   *          not one this trace has
+   */
+  public positionOfDataIndex(index: number): { row: number; col: number } | null {
+    const point = this.flatPoints[index];
+    if (!point) {
+      return null;
+    }
+    if (this.mode === NavMode.COL) {
+      return { row: point.yIndexInColumn, col: point.xIndex };
+    }
+    // yValues is the sorted unique y axis, so a point of this trace is always
+    // on it; the clamp only guards a malformed layer.
+    return { row: Math.max(0, this.yValues.indexOf(point.y)), col: point.xIndex };
+  }
+
   protected override get hasMultiPoints(): boolean {
     return true;
   }

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -15,9 +15,11 @@ import type {
   StepPoint,
   ViolinKdePoint,
 } from '@type/grammar';
+import { BOX_SECTIONS } from '@model/box';
 import { candlestickSectionsOf } from '@model/candlestick';
 import { ScatterTrace } from '@model/scatter';
-import { TraceType } from '@type/grammar';
+import { BoxplotSection } from '@type/boxplotSection';
+import { Orientation, TraceType } from '@type/grammar';
 
 /**
  * Trace types whose layer data is a nested array of groups
@@ -90,8 +92,9 @@ export interface AppendedPointInfo {
    * so a reader keeps the point they were on.
    *
    * `trimmed` wherever columns index the data points in arrival order, which
-   * is most traces. Zero where they do not: a scatter's columns are its
-   * sorted unique x values, which a trim does not shift by any fixed amount.
+   * is most traces. Zero where they do not: a horizontal box navigates its
+   * sections along the column axis, and a scatter's columns are its sorted
+   * unique x values, which a trim does not shift by any fixed amount.
    */
   colShift: number;
   /**
@@ -265,6 +268,25 @@ export function appendPointToMaidr(
       // (see the Candlestick constructor), so the same cell is targeted
       // whichever way the chart is drawn.
       row = candlestickSectionsOf(newData as CandlestickPoint[]).indexOf('close');
+    } else if (layer.type === TraceType.BOX) {
+      // A box navigates sections along one axis and boxes along the other,
+      // and which is which follows the orientation (see `computeBoxValues`).
+      // Announce the new box at its median: every section of it is new, and
+      // the median is the one reading that stands for the distribution. The
+      // default — the last column of the first row — is the lower outliers
+      // of some other box, announced with no value at all.
+      const median = BOX_SECTIONS.indexOf(BoxplotSection.Q2);
+      if (layer.orientation === Orientation.HORIZONTAL) {
+        // Horizontal: [boxes][sections], and the trace reverses the points so
+        // the newest box is the first row. The column axis is the sections
+        // here, and a trim never moves those, so it takes no shift.
+        row = 0;
+        col = median;
+        colShift = 0;
+      } else {
+        // Vertical: [sections][boxes], so the column is still the new box.
+        row = median;
+      }
     } else if (layer.type === TraceType.SCATTER) {
       // A scatter's columns are its sorted unique x values, so a trim does
       // not shift them by the number of points it dropped — the dropped

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -272,9 +272,13 @@ export function appendPointToMaidr(
       // A box navigates sections along one axis and boxes along the other,
       // and which is which follows the orientation (see `computeBoxValues`).
       // Announce the new box at its median: every section of it is new, and
-      // the median is the one reading that stands for the distribution. The
-      // default — the last column of the first row — is the lower outliers
-      // of some other box, announced with no value at all.
+      // the median is the one reading that stands for the distribution.
+      //
+      // The flat default — row 0, last column — announces the lower outliers
+      // on a vertical chart, which is an empty list and no reading at all,
+      // and on a horizontal one whichever section sits at the new box's data
+      // index, or nothing once a chart has more boxes than a box has
+      // sections.
       const median = BOX_SECTIONS.indexOf(BoxplotSection.Q2);
       if (layer.orientation === Orientation.HORIZONTAL) {
         // Horizontal: [boxes][sections], and the trace reverses the points so

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -1,4 +1,4 @@
-import type { Figure } from '@model/plot';
+import type { Figure, Trace } from '@model/plot';
 import type { Disposable } from '@type/disposable';
 import type {
   BarPoint,
@@ -16,6 +16,7 @@ import type {
   ViolinKdePoint,
 } from '@type/grammar';
 import { candlestickSectionsOf } from '@model/candlestick';
+import { ScatterTrace } from '@model/scatter';
 import { TraceType } from '@type/grammar';
 
 /**
@@ -84,6 +85,15 @@ export interface AppendedPointInfo {
   col: number;
   /** Number of points dropped from the front by the `maxWidth` sliding window. */
   trimmed: number;
+  /**
+   * How far a `maxWidth` trim moves the cursor along the trace's column axis,
+   * so a reader keeps the point they were on.
+   *
+   * `trimmed` wherever columns index the data points in arrival order, which
+   * is most traces. Zero where they do not: a scatter's columns are its
+   * sorted unique x values, which a trim does not shift by any fixed amount.
+   */
+  colShift: number;
   /**
    * True when the point was merged into a nested group layer (e.g. multiline),
    * where `row` is the series index. For flat layers `row`/`col` are announce
@@ -200,6 +210,7 @@ export function appendPointToMaidr(
   let row: number;
   let col: number;
   let trimmed: number;
+  let colShift: number;
   let nested: boolean;
 
   // Nested layers are detected by trace type so that an initially empty
@@ -229,6 +240,7 @@ export function appendPointToMaidr(
     row = groupIndex;
     col = result.points.length - 1;
     trimmed = result.trimmed;
+    colShift = result.trimmed;
     nested = true;
   } else {
     // Flat point data (e.g. bar, scatter): traces store these as a single row.
@@ -238,6 +250,7 @@ export function appendPointToMaidr(
     row = 0;
     col = result.points.length - 1;
     trimmed = result.trimmed;
+    colShift = result.trimmed;
     nested = false;
 
     // Candlestick navigation maps one axis to OHLC sections: target the
@@ -252,6 +265,16 @@ export function appendPointToMaidr(
       // (see the Candlestick constructor), so the same cell is targeted
       // whichever way the chart is drawn.
       row = candlestickSectionsOf(newData as CandlestickPoint[]).indexOf('close');
+    } else if (layer.type === TraceType.SCATTER) {
+      // A scatter's columns are its sorted unique x values, so a trim does
+      // not shift them by the number of points it dropped — the dropped
+      // point may sort anywhere, and may have shared its column with points
+      // that remain. Holding the cursor still is the closest thing to
+      // leaving the reader where they were.
+      //
+      // `col` stays the appended point's index in `data`, which is what
+      // `appendedPointPosition` translates into the trace's own coordinates.
+      colShift = 0;
     }
   }
 
@@ -282,6 +305,7 @@ export function appendPointToMaidr(
       row,
       col,
       trimmed,
+      colShift,
       nested,
     },
   };
@@ -510,6 +534,35 @@ export function isAppendedPointFocused(
     return false;
   }
   return true;
+}
+
+/**
+ * Where the rebuilt trace holds a newly appended point, as the (row, col)
+ * `Trace.getStateAt` must be asked for to announce it.
+ *
+ * {@link appendPointToMaidr} answers this from the data alone, which is enough
+ * for a trace that navigates its points in the order they arrived. A scatter
+ * does not: it sorts by x and groups the duplicates, so the raw index it
+ * carries in `col` addresses a different point, or a column that does not
+ * exist — the announcement was then silent (the lookup threw and the
+ * controller swallowed it) or named whichever point sorted last.
+ *
+ * Asked of the trace rather than recomputed here, so the grouping rule stays
+ * the model's and cannot drift from it.
+ *
+ * @param trace - The trace rebuilt from the updated data
+ * @param appended - Location of the appended point
+ * @returns The position to read the appended point's state at
+ */
+export function appendedPointPosition(
+  trace: Trace,
+  appended: AppendedPointInfo,
+): { row: number; col: number } {
+  if (trace instanceof ScatterTrace && !appended.nested) {
+    // Flat layers report `col` as the point's index in the layer's data.
+    return trace.positionOfDataIndex(appended.col) ?? { row: appended.row, col: appended.col };
+  }
+  return { row: appended.row, col: appended.col };
 }
 
 /**

--- a/test/model/scatterAppendedPosition.test.ts
+++ b/test/model/scatterAppendedPosition.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A scatter can say where it keeps one of the points it was given.
+ *
+ * Live data streams a point in and reports it by its index in the layer's
+ * `data` array, which for most traces is also the column it lands on. A
+ * scatter is not one of those: the constructor sorts by x and groups the
+ * duplicates, so a column is a unique x and the raw index addresses some
+ * other point — or a column the chart does not have, once duplicates have
+ * collapsed several into one.
+ *
+ * These pin the translation the monitor announcement of a streamed point
+ * goes through.
+ */
+
+/**
+ * A scatter with no axis ranges, so grid mode is unavailable and the trace
+ * navigates its columns — the configuration a streaming chart arrives in.
+ * @param data - The points the layer carries
+ * @returns The layer
+ */
+function createLayer(data: ScatterPoint[]): MaidrLayer {
+  return {
+    id: 'points',
+    type: TraceType.SCATTER,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  };
+}
+
+/** Two points at one x, and one either side of it, in no particular order. */
+const unsorted: ScatterPoint[] = [
+  { x: 5, y: 1 },
+  { x: 1, y: 2 },
+  { x: 5, y: 3 },
+  { x: 3, y: 9 },
+];
+
+describe('the position a scatter keeps a data point at', () => {
+  test('is the column its x sorts into, not the order it arrived in', () => {
+    const trace = new ScatterTrace(createLayer(unsorted));
+
+    // Unique x values are 1, 3, 5 — so the last point to arrive is the
+    // middle column, and reading it at index 3 would fall off the axis.
+    expect(trace.positionOfDataIndex(3)).toEqual({ row: 0, col: 1 });
+    expect(trace.positionOfDataIndex(1)).toEqual({ row: 0, col: 0 });
+  });
+
+  test('is the point\'s place within its column when points share an x', () => {
+    const trace = new ScatterTrace(createLayer(unsorted));
+
+    // The two points at x = 5 stack in ascending y: y = 1 then y = 3.
+    expect(trace.positionOfDataIndex(0)).toEqual({ row: 0, col: 2 });
+    expect(trace.positionOfDataIndex(2)).toEqual({ row: 1, col: 2 });
+  });
+
+  test('is a row on the y axis once the reader has switched to row navigation', () => {
+    const trace = new ScatterTrace(createLayer(unsorted));
+    trace.isInitialEntry = false;
+
+    trace.moveOnce('UPWARD'); // COL -> ROW
+
+    // Unique y values are 1, 2, 3, 9; the appended point's y = 9 is the last.
+    expect(trace.positionOfDataIndex(3)).toEqual({ row: 3, col: 1 });
+  });
+
+  test('is nothing for an index the layer does not have', () => {
+    const trace = new ScatterTrace(createLayer(unsorted));
+
+    expect(trace.positionOfDataIndex(4)).toBeNull();
+    expect(trace.positionOfDataIndex(-1)).toBeNull();
+  });
+});

--- a/test/service/liveData.test.ts
+++ b/test/service/liveData.test.ts
@@ -1,10 +1,11 @@
 import type { AppendedPointInfo, AppendResult } from '@service/liveData';
-import type { BarPoint, CandlestickPoint, LinePoint, Maidr, ScatterPoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, LinePoint, Maidr, ScatterPoint } from '@type/grammar';
 import type { NonEmptyTraceState } from '@type/state';
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { Figure } from '@model/plot';
 import { appendedPointPosition, appendPointToMaidr, cloneMaidrData, isAppendedPointFocused, LiveDataManager } from '@service/liveData';
-import { TraceType } from '@type/grammar';
+import { BoxplotSection } from '@type/boxplotSection';
+import { Orientation, TraceType } from '@type/grammar';
 
 /**
  * Creates a minimal bar-chart Maidr config for live data tests.
@@ -150,6 +151,49 @@ function createScatterMaidr(id = 'scatter-chart', maxWidth?: number): Maidr {
 }
 
 /**
+ * One box of the five-number summary, its values spread around `base`.
+ * @param z - The group name
+ * @param base - The whisker minimum; the rest follow one apart
+ * @returns The box
+ */
+function createBox(z: string, base: number): BoxPoint {
+  return {
+    z,
+    lowerOutliers: [],
+    min: base,
+    q1: base + 1,
+    q2: base + 2,
+    q3: base + 3,
+    max: base + 4,
+    upperOutliers: [],
+  };
+}
+
+/**
+ * A box chart drawn in the given orientation.
+ * @param orientation - How the boxes are laid out
+ * @param count - How many boxes the chart starts with
+ * @param maxWidth - Optional sliding window size
+ * @returns A Maidr config with a single box layer
+ */
+function createBoxMaidr(orientation: Orientation, count: number, maxWidth?: number): Maidr {
+  return {
+    id: 'box-chart',
+    ...(maxWidth !== undefined && { maxWidth }),
+    live: true,
+    subplots: [[{
+      layers: [{
+        id: 'boxes',
+        type: TraceType.BOX,
+        orientation,
+        axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+        data: Array.from({ length: count }, (_, i) => createBox(`B${i}`, i * 10)),
+      }],
+    }]],
+  };
+}
+
+/**
  * What a monitoring reader is told about an appended point, taken the way
  * `Controller.announceAppendedPoint` takes it: rebuild the figure from the
  * updated data, translate the append into the trace's coordinates, and read
@@ -210,9 +254,11 @@ describe('a streamed candle on a chart with no opening price', () => {
 
 /**
  * Monitor mode reads the streamed point out of the rebuilt trace, so the
- * coordinates it is given have to be the ones that trace navigates by. A
- * scatter does not keep its points in the order they arrived — it sorts by x
- * and groups the duplicates — and was announced from the raw data index.
+ * coordinates it is given have to be the ones that trace navigates by. Two
+ * traces do not keep their points in the order they arrived, and both were
+ * announced from the raw data index: a scatter sorts by x and groups the
+ * duplicates, and a box lays out sections along one axis and boxes along the
+ * other, swapping which is which with the orientation.
  */
 describe('a streamed point is announced where its trace keeps it', () => {
   test('a scatter announces the point that arrived, wherever its x sorts to', () => {
@@ -226,11 +272,45 @@ describe('a streamed point is announced where its trace keeps it', () => {
     expect(state.text.cross?.value).toEqual([9]);
   });
 
+  test('a vertical box announces the new box at its median', () => {
+    const result = appendPointToMaidr(
+      createBoxMaidr(Orientation.VERTICAL, 2),
+      createBox('C', 20),
+    );
+
+    const state = announcementFor(result!);
+
+    expect(state.text.main.value).toBe('C');
+    expect(state.text.section).toBe(BoxplotSection.Q2);
+    expect(state.text.cross?.value).toBe(22);
+  });
+
+  test('a horizontal box announces the new box at its median', () => {
+    // Eight boxes, so the raw index is past the seven sections a box has:
+    // the announcement had no section and no value at all.
+    const result = appendPointToMaidr(
+      createBoxMaidr(Orientation.HORIZONTAL, 8),
+      createBox('C', 100),
+    );
+
+    const state = announcementFor(result!);
+
+    expect(state.text.main.value).toBe('C');
+    expect(state.text.section).toBe(BoxplotSection.Q2);
+    expect(state.text.cross?.value).toBe(102);
+  });
+
   test('a trim shifts the cursor along a column axis that indexes the data', () => {
     const bar = appendPointToMaidr(createBarMaidr('bar-chart', 2), { x: 'C', y: 3 });
+    const vertical = appendPointToMaidr(
+      createBoxMaidr(Orientation.VERTICAL, 2, 2),
+      createBox('C', 20),
+    );
 
     expect(bar!.appended.trimmed).toBe(1);
     expect(bar!.appended.colShift).toBe(1);
+    expect(vertical!.appended.trimmed).toBe(1);
+    expect(vertical!.appended.colShift).toBe(1);
   });
 
   test('a trim does not shift a scatter, whose columns are its sorted x values', () => {
@@ -241,6 +321,16 @@ describe('a streamed point is announced where its trace keeps it', () => {
 
     // The dropped point may sort anywhere, and may have shared its column
     // with points that remain, so no fixed shift keeps the reader in place.
+    expect(result!.appended.trimmed).toBe(1);
+    expect(result!.appended.colShift).toBe(0);
+  });
+
+  test('a trim does not shift a horizontal box, whose columns are its sections', () => {
+    const result = appendPointToMaidr(
+      createBoxMaidr(Orientation.HORIZONTAL, 2, 2),
+      createBox('C', 20),
+    );
+
     expect(result!.appended.trimmed).toBe(1);
     expect(result!.appended.colShift).toBe(0);
   });

--- a/test/service/liveData.test.ts
+++ b/test/service/liveData.test.ts
@@ -1,8 +1,9 @@
-import type { AppendedPointInfo } from '@service/liveData';
-import type { BarPoint, CandlestickPoint, LinePoint, Maidr } from '@type/grammar';
+import type { AppendedPointInfo, AppendResult } from '@service/liveData';
+import type { BarPoint, CandlestickPoint, LinePoint, Maidr, ScatterPoint } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { Figure } from '@model/plot';
-import { appendPointToMaidr, cloneMaidrData, isAppendedPointFocused, LiveDataManager } from '@service/liveData';
+import { appendedPointPosition, appendPointToMaidr, cloneMaidrData, isAppendedPointFocused, LiveDataManager } from '@service/liveData';
 import { TraceType } from '@type/grammar';
 
 /**
@@ -119,6 +120,58 @@ function createHlcMaidr(id = 'hlc-chart'): Maidr {
   };
 }
 
+/**
+ * A scatter whose points did not arrive in x order, two of them sharing an x.
+ *
+ * The trace sorts by x and groups the duplicates, so these four points make
+ * three columns and no column is at the index the point arrived at.
+ * @param id - The chart identifier
+ * @param maxWidth - Optional sliding window size
+ * @returns A Maidr config with a single scatter layer
+ */
+function createScatterMaidr(id = 'scatter-chart', maxWidth?: number): Maidr {
+  return {
+    id,
+    ...(maxWidth !== undefined && { maxWidth }),
+    live: true,
+    subplots: [[{
+      layers: [{
+        id: 'points',
+        type: TraceType.SCATTER,
+        axes: { x: { label: 'X' }, y: { label: 'Y' } },
+        data: [
+          { x: 5, y: 1 },
+          { x: 1, y: 2 },
+          { x: 5, y: 3 },
+        ] as ScatterPoint[],
+      }],
+    }]],
+  };
+}
+
+/**
+ * What a monitoring reader is told about an appended point, taken the way
+ * `Controller.announceAppendedPoint` takes it: rebuild the figure from the
+ * updated data, translate the append into the trace's coordinates, and read
+ * the state there. The translation is imported rather than re-implemented, so
+ * what runs here is the shipped wiring.
+ * @param result - The append to announce
+ * @returns The state the monitor service would be handed
+ */
+function announcementFor(result: AppendResult): NonEmptyTraceState {
+  const figure = new Figure(result.maidr);
+  const trace = figure.activeSubplot.activeTrace;
+  if (!trace) {
+    throw new Error('fixture subplot should have an active trace');
+  }
+  const position = appendedPointPosition(trace, result.appended);
+  const state = trace.getStateAt(position.row, position.col);
+  if (state.empty) {
+    throw new Error('the appended point was announced as an empty state');
+  }
+  return state;
+}
+
 describe('a streamed candle on a chart with no opening price', () => {
   test('is announced on a row that chart has', () => {
     const result = appendPointToMaidr(createHlcMaidr(), {
@@ -155,6 +208,44 @@ describe('a streamed candle on a chart with no opening price', () => {
   });
 });
 
+/**
+ * Monitor mode reads the streamed point out of the rebuilt trace, so the
+ * coordinates it is given have to be the ones that trace navigates by. A
+ * scatter does not keep its points in the order they arrived — it sorts by x
+ * and groups the duplicates — and was announced from the raw data index.
+ */
+describe('a streamed point is announced where its trace keeps it', () => {
+  test('a scatter announces the point that arrived, wherever its x sorts to', () => {
+    const result = appendPointToMaidr(createScatterMaidr(), { x: 3, y: 9 } as ScatterPoint);
+
+    const state = announcementFor(result!);
+
+    // x = 3 sorts into the middle of 1, 3, 5 — the raw index 3 is past the
+    // last column the chart has, which the reader heard as silence.
+    expect(state.text.main.value).toBe(3);
+    expect(state.text.cross?.value).toEqual([9]);
+  });
+
+  test('a trim shifts the cursor along a column axis that indexes the data', () => {
+    const bar = appendPointToMaidr(createBarMaidr('bar-chart', 2), { x: 'C', y: 3 });
+
+    expect(bar!.appended.trimmed).toBe(1);
+    expect(bar!.appended.colShift).toBe(1);
+  });
+
+  test('a trim does not shift a scatter, whose columns are its sorted x values', () => {
+    const result = appendPointToMaidr(
+      createScatterMaidr('scatter-chart', 3),
+      { x: 3, y: 9 } as ScatterPoint,
+    );
+
+    // The dropped point may sort anywhere, and may have shared its column
+    // with points that remain, so no fixed shift keeps the reader in place.
+    expect(result!.appended.trimmed).toBe(1);
+    expect(result!.appended.colShift).toBe(0);
+  });
+});
+
 describe('appendPointToMaidr', () => {
   test('appends a point to flat (bar) layer data', () => {
     const maidr = createBarMaidr();
@@ -172,6 +263,7 @@ describe('appendPointToMaidr', () => {
       row: 0,
       col: 2,
       trimmed: 0,
+      colShift: 0,
       nested: false,
     });
   });
@@ -597,6 +689,7 @@ function createAppended(overrides: Partial<AppendedPointInfo> = {}): AppendedPoi
     row: 0,
     col: 1,
     trimmed: 0,
+    colShift: 0,
     nested: false,
     ...overrides,
   };


### PR DESCRIPTION
# Pull Request

## Description

Two defects in the live-data append path, found in a codebase audit. Both were reproduced with a failing test first.

Streaming a point into a scatter layer announced the wrong point, or nothing at all. `appendData` used the raw insertion index as a column, but a scatter trace keeps its points sorted, so the two disagree the moment a point does not arrive in order. With the fix neutered, the reproduction throws `Cannot read properties of undefined (reading 'y')` and the controller swallows the announcement entirely.

A box layer had a related fault: the appended coordinates ignored the trace's section and position layout. A vertical box announced the section "Lower outlier(s)" with an empty value, and a horizontal box with eight boxes announced no section at all.

## Related Issues

None.

## Changes Made

- **scatter**: a streamed point is announced at the position the trace sorted it to, not at the index it arrived at. New public `ScatterTrace.positionOfDataIndex(index)` answers that question.
- **box**: appended coordinates follow the box trace's own section and position layout, so a streamed box is announced on a section it actually has. `BOX_SECTIONS` is exported for it; `BoxTrace` copies the array, since `dispose()` truncates its own.
- **liveData**: `AppendedPointInfo` gains `colShift`, how far a `maxWidth` trim moves the cursor along the column axis. The controller reads that instead of `trimmed`. New exported helper `appendedPointPosition(trace, appended)`.
- **docs**: `docs/LIVE_DATA.md` promised that a trim always carries the cursor onto the same data point. That is no longer true for a scatter or a horizontal box, and the page now says so, along with which reading of a multi-section item monitor mode announces.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Two limits are left in place on purpose, and the code comments claim only what is true:

- Violin box layers have the same class of bug, but their section list depends on the layer options, so they still get the flat default. That is its own change.
- A horizontal box's *row* cursor still drifts by one per trimmed box, because the reversal prepends the new box. There is only `activeColShift` and no row equivalent, and inventing one is beyond this fix.

A third limit was listed here and was wrong: it said a scatter in grid mode still announces the focused grid cell. `ScatterTrace.getStateAt` suspends grid and grid-cell mode along with point and intersection mode, so that limitation no longer exists. It was fixed in #1220 and the note was stale. It never reached the code or the docs.

One existing test changed: the two `AppendedPointInfo` literals in `test/service/liveData.test.ts` carry the new field. Their intent is unchanged.

`npm run lint:fix`, `npm run type-check` and `npm test` (6640 unit across 485 suites, 158 ESM across 12) all pass on this branch with `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun