### PR TITLE
test(command): pin the single-violin KDE position announcement

### DIFF
--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -828,6 +828,56 @@ describe('AnnouncePositionCommand on a multi-violin KDE', () => {
   });
 });
 
+/**
+ * A violin KDE trace with a single violin of five density samples.
+ *
+ * @param sample Zero-based index of the density sample the cursor is on
+ * @param orientation Which way the violin is laid out
+ * @returns The trace's state with the cursor there
+ */
+function singleViolinKdeTraceState(
+  sample: number,
+  orientation = Orientation.VERTICAL,
+): PlotState {
+  const trace = TraceFactory.create({
+    id: 'position-single-violin-kde',
+    type: TraceType.VIOLIN_KDE,
+    title: 'Violin',
+    orientation,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data: [[1, 2, 3, 4, 5].map(y => ({ x: 'A', y, density: 0.1 * y }))] as ViolinKdePoint[][],
+  });
+  trace.moveToIndex(0, sample);
+
+  return trace.state as PlotState;
+}
+
+describe('AnnouncePositionCommand on a single-violin KDE', () => {
+  /**
+   * One violin is a curve, not a set of them, so the announcement is the
+   * plain position along it and names no violin at all.
+   *
+   * Which branch it takes turns on the row count, so the frame that count is
+   * read from matters here as much as the numbers do. A vertical violin's pan
+   * reports the sample count as its rows and the violin count as its columns,
+   * and reading the position out of that answered "Violin 3 of 5, Position is
+   * 1 of 1" -- five violins where there is one, and a curve one sample long.
+   * The horizontal case passed either way, which is why it is here beside it.
+   */
+  test.each([
+    ['vertical', Orientation.VERTICAL],
+    ['horizontal', Orientation.HORIZONTAL],
+  ])('reads the position along a %s curve without naming a violin', (_name, orientation) => {
+    const { command, textViewModel } = createCommand(
+      singleViolinKdeTraceState(2, orientation),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Position is 3 of 5');
+  });
+});
+
 describe('AnnouncePositionCommand at the multi-panel lobby', () => {
   function figureState(index: number, size: number): PlotState {
     return { type: 'figure', empty: false, index, size } as unknown as PlotState;


### PR DESCRIPTION
# Pull Request

## Description

The review of #1223 noticed that the fix there also corrected a case nothing covered, and asked for a test. This is that test.

#1223 stopped the violin KDE position announcement reading the reader's position out of the stereo panning. A vertical violin's pan reports the sample count as its rows and the violin count as its columns, and the row count is what decides whether the announcement names a violin at all. So a single violin of five density samples took the multi-violin branch and announced:

```
Violin 3 of 5, Position is 1 of 1
```

Five violins where there is one, and a curve one sample long. One violin is a curve, not a set of them, so the announcement should be the plain position along it and should name no violin.

I confirmed this rather than reasoning it: with the `VIOLIN_KDE` entry removed from `GRID_FRAME_TRACES`, the new vertical case fails with exactly the string above, and passes with it restored. The horizontal case passes either way, because a horizontal violin's pan already agrees with its navigation frame, and it sits beside the vertical one to say so.

## Related Issues

Follows up the review on #1223.

## Changes Made

One test file. No source change — the behaviour is already correct on `main`; this pins it so the two frames cannot be conflated again without a red suite.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint:fix` and `npm run type-check` pass. `test/command/announce-position.test.ts` goes from 43 to 45 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_