### PR TITLE
fix(chartjs): resolve the highlights and x values the adapters were getting wrong

### DIFF
--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -494,13 +494,19 @@ function formatCandlePosition(value: unknown): string {
  * keeps naming the candle it addresses -- the same rule
  * {@link readCategoryValues} follows.
  *
+ * Read through {@link orderedDataItems}, as every other family is, so an
+ * inversed x axis is walked from the end it is drawn from -- and, more to the
+ * point, from the same end `filterCandlestickItems` walks it from. The two
+ * disagreeing is a payload naming one candle while the overlay outlines its
+ * mirror image (#1024).
+ *
  * @param series - The financial series
  * @returns One point per complete candle
  */
 export function extractCandlestickPoints(series: AmXYSeries): CandlestickPoint[] {
   const points: CandlestickPoint[] = [];
 
-  for (const item of series.dataItems) {
+  for (const item of orderedDataItems(series)) {
     const open = toNumber(item.get('openValueY'));
     const high = toNumber(item.get('highValueY'));
     const low = toNumber(item.get('lowValueY'));

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -930,13 +930,15 @@ export function groupSeries(chart: AmChart): SeriesGroups {
       case 'gantt':
         groups.ganttSeriesList.push(series);
         break;
-      // A treemap, an icicle and a sunburst draw one tree three ways; the
-      // highlight walks the same nodes whichever it is, so they share a
-      // bucket. Which *mark* to measure is decided from the layer's trace type
-      // where the resolver is built, since that is what differs.
+      // A treemap, an icicle, a sunburst, a tree and a pack draw one tree five
+      // ways; the highlight walks the same nodes whichever it is, so they
+      // share a bucket. Which *mark* to measure is decided from the layer's
+      // trace type where the resolver is built, since that is what differs.
       case 'treemap':
       case 'icicle':
       case 'sunburst':
+      case 'tree':
+      case 'pack':
         groups.hierarchySeriesList.push(series);
         break;
       case 'wordcloud':
@@ -1169,9 +1171,12 @@ function addEntryResolvers(
       }
       case TraceType.TREEMAP:
       case TraceType.ICICLE:
-      case TraceType.SUNBURST: {
-        // One tree, three marks: a treemap block and an icicle bar are
-        // rectangles, a sunburst node is a wedge.
+      case TraceType.SUNBURST:
+      case TraceType.TREE:
+      case TraceType.PACK: {
+        // One tree, several marks: a treemap block and an icicle bar are
+        // rectangles, a tree node and a pack circle are measured by the box
+        // they occupy just the same, and a sunburst node is a wedge.
         const kind: NavItemTarget['kind']
           = layer.type === TraceType.SUNBURST ? 'slice' : 'column';
         register(

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -320,6 +320,12 @@ function orderPanelsByGeometry(
  * datasets, and with the panel's own scale substituted as the default value
  * scale so the existing per-type extractors (which read `scales.x`/`scales.y`)
  * pick up the panel's axis label and stacked flag unchanged.
+ *
+ * `data.datasets` is a subset, so every extractor handed this view counts its
+ * datasets from zero. The per-dataset lookups have to be translated back onto
+ * the real chart, or the panel reads whichever dataset happens to sit at that
+ * position in the whole figure -- for the second panel that is the first
+ * panel's parse, announced under the second panel's name.
  */
 function createPanelView(
   chart: ChartJsChart,
@@ -328,6 +334,10 @@ function createPanelView(
 ): ChartJsChart {
   const scales = chart.options.scales ?? {};
   const panelScale = scales[panel.scaleId];
+  // The `?? local` mirrors `layerDatasets`: an index outside the partition
+  // cannot happen while extractors walk only the datasets they were handed,
+  // and falling back beats throwing away the whole accessibility layer.
+  const globalIndex = (local: number): number => panel.datasetIndices[local] ?? local;
 
   return {
     canvas: chart.canvas,
@@ -338,7 +348,10 @@ function createPanelView(
       scales: panelScale ? { ...scales, [axisKind]: panelScale } : scales,
     },
     scales: chart.scales,
-    getDatasetMeta: datasetIndex => chart.getDatasetMeta(datasetIndex),
+    getDatasetMeta: local => chart.getDatasetMeta(globalIndex(local)),
+    ...(chart.isDatasetVisible
+      ? { isDatasetVisible: (local: number) => chart.isDatasetVisible?.(globalIndex(local)) !== false }
+      : {}),
     setActiveElements: elements => chart.setActiveElements(elements),
     tooltip: chart.tooltip,
     update: mode => chart.update(mode),

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -894,6 +894,53 @@ function extractLayers(
 const PARALLEL_VARIABLE_AXIS = 'Variable';
 const PARALLEL_VALUE_AXIS = 'Value';
 
+/** Which chart positions a parallel coordinates payload's rows and columns are. */
+export interface ParallelGrid {
+  /** The dataset drawing each emitted column, which is each drawn axis. */
+  axes: number[];
+  /** The dataset position of each emitted row, which is each observation that read. */
+  observations: number[];
+}
+
+/**
+ * The chart positions a parallel coordinates layer is emitted from.
+ *
+ * Exported because the highlight half has to walk them the same way: a pcp
+ * chart's payload is the transpose of its datasets, so its row is an
+ * observation and its column an axis -- and a table built by a different walk
+ * names a different mark from the one the payload announces (#1024). Sharing
+ * this is what keeps the two paired, as `drawnErrorBarIndices` does for the
+ * interval charts.
+ *
+ * @param chart - The Chart.js chart
+ * @returns The datasets drawn as axes, and the observations that read
+ */
+export function parallelGrid(chart: ChartJsChart): ParallelGrid {
+  // A hidden dataset is skipped: Chart.js lays out no axis for it, so it is
+  // not a column of the drawn chart.
+  const axes = chart.data.datasets
+    .map((_, index) => index)
+    .filter(index => chart.isDatasetVisible?.(index) !== false);
+
+  // How far the widest axis reaches, which is how many observations the
+  // chart draws. There is one emptiness check for this reading and it is
+  // the caller's: a chart with no datasets, one whose datasets are all
+  // hidden, and one whose datasets carry no values all arrive at no rows
+  // here, and each is declined by finding none.
+  const width = axes.reduce(
+    (widest, index) => Math.max(widest, chart.data.datasets[index].data.length),
+    0,
+  );
+
+  const observations: number[] = [];
+  for (let row = 0; row < width; row++) {
+    if (axes.some(index => toFiniteNumber(chart.data.datasets[index].data[row]) !== null))
+      observations.push(row);
+  }
+
+  return { axes, observations };
+}
+
 /**
  * Reads a `chartjs-chart-pcp` chart as the parallel coordinates it draws.
  *
@@ -934,34 +981,18 @@ function extractParallelLayers(
   chart: ChartJsChart,
   pluginOptions?: MaidrPluginOptions,
 ): MaidrLayer[] {
-  const axes = chart.data.datasets
-    .map((dataset, index) => ({ dataset, index }))
-    .filter(({ index }) => chart.isDatasetVisible?.(index) !== false);
-
-  // How far the widest axis reaches, which is how many observations the
-  // chart draws. There is one emptiness check for this reading and it is the
-  // one below: a chart with no datasets, one whose datasets are all hidden,
-  // and one whose datasets carry no values all arrive at no rows here, and
-  // each is declined by finding none.
-  const observations = axes.reduce(
-    (widest, { dataset }) => Math.max(widest, dataset.data.length),
-    0,
-  );
-
+  const { axes, observations } = parallelGrid(chart);
   const labels = chart.data.labels ?? [];
-  const data: LinePoint[][] = [];
-  for (let row = 0; row < observations; row++) {
+  const data: LinePoint[][] = observations.map((row) => {
     const name = labels[row];
-    const points: LinePoint[] = axes.map(({ dataset, index }) => ({
-      x: parallelAxisName(chart, dataset, index),
+    return axes.map(index => ({
+      x: parallelAxisName(chart, chart.data.datasets[index], index),
       // `null` rather than omitted: the axis is drawn and the cursor reaches
       // it, so the observation has a position there and no reading.
-      y: toFiniteNumber(dataset.data[row]),
+      y: toFiniteNumber(chart.data.datasets[index].data[row]),
       ...(name === undefined ? {} : { z: String(name) }),
     }));
-    if (points.some(point => point.y !== null))
-      data.push(points);
-  }
+  });
 
   if (data.length === 0)
     return [];
@@ -2805,6 +2836,69 @@ function extractErrorBarLayers(
 // Boxplot chart extraction (chartjs-chart-boxplot plugin)
 // ---------------------------------------------------------------------------
 
+/** One mark of a distribution chart, and the parse it was read from. */
+export interface DistributionCell {
+  /** The dataset that drew it. */
+  datasetIndex: number;
+  /** Its position within that dataset, which is its Chart.js element index. */
+  index: number;
+  /** The plugin's parse of it. */
+  value: ChartJsParsedValue;
+}
+
+/** Every dataset of a chart, in order. */
+function allDatasetIndices(chart: ChartJsChart): number[] {
+  return chart.data.datasets.map((_, index) => index);
+}
+
+/**
+ * The marks a distribution chart drew, dataset by dataset.
+ *
+ * Exported because the highlight half has to walk them the same way: a box
+ * plot's MAIDR row is the box, and only a walk of the same parses in the same
+ * order says which dataset and which element that box is (#1024).
+ *
+ * @param chart - The Chart.js chart
+ * @param datasetIndices - The datasets backing the layer, in its row order
+ * @param drawn - Which parses count as a mark
+ * @returns One cell per mark
+ */
+function drawnDistributionCells(
+  chart: ChartJsChart,
+  datasetIndices: number[],
+  drawn: (value: ChartJsParsedValue) => boolean,
+): DistributionCell[] {
+  const cells: DistributionCell[] = [];
+  for (const datasetIndex of datasetIndices) {
+    const parsed = chart.getDatasetMeta(datasetIndex)?._parsed ?? [];
+    parsed.forEach((value, index) => {
+      if (value && drawn(value))
+        cells.push({ datasetIndex, index, value });
+    });
+  }
+  return cells;
+}
+
+/** The boxes a box plot or violin drew, one per five-number summary. */
+export function drawnBoxCells(
+  chart: ChartJsChart,
+  datasetIndices: number[],
+): DistributionCell[] {
+  return drawnDistributionCells(chart, datasetIndices, value => value.median !== undefined);
+}
+
+/** The violins whose parse carries a density curve, which is what the kde layer holds. */
+export function drawnViolinCurveCells(
+  chart: ChartJsChart,
+  datasetIndices: number[],
+): DistributionCell[] {
+  return drawnDistributionCells(
+    chart,
+    datasetIndices,
+    value => (value.coords?.length ?? 0) > 0,
+  );
+}
+
 /**
  * The five-number summaries a distribution chart drew, one per box.
  *
@@ -2828,31 +2922,25 @@ function extractBoxSummaries(chart: ChartJsChart): BoxPoint[] {
   const labels = chart.data.labels ?? [];
   const boxes: BoxPoint[] = [];
 
-  for (let d = 0; d < chart.data.datasets.length; d++) {
-    const dataset = chart.data.datasets[d];
-    const parsed = chart.getDatasetMeta(d)?._parsed ?? [];
+  for (const { datasetIndex, index: i, value } of drawnBoxCells(chart, allDatasetIndices(chart))) {
+    const dataset = chart.data.datasets[datasetIndex];
+    const outliers = value.outliers ?? [];
+    const min = value.whiskerMin ?? value.min ?? 0;
+    const max = value.whiskerMax ?? value.max ?? 0;
 
-    for (let i = 0; i < parsed.length; i++) {
-      const value = parsed[i];
-      if (value?.median === undefined)
-        continue;
-
-      const outliers = value.outliers ?? [];
-      const min = value.whiskerMin ?? value.min ?? 0;
-      const max = value.whiskerMax ?? value.max ?? 0;
-
-      boxes.push({
-        z: String(labels[i] ?? dataset.label ?? `Box ${i + 1}`),
-        lowerOutliers: outliers.filter(v => v < min),
-        min,
-        q1: value.q1 ?? 0,
-        q2: value.median,
-        q3: value.q3 ?? 0,
-        max,
-        upperOutliers: outliers.filter(v => v > max),
-        ...(value.mean !== undefined ? { mean: value.mean } : {}),
-      });
-    }
+    boxes.push({
+      z: String(labels[i] ?? dataset.label ?? `Box ${i + 1}`),
+      lowerOutliers: outliers.filter(v => v < min),
+      min,
+      q1: value.q1 ?? 0,
+      // `drawnBoxCells` has already accepted the summary; this is the
+      // narrowing rather than a second test of it.
+      q2: value.median as number,
+      q3: value.q3 ?? 0,
+      max,
+      upperOutliers: outliers.filter(v => v > max),
+      ...(value.mean !== undefined ? { mean: value.mean } : {}),
+    });
   }
 
   return boxes;
@@ -2930,20 +3018,15 @@ function extractViolinLayers(
 
   const labels = chart.data.labels ?? [];
   const curves: ViolinKdePoint[][] = [];
-  for (let d = 0; d < chart.data.datasets.length; d++) {
-    const dataset = chart.data.datasets[d];
-    const parsed = chart.getDatasetMeta(d)?._parsed ?? [];
-    for (let i = 0; i < parsed.length; i++) {
-      const coords = parsed[i]?.coords;
-      if (!coords || coords.length === 0)
-        continue;
-      const label = String(labels[i] ?? dataset.label ?? `Violin ${i + 1}`);
-      curves.push(coords.map(coord => ({
-        x: label,
-        y: coord.v,
-        density: coord.estimate,
-      })));
-    }
+  for (const { datasetIndex, index: i, value } of drawnViolinCurveCells(chart, allDatasetIndices(chart))) {
+    const dataset = chart.data.datasets[datasetIndex];
+    const label = String(labels[i] ?? dataset.label ?? `Violin ${i + 1}`);
+    // `drawnViolinCurveCells` has already accepted the curve.
+    curves.push((value.coords ?? []).map(coord => ({
+      x: label,
+      y: coord.v,
+      density: coord.estimate,
+    })));
   }
 
   if (curves.length > 0) {

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -1944,14 +1944,23 @@ function extractLineLayers(
   // Skip gap markers (`null` / `NaN`) so they are never sonified as a 0 tone;
   // the plugin re-derives the original Chart.js indices for highlight
   // alignment, from this same walk so the two cannot disagree (#1024).
+  //
+  // A line plotted along a linear or time x scale is authored as `{x, y}`
+  // objects and carries no `labels` array, so there is nothing at `labels[i]`
+  // and the array position is not the reading -- the datum's own coordinate
+  // is. Same preference `survivalTime` makes, for the same reason. The
+  // categorical case is unaffected: a label, where there is one, still names
+  // the position.
+  const continuousX = categoryAxis(chart) === 'x' && !isCategoryScale(chart, 'x');
   const linePoints = (dataset: ChartJsDataset, dsIdx: number): LinePoint[] => {
     const points: LinePoint[] = [];
     for (const i of drawnCategoryPositions(chart, dataset.data.length)) {
-      const num = toFiniteNumber(dataset.data[i]);
+      const value = dataset.data[i];
+      const num = toFiniteNumber(value);
       if (num === null)
         continue;
       points.push({
-        x: labels[i] ?? i,
+        x: labels[i] ?? (continuousX && isPointValue(value) ? value.x : i),
         y: num,
         z: dataset.label ?? `Line ${dsIdx + 1}`,
       });
@@ -1980,7 +1989,13 @@ function extractLineLayers(
   }
 
   const axes = {
-    x: { label: getAxisLabel(chart, 'x', pluginOptions) },
+    x: {
+      label: getAxisLabel(chart, 'x', pluginOptions),
+      // A time scale parses its coordinates to epoch milliseconds, and one
+      // announced raw says nothing a reader can place -- so the axis names
+      // the rendering, as a Gantt's interval axis does.
+      ...(continuousX && isTimeScale(chart, 'x') ? { format: { type: 'date' as const } } : {}),
+    },
     y: { label: getAxisLabel(chart, 'y', pluginOptions) },
   };
 

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -10,8 +10,8 @@
 
 import type { ChoroplethPoint, GanttData, HeatmapData, MaidrLayer, TreemapPoint } from '../../type/grammar';
 import type { ChartJsActiveElement, ChartJsChart, ChartJsDataset, ChartJsDataValue } from './types';
-import { TraceType } from '../../type/grammar';
-import { drawnCategoryPositions, drawnErrorBarIndices, drawnGeoRows, isMatrixValue, isPointValue, isRangeValue, toFiniteNumber } from './extractor';
+import { Orientation, TraceType } from '../../type/grammar';
+import { drawnBoxCells, drawnCategoryPositions, drawnErrorBarIndices, drawnGeoRows, drawnViolinCurveCells, isMatrixValue, isPointValue, isRangeValue, parallelGrid, toFiniteNumber } from './extractor';
 
 /**
  * Figure-unique layer id → original Chart.js dataset indices backing that
@@ -58,6 +58,24 @@ export interface TargetMaps {
    * which would drift from the model silently.
    */
   treemapIndices: Map<string, Map<string, number>>;
+  /**
+   * Box / violin: `distributionTargets[layerId][i]` is the element drawing the
+   * layer's i-th distribution, in the payload's own order.
+   *
+   * A box is one mark however many sections a reader walks along it, so the
+   * table is flat: the column of the pair says which section, which is a
+   * reading of the box and not a mark of its own.
+   */
+  distributionTargets: Map<string, ChartJsActiveElement[]>;
+  /**
+   * Parallel coordinates: `parallelTargets[layerId][row][col]` is the element
+   * drawing observation `row` on axis `col`.
+   *
+   * A pcp payload is the transpose of the chart's datasets -- one dataset is
+   * one axis -- so both halves of the pair have to be translated, and neither
+   * is the other's index space.
+   */
+  parallelTargets: Map<string, ChartJsActiveElement[][]>;
 }
 
 /**
@@ -270,6 +288,8 @@ export function computeTargetMaps(
   const heatmapIndices = new Map<string, Map<string, number>>();
   const ganttTargets = new Map<string, ChartJsActiveElement[][]>();
   const treemapIndices = new Map<string, Map<string, number>>();
+  const distributionTargets = new Map<string, ChartJsActiveElement[]>();
+  const parallelTargets = new Map<string, ChartJsActiveElement[][]>();
   const datasets = chart.data.datasets;
 
   for (const layer of layers) {
@@ -435,12 +455,53 @@ export function computeTargetMaps(
           treemapIndices.set(layer.id, buildTreemapIndex(layer.data as TreemapPoint[]));
         break;
       }
+      // A box or a violin is one mark per distribution, drawn one element per
+      // parsed summary in dataset order -- which is the order the payload
+      // emits them in, so the extractor's own walk is shared rather than
+      // repeated here (#1024). The kde layer is the same list filtered to the
+      // violins that carry a curve, which is how it was emitted.
+      case TraceType.BOX:
+      case TraceType.VIOLIN_BOX:
+      case TraceType.VIOLIN_KDE: {
+        const dsIndices = layerDatasetIndices.get(layer.id) ?? datasets.map((_, i) => i);
+        const cells = layer.type === TraceType.VIOLIN_KDE
+          ? drawnViolinCurveCells(chart, dsIndices)
+          : drawnBoxCells(chart, dsIndices);
+        distributionTargets.set(
+          layer.id,
+          cells.map(cell => ({ datasetIndex: cell.datasetIndex, index: cell.index })),
+        );
+        break;
+      }
+      // Parallel coordinates: the payload is the transpose of the datasets,
+      // so a row is an observation and a column an axis. Chart.js builds one
+      // element per data entry per dataset, so the element drawing
+      // observation `o` on axis `a` is `{datasetIndex: a, index: o}` -- and
+      // both halves come from the extractor's own walk, hidden axes and
+      // empty observations included.
+      case TraceType.PARALLEL: {
+        const grid = parallelGrid(chart);
+        parallelTargets.set(
+          layer.id,
+          grid.observations.map(observation =>
+            grid.axes.map(datasetIndex => ({ datasetIndex, index: observation }))),
+        );
+        break;
+      }
       default:
         break;
     }
   }
 
-  return { pointTargets, barLineIndices, heatmapIndices, ganttTargets, treemapIndices };
+  return {
+    pointTargets,
+    barLineIndices,
+    heatmapIndices,
+    ganttTargets,
+    treemapIndices,
+    distributionTargets,
+    parallelTargets,
+  };
 }
 
 /**
@@ -531,6 +592,35 @@ export function resolveActiveTargets(
     if (index === undefined)
       return [];
     return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index }];
+  }
+
+  // Box / violin: MAIDR row = the distribution, col = the section along it
+  // (or the sample along the density curve), which is a reading of the box
+  // and not a mark of its own -- the same shape the candlestick branch above
+  // has for its OHLC field.
+  //
+  // A sideways chart is read bottom-up, and `BoxTrace`, `ViolinBoxTrace` and
+  // `ViolinTrace` all reverse the payload to do it, so the row is
+  // un-reversed before the lookup.
+  if (layer.type === TraceType.BOX
+    || layer.type === TraceType.VIOLIN_BOX
+    || layer.type === TraceType.VIOLIN_KDE) {
+    const targets = maps.distributionTargets.get(layer.id);
+    if (!targets)
+      return [];
+    const index = layer.orientation === Orientation.HORIZONTAL
+      ? targets.length - 1 - row
+      : row;
+    const target = targets[index];
+    return target ? [target] : [];
+  }
+
+  // Parallel coordinates: MAIDR row = the observation, col = the axis. Both
+  // halves are translated -- the payload is the transpose of the datasets --
+  // so neither can stand in for a Chart.js index on its own.
+  if (layer.type === TraceType.PARALLEL) {
+    const target = maps.parallelTargets.get(layer.id)?.[row]?.[col];
+    return target ? [target] : [];
   }
 
   // Sankey: nothing is outlined, deliberately.

--- a/test/adapters/amcharts/candlestick.test.ts
+++ b/test/adapters/amcharts/candlestick.test.ts
@@ -34,8 +34,8 @@
 import type { AmXYSeries } from '@adapters/amcharts/types';
 import type { CandlestickPoint } from '@type/grammar';
 import { fromXYChart } from '@adapters/amcharts/adapter';
-import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
 import { classifySeriesKind } from '@adapters/amcharts/extractor';
+import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
 import { describe, expect, it } from '@jest/globals';
 import { TraceType } from '@type/grammar';
 import { fakeChart, fakeContainerEl, fakeSeries, itemOf } from './helpers';

--- a/test/adapters/amcharts/candlestick.test.ts
+++ b/test/adapters/amcharts/candlestick.test.ts
@@ -34,10 +34,16 @@
 import type { AmXYSeries } from '@adapters/amcharts/types';
 import type { CandlestickPoint } from '@type/grammar';
 import { fromXYChart } from '@adapters/amcharts/adapter';
+import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
 import { classifySeriesKind } from '@adapters/amcharts/extractor';
 import { describe, expect, it } from '@jest/globals';
 import { TraceType } from '@type/grammar';
-import { fakeChart, fakeContainerEl, fakeSeries } from './helpers';
+import { fakeChart, fakeContainerEl, fakeSeries, itemOf } from './helpers';
+
+/** The date an item sits at, in the form the payload announces it. */
+function formatDate(value: unknown): string {
+  return new Date(Number(value)).toISOString().slice(0, 10);
+}
 
 /** Three days, measured: two up and one down, so a Bear cannot hide. */
 const DAYS = [
@@ -53,7 +59,9 @@ const DAYS = [
  * @param days - The candles to draw
  * @returns The fake series
  */
-function financialSeries(className: string, days = DAYS): AmXYSeries {
+function financialSeries(className: string, days = DAYS, inversed = false): AmXYSeries {
+  const renderer = { get: (key: string) => (key === 'inversed' ? inversed : undefined) };
+  const xAxis = { get: (key: string) => (key === 'renderer' ? renderer : undefined) };
   return fakeSeries({
     className,
     name: 'ACME',
@@ -63,6 +71,7 @@ function financialSeries(className: string, days = DAYS): AmXYSeries {
       openValueYField: 'open',
       highValueYField: 'high',
       lowValueYField: 'low',
+      xAxis,
     },
     data: days.map(day => ({
       valueX: day.date,
@@ -117,6 +126,24 @@ describe('amcharts candlestick', () => {
     // amCharts keeps volume on a separate series when a chart draws one at
     // all, so a zero here would report a measurement nobody took.
     expect(candlesOf('CandlestickSeries')[0].volume).toBeUndefined();
+  });
+
+  it('reads a candlestick on an inversed x axis from the left of the screen', () => {
+    // Every other family reads `orderedDataItems` on both halves (#1037); the
+    // candlestick payload walked the raw list while its highlight walked the
+    // ordered one, so the reader heard candle A while the overlay outlined
+    // candle C (#1024).
+    const series = financialSeries('CandlestickSeries', DAYS, true);
+    const chart = fakeChart({ series: [series] });
+    const layers = fromXYChart(chart, fakeContainerEl()).subplots[0][0].layers;
+    const navMap = buildNavigationMap([{ chart, layers, groups: groupSeries(chart) }]);
+
+    const payload = (layers[0].data as CandlestickPoint[]).map(candle => candle.value);
+    const highlight = payload.map((_, col) =>
+      formatDate(itemOf(navMap.resolve(layers[0].id, 0, col)[0]).get('valueX')));
+
+    expect(payload).toEqual(['2024-01-03', '2024-01-02', '2024-01-01']);
+    expect(highlight).toEqual(payload);
   });
 
   it('skips a candle missing one of its four prices', () => {

--- a/test/adapters/amcharts/hierarchyHighlight.test.ts
+++ b/test/adapters/amcharts/hierarchyHighlight.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `Tree` and `Pack` were read as hierarchies (#1140) but never given a
+ * highlight.
+ *
+ * `classifySeriesKind` returns `'tree'` and `'pack'`, and the adapter emits
+ * them as `TraceType.TREE` and `TraceType.PACK` -- but `groupSeries` bucketed
+ * neither and `addEntryResolvers` registered a resolver for neither, so
+ * `navMap.resolve()` answered `[]` at every position and the binder's overlay
+ * cleared. Their treemap, icicle and sunburst siblings, which share the same
+ * converter and the same node walk, highlighted normally.
+ */
+import type { AmXYChart } from '@adapters/amcharts/types';
+import type { MaidrLayer } from '@type/grammar';
+import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { fakeChart, fakeHierarchySeries, itemOf } from './helpers';
+
+const CONTINENTS = {
+  category: 'Root',
+  children: [
+    { category: 'Asia', children: [{ category: 'China', value: 1425 }] },
+    { category: 'Africa', children: [{ category: 'Nigeria', value: 224 }] },
+  ],
+};
+
+/** The nav map for one standalone hierarchy series, built the way the binder does. */
+function navMapFor(className: string, type: MaidrLayer['type']): ReturnType<typeof buildNavigationMap> {
+  const series = fakeHierarchySeries('Population', CONTINENTS, className);
+  const chart = fakeChart({ series: [series] }) as unknown as AmXYChart;
+  return buildNavigationMap([{
+    chart,
+    layers: [{ id: 'nodes', type, data: [] }],
+    groups: groupSeries(chart),
+  }]);
+}
+
+describe('amCharts hierarchy highlight', () => {
+  it.each([
+    ['Tree', TraceType.TREE],
+    ['LinkedHierarchy', TraceType.TREE],
+    ['Pack', TraceType.PACK],
+  ] as const)('resolves a %s node by [depth, index within depth]', (className, type) => {
+    const navMap = navMapFor(className, type);
+
+    expect(itemOf(navMap.resolve('nodes', 0, 1)[0]).get('category')).toBe('Africa');
+    expect(itemOf(navMap.resolve('nodes', 1, 1)[0]).get('category')).toBe('Nigeria');
+  });
+
+  it.each([
+    ['Tree', TraceType.TREE],
+    ['Pack', TraceType.PACK],
+  ] as const)('measures a %s node as a rectangle, the way a treemap block is', (className, type) => {
+    const navMap = navMapFor(className, type);
+
+    expect(navMap.resolve('nodes', 0, 0)[0].kind).toBe('column');
+  });
+
+  it('outlines nothing below a tree\'s deepest level', () => {
+    const navMap = navMapFor('Tree', TraceType.TREE);
+
+    expect(navMap.resolve('nodes', 2, 0)).toEqual([]);
+  });
+
+  it('buckets a tree and a pack alongside the treemap they share a walk with', () => {
+    const tree = fakeHierarchySeries('T', CONTINENTS, 'Tree');
+    const pack = fakeHierarchySeries('P', CONTINENTS, 'Pack');
+    const chart = fakeChart({ series: [tree, pack] }) as unknown as AmXYChart;
+
+    const groups = groupSeries(chart);
+
+    expect(groups.hierarchySeriesList).toEqual([tree, pack]);
+  });
+});

--- a/test/adapters/amcharts/hierarchyHighlight.test.ts
+++ b/test/adapters/amcharts/hierarchyHighlight.test.ts
@@ -24,6 +24,15 @@ const CONTINENTS = {
   ],
 };
 
+/**
+ * One row of a hierarchy table: the amCharts class name and the trace type the
+ * adapter emits for it.
+ *
+ * Named rather than inferred because `as const` would make the rows readonly,
+ * which `it.each`'s callback signature does not accept.
+ */
+type HierarchyCase = [className: string, type: MaidrLayer['type']];
+
 /** The nav map for one standalone hierarchy series, built the way the binder does. */
 function navMapFor(className: string, type: MaidrLayer['type']): ReturnType<typeof buildNavigationMap> {
   const series = fakeHierarchySeries('Population', CONTINENTS, className);
@@ -36,21 +45,21 @@ function navMapFor(className: string, type: MaidrLayer['type']): ReturnType<type
 }
 
 describe('amCharts hierarchy highlight', () => {
-  it.each([
+  it.each<HierarchyCase>([
     ['Tree', TraceType.TREE],
     ['LinkedHierarchy', TraceType.TREE],
     ['Pack', TraceType.PACK],
-  ] as const)('resolves a %s node by [depth, index within depth]', (className, type) => {
+  ])('resolves a %s node by [depth, index within depth]', (className, type) => {
     const navMap = navMapFor(className, type);
 
     expect(itemOf(navMap.resolve('nodes', 0, 1)[0]).get('category')).toBe('Africa');
     expect(itemOf(navMap.resolve('nodes', 1, 1)[0]).get('category')).toBe('Nigeria');
   });
 
-  it.each([
+  it.each<HierarchyCase>([
     ['Tree', TraceType.TREE],
     ['Pack', TraceType.PACK],
-  ] as const)('measures a %s node as a rectangle, the way a treemap block is', (className, type) => {
+  ])('measures a %s node as a rectangle, the way a treemap block is', (className, type) => {
     const navMap = navMapFor(className, type);
 
     expect(navMap.resolve('nodes', 0, 0)[0].kind).toBe('column');

--- a/test/adapters/chartjs/distributionHighlight.test.ts
+++ b/test/adapters/chartjs/distributionHighlight.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Box, violin and parallel coordinates had no branch in the highlight
+ * resolver, so they fell through to the bar/line default -- which reads the
+ * MAIDR row as a dataset and the column as an element index.
+ *
+ * Neither is what those traces mean by the pair. A box plot's row is the box
+ * and its column the section along it, so moving across the sections of one
+ * box outlined a different box each time; a parallel plot's row is the
+ * observation and its column the axis, which is the transpose of the elements
+ * that draw them. With several datasets in the chart both resolve to indices
+ * that exist, so a mark the reader was never told about lights up -- the
+ * failure the SANKEY and NETWORK branches decline in order to avoid (#814).
+ */
+import type { ChartJsActiveElement, ChartJsChart, ChartJsDataValue, ChartJsParsedValue } from '@adapters/chartjs/types';
+import type { MaidrLayer } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { describe, expect, it } from '@jest/globals';
+
+/** The parse the boxplot plugin leaves for one box. */
+function boxParse(median: number): ChartJsParsedValue {
+  return {
+    x: 0,
+    outliers: [],
+    whiskerMin: median - 4,
+    whiskerMax: median + 4,
+    min: median - 4,
+    max: median + 4,
+    median,
+    q1: median - 2,
+    q3: median + 2,
+    y: median,
+  };
+}
+
+/** The same parse with the density curve a violin adds. */
+function violinParse(median: number): ChartJsParsedValue {
+  return {
+    ...boxParse(median),
+    coords: [
+      { v: median - 4, estimate: 0.1 },
+      { v: median, estimate: 0.4 },
+      { v: median + 4, estimate: 0.1 },
+    ],
+  };
+}
+
+/** A distribution chart as the boxplot plugin leaves it after `update()`. */
+function distributionChart(
+  type: 'boxplot' | 'violin',
+  parsed: ChartJsParsedValue[][],
+  options: { labels?: string[]; indexAxis?: 'x' | 'y' } = {},
+): ChartJsChart {
+  const { labels = ['A', 'B', 'C'], indexAxis } = options;
+  const datasets = parsed.map((one, index) => ({
+    label: `S${index + 1}`,
+    data: one.map(() => [] as unknown as ChartJsDataValue),
+  }));
+
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: { labels, datasets },
+    options: { plugins: {}, ...(indexAxis ? { indexAxis } : {}), scales: { x: {}, y: {} } },
+    config: { type },
+    getDatasetMeta: (index: number) => ({ data: [], type, _parsed: parsed[index] ?? [] }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** A parallel coordinates chart: one dataset per axis, one entry per observation. */
+function pcpChart(axes: { label: string; data: ChartJsDataValue[]; hidden?: boolean }[]): ChartJsChart {
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: {
+      labels: ['car A', 'car B', 'car C'],
+      datasets: axes.map(axis => ({ label: axis.label, data: axis.data })),
+    },
+    options: { plugins: {}, scales: { x: { type: 'pcp' } } },
+    config: { type: 'pcp' },
+    isDatasetVisible: (index: number) => axes[index]?.hidden !== true,
+    getDatasetMeta: (index: number) => ({
+      data: [],
+      type: 'pcp',
+      vScale: { id: axes[index]?.label },
+    }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** Extract a chart and precompute everything the plugin's nav bridge uses. */
+function setup(chart: ChartJsChart): {
+  layers: MaidrLayer[];
+  resolve: (layerId: string, row: number, col: number) => ChartJsActiveElement[];
+} {
+  const { maidr, layerDatasetIndices } = extractChartData(chart);
+  const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+  const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+  return {
+    layers,
+    resolve: (layerId, row, col) =>
+      resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, row, col),
+  };
+}
+
+describe('chart.js distribution highlight resolution', () => {
+  it('keeps one box outlined while the reader walks its sections', () => {
+    const chart = distributionChart('boxplot', [[boxParse(10), boxParse(20), boxParse(30)]]);
+
+    const { resolve } = setup(chart);
+
+    // Row is the box, col the section along it -- which does not change the
+    // mark, the way a candlestick's OHLC field does not.
+    expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+    expect(resolve('0', 0, 3)).toEqual([{ datasetIndex: 0, index: 0 }]);
+    expect(resolve('0', 2, 1)).toEqual([{ datasetIndex: 0, index: 2 }]);
+  });
+
+  it('routes a grouped box plot\'s later boxes to the dataset that drew them', () => {
+    const chart = distributionChart('boxplot', [
+      [boxParse(10), boxParse(20)],
+      [boxParse(30), boxParse(40)],
+    ]);
+
+    const { resolve } = setup(chart);
+
+    expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+    expect(resolve('0', 2, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+    expect(resolve('0', 3, 0)).toEqual([{ datasetIndex: 1, index: 1 }]);
+  });
+
+  it('un-reverses a horizontal box plot, whose model reads bottom-up', () => {
+    const chart = distributionChart(
+      'boxplot',
+      [[boxParse(10), boxParse(20), boxParse(30)]],
+      { indexAxis: 'y' },
+    );
+
+    const { resolve } = setup(chart);
+
+    expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    expect(resolve('0', 2, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+  });
+
+  it('outlines nothing for a box the chart never drew', () => {
+    const chart = distributionChart('boxplot', [[boxParse(10)]]);
+
+    const { resolve } = setup(chart);
+
+    expect(resolve('0', 5, 0)).toEqual([]);
+  });
+
+  it('outlines the violin itself from both of a violin chart\'s layers', () => {
+    const chart = distributionChart('violin', [[violinParse(10), violinParse(20)]]);
+
+    const { layers, resolve } = setup(chart);
+
+    expect(layers.map(layer => layer.type)).toEqual(['violin_box', 'violin_kde']);
+    expect(resolve('0', 1, 0)).toEqual([{ datasetIndex: 0, index: 1 }]);
+    // The kde layer's col walks the density curve, which is one violin's
+    // shape and not a mark of its own.
+    expect(resolve('1', 1, 2)).toEqual([{ datasetIndex: 0, index: 1 }]);
+  });
+
+  it('reads a parallel plot\'s row as the observation and its col as the axis', () => {
+    const chart = pcpChart([
+      { label: 'mpg', data: [21, 15, 33] },
+      { label: 'hp', data: [110, 245, 65] },
+      { label: 'wt', data: [2.6, 3.6, 1.8] },
+    ]);
+
+    const { resolve } = setup(chart);
+
+    // Observation 2 on axis 0 is drawn by dataset 0's third element, not by
+    // dataset 2's first.
+    expect(resolve('0', 2, 0)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    expect(resolve('0', 0, 2)).toEqual([{ datasetIndex: 2, index: 0 }]);
+  });
+
+  it('skips a hidden axis when routing a parallel plot\'s columns', () => {
+    const chart = pcpChart([
+      { label: 'mpg', data: [21, 15, 33], hidden: true },
+      { label: 'hp', data: [110, 245, 65] },
+      { label: 'wt', data: [2.6, 3.6, 1.8] },
+    ]);
+
+    const { resolve } = setup(chart);
+
+    expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+    expect(resolve('0', 0, 1)).toEqual([{ datasetIndex: 2, index: 0 }]);
+  });
+
+  it('keeps a parallel plot\'s rows on the observations that read', () => {
+    // An observation with no reading on any axis is dropped from the payload,
+    // so the MAIDR row is not the dataset position.
+    const chart = pcpChart([
+      { label: 'mpg', data: [21, null, 33] },
+      { label: 'hp', data: [110, null, 65] },
+    ]);
+
+    const { resolve } = setup(chart);
+
+    expect(resolve('0', 1, 0)).toEqual([{ datasetIndex: 0, index: 2 }]);
+  });
+});

--- a/test/adapters/chartjs/lineContinuousX.test.ts
+++ b/test/adapters/chartjs/lineContinuousX.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A line chart drawn against a linear or time x scale is authored as `{x, y}`
+ * objects with no `data.labels`, so there is no label to name a point's
+ * position with -- and the position is not the array index either. It is the
+ * datum's own coordinate, which is what the reader is looking at.
+ *
+ * `survivalTime` already makes that choice for the survival branch; the
+ * general line/area/step path had to make it too.
+ */
+import type { ChartJsChart, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { describe, expect, it } from '@jest/globals';
+
+/** A line chart as Chart.js leaves it after `update()`. */
+function lineChart(
+  datasets: Partial<ChartJsDataset>[],
+  options: ChartJsOptions = {},
+  labels?: (string | number)[],
+): ChartJsChart {
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: {
+      ...(labels ? { labels } : {}),
+      datasets: datasets as ChartJsDataset[],
+    },
+    options,
+    config: { type: 'line' },
+    getDatasetMeta: () => ({ data: [], type: 'line' }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** The chart's layers. */
+function layersOf(chart: ChartJsChart): MaidrLayer[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers;
+}
+
+describe('chart.js line charts on a continuous x scale', () => {
+  it('announces the datum\'s own x rather than its array position', () => {
+    const chart = lineChart(
+      [{ label: 'S', data: [{ x: 2020, y: 5 }, { x: 2021, y: 7 }] }],
+      { scales: { x: { type: 'linear' } } },
+    );
+
+    const points = layersOf(chart)[0].data as LinePoint[][];
+
+    expect(points[0].map(point => point.x)).toEqual([2020, 2021]);
+  });
+
+  it('keeps naming a category chart\'s points by their label', () => {
+    const chart = lineChart(
+      [{ label: 'S', data: [5, 7] }],
+      { scales: { x: {} } },
+      ['Jan', 'Feb'],
+    );
+
+    const points = layersOf(chart)[0].data as LinePoint[][];
+
+    expect(points[0].map(point => point.x)).toEqual(['Jan', 'Feb']);
+  });
+
+  it('carries a date format when the continuous x scale plots instants', () => {
+    const chart = lineChart(
+      [{ label: 'S', data: [{ x: 1704067200000, y: 5 }, { x: 1704153600000, y: 7 }] }],
+      { scales: { x: { type: 'time' } } },
+    );
+
+    const layer = layersOf(chart)[0];
+
+    expect((layer.data as LinePoint[][])[0].map(point => point.x))
+      .toEqual([1704067200000, 1704153600000]);
+    expect(layer.axes?.x?.format).toEqual({ type: 'date' });
+  });
+
+  it('reads a stepped series on a linear scale the same way', () => {
+    const chart = lineChart(
+      [{ label: 'S', data: [{ x: 10, y: 1 }, { x: 20, y: 2 }], stepped: 'after' }],
+      { scales: { x: { type: 'linear' } } },
+    );
+
+    const points = layersOf(chart)[0].data as LinePoint[][];
+
+    expect(points[0].map(point => point.x)).toEqual([10, 20]);
+  });
+
+  it('leaves a horizontal line chart naming its categories', () => {
+    // `indexAxis: 'y'` puts the categories on y, so a point's `x` is the
+    // measurement, not a position to announce.
+    const chart = lineChart(
+      [{ label: 'S', data: [5, 7] }],
+      { indexAxis: 'y', scales: { x: { type: 'linear' } } },
+      ['Jan', 'Feb'],
+    );
+
+    const points = layersOf(chart)[0].data as LinePoint[][];
+
+    expect(points[0].map(point => point.x)).toEqual(['Jan', 'Feb']);
+  });
+});

--- a/test/adapters/chartjs/panelDatasetMeta.test.ts
+++ b/test/adapters/chartjs/panelDatasetMeta.test.ts
@@ -1,0 +1,75 @@
+/**
+ * A panel view restricts `data.datasets` to the panel's partition, so every
+ * extractor that walks it counts from zero. The metas it asks for have to be
+ * translated back: `getDatasetMeta(0)` inside the second panel means "the
+ * first dataset of THIS panel", not "the first dataset of the chart".
+ *
+ * Every meta-reading extractor (error bars, box, violin, geo, graph, pcp)
+ * loops the panel-local index straight into `chart.getDatasetMeta(d)`, so
+ * without the translation the lower panel reads the upper panel's parse and
+ * announces numbers that belong to a different subplot.
+ */
+import type { ChartJsChart, ChartJsDataset, ChartJsParsedValue } from '@adapters/chartjs/types';
+import type { ErrorBarPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { describe, expect, it } from '@jest/globals';
+
+/** Two error-bar datasets, one per stacked y panel. */
+function twoPanelErrorBarChart(parsed: ChartJsParsedValue[][]): ChartJsChart {
+  const datasets = [
+    { label: 'Top', data: parsed[0].map(() => 0) },
+    { label: 'Bottom', data: parsed[1].map(() => 0), yAxisID: 'y2' },
+  ] as unknown as ChartJsDataset[];
+
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: { labels: ['A'], datasets },
+    options: {
+      plugins: {},
+      scales: {
+        y: { stack: 'panels', title: { text: 'Top' } },
+        y2: { stack: 'panels', title: { text: 'Bottom' } },
+        x: { title: { text: 'Category' } },
+      },
+    },
+    config: { type: 'barWithErrorBars' },
+    getDatasetMeta: (index: number) => ({
+      data: [],
+      type: 'barWithErrorBars',
+      _parsed: parsed[index] ?? [],
+    }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+describe('chart.js stacked panel dataset metas', () => {
+  it('reads each panel from its own dataset meta rather than the first panel\'s', () => {
+    const chart = twoPanelErrorBarChart([
+      [{ x: 0, y: 10, yMin: 8, yMax: 12 }],
+      [{ x: 0, y: 99, yMin: 90, yMax: 105 }],
+    ]);
+
+    const { maidr } = extractChartData(chart);
+
+    const panels = maidr.subplots.flat().map(
+      subplot => subplot.layers[0].data as ErrorBarPoint[],
+    );
+    expect(panels).toHaveLength(2);
+    expect(panels.map(points => points.map(point => point.y)).flat().sort())
+      .toEqual([10, 99]);
+  });
+
+  it('keeps a single-panel chart reading its metas unchanged', () => {
+    const chart = twoPanelErrorBarChart([
+      [{ x: 0, y: 10, yMin: 8, yMax: 12 }],
+      [{ x: 0, y: 99, yMin: 90, yMax: 105 }],
+    ]);
+    chart.options.scales = { y: { title: { text: 'Response' } }, x: {} };
+    (chart.data.datasets[1] as ChartJsDataset).yAxisID = undefined;
+
+    const { maidr } = extractChartData(chart);
+
+    const series = maidr.subplots[0][0].layers[0].data as ErrorBarPoint[][];
+    expect(series.map(points => points[0].y)).toEqual([10, 99]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Five defects across the Chart.js and amCharts adapters, found in a codebase audit. Every one was reproduced with a test that failed on the unfixed code, with the exact wrong values predicted.

Three of them silently point the reader at the wrong mark. A box, violin or parallel layer had no target map at all, so the generic fallback outlined a neighbouring element or nothing. A tree or pack hierarchy had no navigation resolver, so `navMap.resolve()` answered empty at every position and the overlay simply cleared. An amCharts candlestick on an inversed x axis emitted its payload in one order and its highlights in another.

## Related Issues

None.

## Changes Made

- **chartjs**: an axis-stacked panel view translates panel-local dataset indices back to the chart before calling `chart.getDatasetMeta`.
- **chartjs**: a line, area, step or bump layer on a linear or time x scale announces the datum's own x instead of its array index. A time scale now carries `format: {type: 'date'}`. Labels still win wherever they exist, so categorical charts are untouched.
- **chartjs**: box, violin and parallel layers resolve their highlight by their own pair rather than through the generic fallback.
- **amcharts**: tree and pack hierarchies get the resolver their treemap, icicle and sunburst siblings already had.
- **amcharts**: a candlestick payload reverses on an inversed x axis, matching its highlight.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**New exported API** in `src/adapters/chartjs/extractor.ts`: `parallelGrid` / `ParallelGrid`, `drawnBoxCells`, `drawnViolinCurveCells` and `DistributionCell`, all shared with `highlightTargets.ts` so the payload walk and the highlight table cannot drift apart. That is the pattern `drawnErrorBarIndices` already set. `TargetMaps` gains `distributionTargets` and `parallelTargets`, so any external caller building a `TargetMaps` literal would need them.

The parallel-coordinates mapping rests on Chart.js's invariant that a controller builds one element per data entry. `chartjs-chart-pcp` is not in `node_modules`, so it could not be exercised directly — worth a reviewer's eye.

No existing test was changed to accommodate a fix. The only existing file edited is the amCharts candlestick suite, where the shared fixture gained an optional inversed x axis and one new case; all seven pre-existing cases pass unchanged.

Several findings from the same sweep are deliberately **not** here and remain open: Chart.js heatmap holes emitted as `0` rather than `null` (confirmed with a reproduction, one line in `extractHeatmapLayers`), the same shape in the amCharts extractor, grouped box and violin naming, re-extraction after a data update, the leftover Chart.js active element on subplot exit, and a full `chart.update('none')` per navigation event. They belong in their own change.

`npm run lint:fix`, `npm run type-check` and `npm test` (6653 unit across 488 suites, 170 ESM across 12) all pass on this branch with `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_