### PR TITLE
fix(highlight): read a line's stroke width from the element that has one

### DIFF
--- a/src/service/highContrast.ts
+++ b/src/service/highContrast.ts
@@ -95,6 +95,11 @@ export class HighContrastService implements Disposable {
   // Track previous high contrast mode state to detect changes
   private previousHighContrastMode: boolean = false;
 
+  // Whether high contrast colors are currently painted onto the DOM. Distinct
+  // from the setting: the effect is suspended on blur while the setting stays
+  // on, so only this answers "is the DOM showing our colors right now?".
+  private highContrastApplied: boolean = false;
+
   // Shared canvas context for color parsing (reused to avoid GC pressure)
   private sharedCanvasCtx: CanvasRenderingContext2D | null = null;
 
@@ -184,6 +189,15 @@ export class HighContrastService implements Disposable {
    * @param figure - The replacement figure
    */
   public setFigure(figure: Figure): void {
+    // A live update can arrive while high contrast is painted, and the capture
+    // below reads the colors the DOM is showing. Restore first, or the
+    // snapshot records this service's own output as the chart's originals and
+    // turning high contrast off never gets the page back.
+    const wasApplied = this.highContrastApplied;
+    if (wasApplied) {
+      this.restoreOriginalColors();
+    }
+
     this.figure = figure;
     this.originalColorInfo = null;
     // Invalidate the trace-element cache so getAllTraceElements() rebuilds from
@@ -384,6 +398,8 @@ export class HighContrastService implements Disposable {
         this.applyPatternsToElements(highContrastElInfo);
       }
     }
+
+    this.highContrastApplied = true;
   }
 
   /**
@@ -439,6 +455,8 @@ export class HighContrastService implements Disposable {
       this.patternService.dispose();
       this.patternService = null;
     }
+
+    this.highContrastApplied = false;
   }
 
   // ========== Helper Methods ==========

--- a/src/service/highContrast.ts
+++ b/src/service/highContrast.ts
@@ -339,8 +339,13 @@ export class HighContrastService implements Disposable {
     document.body.style.backgroundColor = this.highContrastDarkColor;
     document.body.style.color = this.highContrastLightColor;
 
+    // Whether an element sits under a text group is asked once per captured
+    // fill or stroke below and again for the glow filter. One memo per apply
+    // keeps the ancestor walk to one per element.
+    const textDescendants = new Map<Element, boolean>();
+
     // Get high contrast colors for all elements
-    const highContrastElInfo = this.getHighContrastColors();
+    const highContrastElInfo = this.getHighContrastColors(textDescendants);
 
     // Apply high contrast colors to elements
     for (const item of highContrastElInfo) {
@@ -361,7 +366,7 @@ export class HighContrastService implements Disposable {
 
     // Apply shadow to text elements
     this.originalColorInfo?.forEach((item) => {
-      if (this.hasParentWithStringInID(item.element, 'text')) {
+      if (this.isTextDescendant(item.element, textDescendants)) {
         item.element.setAttribute('filter', 'url(#glow-shadow)');
       }
     });
@@ -573,7 +578,9 @@ export class HighContrastService implements Disposable {
     return originalColorInfo;
   }
 
-  private getHighContrastColors(): ElementColorInfo[] {
+  private getHighContrastColors(
+    textDescendants: Map<Element, boolean>,
+  ): ElementColorInfo[] {
     const originalColorInfo = this.originalColorInfo;
     if (!originalColorInfo)
       return [];
@@ -581,12 +588,36 @@ export class HighContrastService implements Disposable {
     const spreadColors
       = this.spreadColorsAcrossLuminanceSpectrum(originalColorInfo);
 
+    // The ramp depends only on the settings, so interpolate it once here
+    // rather than per captured color: each interpolation parses two colors
+    // through the canvas and rebuilds the whole array.
+    const colorEquivalents = this.colorEquivalents;
+
     const highContrastElInfo = spreadColors.map(item => ({
       ...item,
-      color: this.toColorStep(item),
+      color: this.toColorStep(item, colorEquivalents, textDescendants),
     }));
 
     return highContrastElInfo;
+  }
+
+  /**
+   * Memoised form of the "is this element inside a text group?" question.
+   * The answer is fixed for the duration of one apply, and the walk is asked
+   * for the same element several times over.
+   */
+  private isTextDescendant(
+    element: Element,
+    textDescendants: Map<Element, boolean>,
+  ): boolean {
+    const cached = textDescendants.get(element);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const isText = this.hasParentWithStringInID(element, 'text');
+    textDescendants.set(element, isText);
+    return isText;
   }
 
   private hasParentWithStringInID(
@@ -676,17 +707,19 @@ export class HighContrastService implements Disposable {
     defs.appendChild(filter);
   }
 
-  private toColorStep(colorInfo: ElementColorInfo): string {
+  private toColorStep(
+    colorInfo: ElementColorInfo,
+    colorEquivalents: string[],
+    textDescendants: Map<Element, boolean>,
+  ): string {
     const value = colorInfo.color;
     if (value === 'none' || value === 'transparent') {
       return value;
     }
 
-    if (this.hasParentWithStringInID(colorInfo.element, 'text')) {
+    if (this.isTextDescendant(colorInfo.element, textDescendants)) {
       return this.highContrastLightColor;
     }
-
-    const colorEquivalents = [...this.colorEquivalents];
 
     const ctx = this.getSharedCanvasContext();
     if (!ctx)
@@ -784,10 +817,13 @@ export class HighContrastService implements Disposable {
 
     const inputRgb = hexToRgb(inputColor);
 
+    // The caller's ramp is shared across every color of one apply, so drop the
+    // background from a copy rather than from the array itself.
+    let colors = colorArray;
     if (cantBeBackground) {
-      const backgroundIndex = colorArray.indexOf(this.highContrastDarkColor);
+      const backgroundIndex = colors.indexOf(this.highContrastDarkColor);
       if (backgroundIndex !== -1) {
-        colorArray.splice(backgroundIndex, 1);
+        colors = colors.filter((_, index) => index !== backgroundIndex);
       }
     }
 
@@ -797,36 +833,36 @@ export class HighContrastService implements Disposable {
         = HighContrastConstants.RGB_MAX_VALUE * (1 - nearWhiteScale);
 
       if (inputLuminance >= nearWhiteThreshold) {
-        return colorArray[0];
+        return colors[0];
       }
 
-      let closestColor = colorArray[0];
-      let minDistance = colorDistance(inputRgb, hexToRgb(colorArray[0]));
+      let closestColor = colors[0];
+      let minDistance = colorDistance(inputRgb, hexToRgb(colors[0]));
 
-      for (let i = 1; i < colorArray.length; i++) {
-        const distance = colorDistance(inputRgb, hexToRgb(colorArray[i]));
+      for (let i = 1; i < colors.length; i++) {
+        const distance = colorDistance(inputRgb, hexToRgb(colors[i]));
         if (distance < minDistance) {
           minDistance = distance;
-          closestColor = colorArray[i];
+          closestColor = colors[i];
         }
       }
 
       return closestColor;
     } else {
-      let closestColor = colorArray[0];
-      let minDistance = colorDistance(inputRgb, hexToRgb(colorArray[0]));
+      let closestColor = colors[0];
+      let minDistance = colorDistance(inputRgb, hexToRgb(colors[0]));
 
-      for (let i = 1; i < colorArray.length; i++) {
-        const distance = colorDistance(inputRgb, hexToRgb(colorArray[i]));
+      for (let i = 1; i < colors.length; i++) {
+        const distance = colorDistance(inputRgb, hexToRgb(colors[i]));
         if (distance < minDistance) {
           minDistance = distance;
-          closestColor = colorArray[i];
+          closestColor = colors[i];
         }
       }
 
-      const index = colorArray.indexOf(closestColor);
-      const reversedIndex = colorArray.length - 1 - index;
-      return colorArray[reversedIndex];
+      const index = colors.indexOf(closestColor);
+      const reversedIndex = colors.length - 1 - index;
+      return colors[reversedIndex];
     }
   }
 

--- a/src/service/highContrast.ts
+++ b/src/service/highContrast.ts
@@ -235,10 +235,12 @@ export class HighContrastService implements Disposable {
    * Capture original colors from the DOM before any high contrast changes.
    */
   private captureOriginalColors(): void {
-    // Capture body styles
-    const bodyStyle = window.getComputedStyle(document.body);
-    this.defaultBackgroundColor = bodyStyle.backgroundColor;
-    this.defaultForegroundColor = bodyStyle.color;
+    // Capture the body's own inline declarations rather than its computed
+    // colors. Writing a computed value back on restore would leave a
+    // permanent inline style outranking the page's stylesheet, so a host
+    // theme toggle would stop changing the body after one on/off cycle.
+    this.defaultBackgroundColor = document.body.style.backgroundColor;
+    this.defaultForegroundColor = document.body.style.color;
 
     // Capture SVG element colors
     this.originalColorInfo = this.getOriginalColorInfo();
@@ -416,8 +418,8 @@ export class HighContrastService implements Disposable {
     }
 
     // Restore body styles
-    document.body.style.backgroundColor = this.defaultBackgroundColor;
-    document.body.style.color = this.defaultForegroundColor;
+    this.restoreBodyStyle('background-color', this.defaultBackgroundColor);
+    this.restoreBodyStyle('color', this.defaultForegroundColor);
 
     // Restore SVG element colors
     this.originalColorInfo.forEach((item) => {
@@ -465,6 +467,19 @@ export class HighContrastService implements Disposable {
   }
 
   // ========== Helper Methods ==========
+
+  /**
+   * Puts one body color declaration back the way it was found. An empty
+   * captured value means the page declared nothing inline, so the property is
+   * removed rather than pinned to whatever it computed to.
+   */
+  private restoreBodyStyle(property: string, value: string): void {
+    if (value === '') {
+      document.body.style.removeProperty(property);
+    } else {
+      document.body.style.setProperty(property, value);
+    }
+  }
 
   /**
    * Get all SVG elements from all traces in the Figure hierarchy.

--- a/src/service/highContrast.ts
+++ b/src/service/highContrast.ts
@@ -286,6 +286,11 @@ export class HighContrastService implements Disposable {
       this.patternService = null;
     }
 
+    // The parsing canvas outlives nothing else here, but release it for the
+    // same reason PatternService does: a disposed service should not keep a
+    // rendering context alive if anything still holds a reference to it.
+    this.sharedCanvasCtx = null;
+
     // Note: Colors are restored via suspendHighContrast() before dispose is called.
     // See index.ts onFocusOut handler.
   }

--- a/src/service/pattern.ts
+++ b/src/service/pattern.ts
@@ -140,15 +140,6 @@ export class PatternService {
   }
 
   /**
-   * Remove pattern from an element and restore original fill.
-   * @param element The element to remove the pattern from
-   * @param originalFill The original fill value to restore
-   */
-  public removePattern(element: SVGElement, originalFill: string): void {
-    element.setAttribute('fill', originalFill);
-  }
-
-  /**
    * Get all available pattern types.
    * Useful for cycling through patterns for different data series.
    * Note: order determines assignment, eg the first series gets the first pattern and so on.

--- a/src/service/pattern.ts
+++ b/src/service/pattern.ts
@@ -62,6 +62,9 @@ export class PatternService {
   /** Reference to the target SVG */
   private targetSvg: SVGSVGElement | null = null;
 
+  /** Shared canvas context for color parsing (reused to avoid GC pressure) */
+  private sharedCanvasCtx: CanvasRenderingContext2D | null = null;
+
   /** Pattern generators for each pattern type */
   private readonly patternGenerators: Record<PatternType, PatternGenerator> = {
     'diagonal-stripes': this.createDiagonalStripes.bind(this),
@@ -182,6 +185,7 @@ export class PatternService {
     this.patternCache.clear();
     this.defsElement = null;
     this.targetSvg = null;
+    this.sharedCanvasCtx = null;
   }
 
   /**
@@ -232,11 +236,24 @@ export class PatternService {
   }
 
   /**
+   * Returns a shared canvas 2D context for color parsing operations.
+   * Creates the context on first use and reuses it to avoid GC pressure:
+   * patterns are applied one element at a time, so a context per call is a
+   * context per mark on every apply.
+   */
+  private getSharedCanvasContext(): CanvasRenderingContext2D | null {
+    if (!this.sharedCanvasCtx) {
+      this.sharedCanvasCtx = document.createElement('canvas').getContext('2d');
+    }
+    return this.sharedCanvasCtx;
+  }
+
+  /**
    * Normalize a color value to a consistent format.
    */
   private normalizeColor(color: string): string {
     // Use canvas to normalize any CSS color to hex
-    const ctx = document.createElement('canvas').getContext('2d');
+    const ctx = this.getSharedCanvasContext();
     if (!ctx)
       return color.toLowerCase().replace(/\s/g, '');
 

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -471,7 +471,10 @@ export abstract class Svg {
     clone.style.stroke = color;
 
     if (isLineElement) {
-      const strokeWidth = window.getComputedStyle(clone).getPropertyValue(Constant.STROKE_WIDTH);
+      // Read the width from the original, which is in the document. The clone
+      // is still detached here, and a detached element resolves no computed
+      // style, so reading it there would always fall through to the increment.
+      const strokeWidth = computed.getPropertyValue(Constant.STROKE_WIDTH);
       const match = strokeWidth.match(/^([0-9.]+)([a-z%]*)$/i);
       if (match) {
         const value = Number.parseFloat(match[1]);

--- a/test/service/highContrast.test.ts
+++ b/test/service/highContrast.test.ts
@@ -116,6 +116,11 @@ interface Harness {
   settings: SettingsService;
   marks: SVGElement[];
   bar: SVGElement;
+  /**
+   * The same object the service holds, so a test can repoint it the way a
+   * host does when it re-renders the chart into fresh SVG nodes.
+   */
+  display: { plot: HTMLElement };
 }
 
 function createHarness(
@@ -169,7 +174,7 @@ function createHarness(
     context as unknown as Context,
   );
 
-  return { service, settings, marks, bar: marks[0] };
+  return { service, settings, marks, bar: marks[0], display };
 }
 
 function turnHighContrastOff(settings: SettingsService): void {
@@ -232,6 +237,28 @@ describe('highContrastService', () => {
 
     expect(window.getComputedStyle(document.body).backgroundColor).toBe('rgb(0, 0, 0)');
     expect(harness.bar.getAttribute('fill')).not.toBe(BAR_FILL);
+  });
+
+  it('reads the real colours of a chart the host re-rendered into new nodes', () => {
+    // The restore before the re-capture writes to the elements captured last
+    // time. A host that redraws into fresh SVG nodes leaves those detached, so
+    // the restore reaches nothing -- which is fine, because the new nodes were
+    // never recoloured and already carry their own colours. This pins that the
+    // second path is as correct as the first, since only the first is obvious.
+    harness.service.initializeHighContrast();
+    const replacement = document.createElementNS(SVG_NAMESPACE, 'svg');
+    replacement.setAttribute('id', 'chart');
+    const redrawn = document.createElementNS(SVG_NAMESPACE, 'rect');
+    redrawn.setAttribute('fill', BAR_FILL);
+    redrawn.setAttribute('stroke', '#1f77b4');
+    replacement.appendChild(redrawn);
+    harness.display.plot.replaceWith(replacement);
+    harness.display.plot = replacement as unknown as HTMLElement;
+
+    harness.service.setFigure(createFigure());
+    turnHighContrastOff(harness.settings);
+
+    expect(redrawn.getAttribute('fill')).toBe(BAR_FILL);
   });
 
   it('interpolates the colour ramp once per apply, not once per colour', () => {

--- a/test/service/highContrast.test.ts
+++ b/test/service/highContrast.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for `HighContrastService` in `src/service/highContrast.ts`.
+ *
+ * The service repaints the page and the chart, so the only thing that makes
+ * it safe is the snapshot it restores from. Every path that re-takes that
+ * snapshot has to run against the chart's own colours; taking it while high
+ * contrast is painted records the service's own output as the page default
+ * and there is no way back to the original appearance.
+ */
+
+import type { Context } from '@model/context';
+import type { Figure } from '@model/plot';
+import type { DisplayService } from '@service/display';
+import type { NotificationService } from '@service/notification';
+import type { StorageService } from '@service/storage';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { HighContrastService } from '@service/highContrast';
+import { SettingsService } from '@service/settings';
+
+// `jest-environment-jsdom` does not expose `structuredClone`, which
+// `SettingsService` uses to clone the default settings.
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+}
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const PAGE_BACKGROUND = 'rgb(250, 250, 250)';
+const PAGE_FOREGROUND = 'rgb(17, 17, 17)';
+const BAR_FILL = '#dddddd';
+
+/**
+ * Minimal stand-in for the 2D canvas context the service uses to normalise CSS
+ * colours. jsdom has no canvas, and the real one is a boundary worth mocking
+ * rather than reaching through: assigning an unparseable colour leaves
+ * `fillStyle` at its previous value, which is what the service relies on.
+ */
+function installCanvasStub(): void {
+  const toHex = (value: string): string | null => {
+    const trimmed = value.trim().toLowerCase();
+    if (/^#[0-9a-f]{6}$/.test(trimmed)) {
+      return trimmed;
+    }
+    if (/^#[0-9a-f]{3}$/.test(trimmed)) {
+      return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
+    }
+    const rgb = trimmed.match(/^rgb\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)\s*\)$/);
+    if (rgb) {
+      const channels = [rgb[1], rgb[2], rgb[3]]
+        .map(channel => Number.parseInt(channel, 10).toString(16).padStart(2, '0'));
+      return `#${channels.join('')}`;
+    }
+    return null;
+  };
+
+  class CanvasContextStub {
+    private currentFillStyle = '#000000';
+
+    public get fillStyle(): string {
+      return this.currentFillStyle;
+    }
+
+    public set fillStyle(value: string) {
+      const hex = toHex(value);
+      if (hex !== null) {
+        this.currentFillStyle = hex;
+      }
+    }
+  }
+
+  const stub = new CanvasContextStub();
+  HTMLCanvasElement.prototype.getContext
+    = (() => stub) as unknown as HTMLCanvasElement['getContext'];
+}
+
+function createStorage(): StorageService {
+  const store = new Map<string, unknown>();
+  return {
+    save: <T>(key: string, value: T): void => {
+      store.set(key, value);
+    },
+    load: <T>(key: string): T | null => (store.get(key) as T) ?? null,
+    remove: (key: string): void => {
+      store.delete(key);
+    },
+  };
+}
+
+/**
+ * An empty figure. The service only walks it to decide which elements belong
+ * to a trace, and these tests assert on the page and on chart colours that do
+ * not depend on that classification.
+ */
+function createFigure(): Figure {
+  const figure: Pick<Figure, 'subplots'> = { subplots: [] };
+  return figure as unknown as Figure;
+}
+
+interface Harness {
+  service: HighContrastService;
+  settings: SettingsService;
+  bar: SVGElement;
+}
+
+function createHarness(): Harness {
+  document.head.innerHTML = `<style>body { background-color: ${PAGE_BACKGROUND}; color: ${PAGE_FOREGROUND}; }</style>`;
+  document.body.innerHTML = '';
+  // The service writes to the body's inline style, which survives a change of
+  // its children; clear it so each test starts from the stylesheet alone.
+  document.body.removeAttribute('style');
+
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+  svg.setAttribute('id', 'chart');
+  const bar = document.createElementNS(SVG_NAMESPACE, 'rect');
+  bar.setAttribute('fill', BAR_FILL);
+  svg.appendChild(bar);
+  document.body.appendChild(svg);
+
+  const display: Pick<DisplayService, 'plot'> = { plot: svg as unknown as HTMLElement };
+  const displayService = display as unknown as DisplayService;
+
+  const settings = new SettingsService(createStorage(), displayService);
+  settings.saveSettings({
+    ...settings.loadSettings(),
+    general: { ...settings.loadSettings().general, highContrastMode: true },
+  });
+
+  const notification: Pick<NotificationService, 'notify'> = { notify: () => {} };
+
+  const context: Pick<Context, 'id' | 'instructionContext'> = {
+    id: 'chart',
+    instructionContext: {} as Context['instructionContext'],
+  };
+
+  const service = new HighContrastService(
+    settings,
+    notification as unknown as NotificationService,
+    displayService,
+    createFigure(),
+    context as unknown as Context,
+  );
+
+  return { service, settings, bar };
+}
+
+function turnHighContrastOff(settings: SettingsService): void {
+  settings.saveSettings({
+    ...settings.loadSettings(),
+    general: { ...settings.loadSettings().general, highContrastMode: false },
+  });
+}
+
+describe('highContrastService', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    installCanvasStub();
+    harness = createHarness();
+  });
+
+  afterEach(() => {
+    harness.service.dispose();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('recolours the page and the chart while high contrast is on', () => {
+    harness.service.initializeHighContrast();
+
+    expect(window.getComputedStyle(document.body).backgroundColor).toBe('rgb(0, 0, 0)');
+    expect(harness.bar.getAttribute('fill')).not.toBe(BAR_FILL);
+  });
+
+  it('restores the page and the chart when high contrast is turned off', () => {
+    harness.service.initializeHighContrast();
+
+    turnHighContrastOff(harness.settings);
+
+    expect(window.getComputedStyle(document.body).backgroundColor).toBe(PAGE_BACKGROUND);
+    expect(harness.bar.getAttribute('fill')).toBe(BAR_FILL);
+  });
+
+  it('restores the page and the chart after a live update taken while high contrast is on', () => {
+    harness.service.initializeHighContrast();
+
+    harness.service.setFigure(createFigure());
+    turnHighContrastOff(harness.settings);
+
+    expect(window.getComputedStyle(document.body).backgroundColor).toBe(PAGE_BACKGROUND);
+    expect(harness.bar.getAttribute('fill')).toBe(BAR_FILL);
+  });
+
+  it('keeps high contrast applied across a live update', () => {
+    harness.service.initializeHighContrast();
+
+    harness.service.setFigure(createFigure());
+
+    expect(window.getComputedStyle(document.body).backgroundColor).toBe('rgb(0, 0, 0)');
+    expect(harness.bar.getAttribute('fill')).not.toBe(BAR_FILL);
+  });
+});

--- a/test/service/highContrast.test.ts
+++ b/test/service/highContrast.test.ts
@@ -118,12 +118,18 @@ interface Harness {
   bar: SVGElement;
 }
 
-function createHarness(specs: MarkSpec[] = [{ fill: BAR_FILL }]): Harness {
+function createHarness(
+  specs: MarkSpec[] = [{ fill: BAR_FILL }],
+  inlineBodyBackground?: string,
+): Harness {
   document.head.innerHTML = `<style>body { background-color: ${PAGE_BACKGROUND}; color: ${PAGE_FOREGROUND}; }</style>`;
   document.body.innerHTML = '';
   // The service writes to the body's inline style, which survives a change of
   // its children; clear it so each test starts from the stylesheet alone.
   document.body.removeAttribute('style');
+  if (inlineBodyBackground !== undefined) {
+    document.body.style.backgroundColor = inlineBodyBackground;
+  }
 
   const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
   svg.setAttribute('id', 'chart');
@@ -188,9 +194,9 @@ describe('highContrastService', () => {
   });
 
   /** Replaces the default single-mark harness with one built for a test. */
-  function rebuild(specs: MarkSpec[]): void {
+  function rebuild(specs: MarkSpec[], inlineBodyBackground?: string): void {
     harness.service.dispose();
-    harness = createHarness(specs);
+    harness = createHarness(specs, inlineBodyBackground);
   }
 
   it('recolours the page and the chart while high contrast is on', () => {
@@ -262,6 +268,27 @@ describe('highContrastService', () => {
     }
 
     expect(ancestorReads).toBeLessThan(capturedColours);
+  });
+
+  it('leaves no inline body colours behind once high contrast is turned off', () => {
+    harness.service.initializeHighContrast();
+
+    turnHighContrastOff(harness.settings);
+
+    // An inline declaration outranks the page's own stylesheet, so leaving one
+    // here would freeze the page at whatever it looked like on the way in --
+    // a host theme toggle would stop changing the body.
+    expect(document.body.style.backgroundColor).toBe('');
+    expect(document.body.style.color).toBe('');
+  });
+
+  it('restores an inline body colour the page set for itself', () => {
+    rebuild([{ fill: BAR_FILL }], 'rgb(200, 0, 0)');
+
+    harness.service.initializeHighContrast();
+    turnHighContrastOff(harness.settings);
+
+    expect(document.body.style.backgroundColor).toBe('rgb(200, 0, 0)');
   });
 
   it('leaves the ramp intact for later marks when one may not take the background', () => {

--- a/test/service/highContrast.test.ts
+++ b/test/service/highContrast.test.ts
@@ -17,7 +17,7 @@ import type { Figure } from '@model/plot';
 import type { DisplayService } from '@service/display';
 import type { NotificationService } from '@service/notification';
 import type { StorageService } from '@service/storage';
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { HighContrastService } from '@service/highContrast';
 import { SettingsService } from '@service/settings';
 
@@ -31,6 +31,12 @@ const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 const PAGE_BACKGROUND = 'rgb(250, 250, 250)';
 const PAGE_FOREGROUND = 'rgb(17, 17, 17)';
 const BAR_FILL = '#dddddd';
+
+/**
+ * A path long enough to trip the "complex path" test, which marks an element
+ * as one that must not be given the background colour.
+ */
+const COMPLEX_PATH = `M 0 0 ${Array.from({ length: 40 }, (_, i) => `L ${i} ${i}`).join(' ')}`;
 
 /**
  * Minimal stand-in for the 2D canvas context the service uses to normalise CSS
@@ -99,13 +105,20 @@ function createFigure(): Figure {
   return figure as unknown as Figure;
 }
 
+interface MarkSpec {
+  fill: string;
+  /** Draw the mark as a long `<path>`, which may not take the background colour. */
+  complexPath?: boolean;
+}
+
 interface Harness {
   service: HighContrastService;
   settings: SettingsService;
+  marks: SVGElement[];
   bar: SVGElement;
 }
 
-function createHarness(): Harness {
+function createHarness(specs: MarkSpec[] = [{ fill: BAR_FILL }]): Harness {
   document.head.innerHTML = `<style>body { background-color: ${PAGE_BACKGROUND}; color: ${PAGE_FOREGROUND}; }</style>`;
   document.body.innerHTML = '';
   // The service writes to the body's inline style, which survives a change of
@@ -114,9 +127,16 @@ function createHarness(): Harness {
 
   const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
   svg.setAttribute('id', 'chart');
-  const bar = document.createElementNS(SVG_NAMESPACE, 'rect');
-  bar.setAttribute('fill', BAR_FILL);
-  svg.appendChild(bar);
+  const marks = specs.map((spec) => {
+    const mark = document.createElementNS(SVG_NAMESPACE, spec.complexPath ? 'path' : 'rect');
+    if (spec.complexPath) {
+      mark.setAttribute('d', COMPLEX_PATH);
+    }
+    mark.setAttribute('fill', spec.fill);
+    mark.setAttribute('stroke', '#1f77b4');
+    svg.appendChild(mark);
+    return mark as SVGElement;
+  });
   document.body.appendChild(svg);
 
   const display: Pick<DisplayService, 'plot'> = { plot: svg as unknown as HTMLElement };
@@ -143,7 +163,7 @@ function createHarness(): Harness {
     context as unknown as Context,
   );
 
-  return { service, settings, bar };
+  return { service, settings, marks, bar: marks[0] };
 }
 
 function turnHighContrastOff(settings: SettingsService): void {
@@ -166,6 +186,12 @@ describe('highContrastService', () => {
     document.head.innerHTML = '';
     document.body.innerHTML = '';
   });
+
+  /** Replaces the default single-mark harness with one built for a test. */
+  function rebuild(specs: MarkSpec[]): void {
+    harness.service.dispose();
+    harness = createHarness(specs);
+  }
 
   it('recolours the page and the chart while high contrast is on', () => {
     harness.service.initializeHighContrast();
@@ -200,5 +226,51 @@ describe('highContrastService', () => {
 
     expect(window.getComputedStyle(document.body).backgroundColor).toBe('rgb(0, 0, 0)');
     expect(harness.bar.getAttribute('fill')).not.toBe(BAR_FILL);
+  });
+
+  it('interpolates the colour ramp once per apply, not once per colour', () => {
+    rebuild(Array.from({ length: 16 }, () => ({ fill: BAR_FILL })));
+    const interpolate = jest.spyOn(harness.service, 'interpolateColors');
+
+    harness.service.initializeHighContrast();
+
+    expect(interpolate).toHaveBeenCalledTimes(1);
+  });
+
+  it('walks an element ancestry once per element, not once per captured colour', () => {
+    // Every mark contributes a fill and a stroke, and the ancestor walk that
+    // decides whether it is text was run for each of them and then again for
+    // the glow filter.
+    rebuild(Array.from({ length: 16 }, () => ({ fill: BAR_FILL })));
+    const capturedColours = harness.marks.length * 2;
+    const descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'parentElement');
+    let ancestorReads = 0;
+    Object.defineProperty(Node.prototype, 'parentElement', {
+      configurable: true,
+      get(this: Node) {
+        ancestorReads++;
+        return descriptor?.get?.call(this);
+      },
+    });
+
+    try {
+      harness.service.initializeHighContrast();
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Node.prototype, 'parentElement', descriptor);
+      }
+    }
+
+    expect(ancestorReads).toBeLessThan(capturedColours);
+  });
+
+  it('leaves the ramp intact for later marks when one may not take the background', () => {
+    rebuild([{ fill: BAR_FILL, complexPath: true }, { fill: BAR_FILL }, { fill: BAR_FILL }]);
+
+    harness.service.initializeHighContrast();
+
+    const [complex, ...rest] = harness.marks.map(mark => mark.getAttribute('fill'));
+    expect(complex).toBe('#ffffff');
+    expect(rest).toEqual(['#000000', '#000000']);
   });
 });

--- a/test/service/pattern.test.ts
+++ b/test/service/pattern.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for `PatternService` in `src/service/pattern.ts`.
+ *
+ * The service is driven one element at a time: high contrast walks every
+ * filled mark of a stacked bar, dodged bar or pie chart and applies a pattern
+ * to each. Anything the service allocates per call is therefore allocated once
+ * per mark, on every focus-in and every live data update.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { PatternService } from '@service/pattern';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/**
+ * jsdom has no canvas, so `getContext` is a boundary to mock. The service only
+ * round-trips a color through `fillStyle`, which a plain string property
+ * models well enough.
+ */
+function installCanvasStub(): void {
+  HTMLCanvasElement.prototype.getContext
+    = (() => ({ fillStyle: '#000000' })) as unknown as HTMLCanvasElement['getContext'];
+}
+
+describe('patternService', () => {
+  let service: PatternService;
+  let svg: SVGSVGElement;
+  let marks: SVGElement[];
+  let createElement: jest.SpiedFunction<typeof document.createElement>;
+
+  beforeEach(() => {
+    installCanvasStub();
+    document.body.innerHTML = '';
+
+    svg = document.createElementNS(SVG_NAMESPACE, 'svg') as SVGSVGElement;
+    marks = [];
+    for (let i = 0; i < 12; i++) {
+      const mark = document.createElementNS(SVG_NAMESPACE, 'rect');
+      mark.setAttribute('fill', i % 2 === 0 ? '#1f77b4' : '#ff7f0e');
+      svg.appendChild(mark);
+      marks.push(mark);
+    }
+    document.body.appendChild(svg);
+
+    service = new PatternService();
+    service.initialize(svg);
+
+    createElement = jest.spyOn(document, 'createElement');
+  });
+
+  afterEach(() => {
+    createElement.mockRestore();
+    service.dispose();
+    document.body.innerHTML = '';
+  });
+
+  it('creates at most one canvas however many elements are patterned', () => {
+    marks.forEach((mark, index) => {
+      service.applyPattern(mark, {
+        type: 'diagonal-stripes',
+        baseColor: index % 2 === 0 ? '#1f77b4' : '#ff7f0e',
+        patternColor: '#ffffff',
+      });
+    });
+
+    const canvases = createElement.mock.calls.filter(([tag]) => tag === 'canvas');
+    expect(canvases.length).toBeLessThanOrEqual(1);
+  });
+
+  it('reuses one pattern definition for a repeated configuration', () => {
+    const config = {
+      type: 'dots' as const,
+      baseColor: '#1f77b4',
+      patternColor: '#ffffff',
+    };
+
+    const first = service.getPattern(config);
+    const second = service.getPattern(config);
+
+    expect(second).toBe(first);
+    expect(svg.querySelectorAll(`#${first}`)).toHaveLength(1);
+  });
+});

--- a/test/util/svgHighlight.test.ts
+++ b/test/util/svgHighlight.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for `Svg.createHighlightElement` in `src/util/svg.ts`.
+ *
+ * A line or polyline highlight is drawn as a clone of the original stroked at
+ * the original width plus two, so the overlay reads as a thickening of the
+ * line the reader is on. The width has to be read from the original element,
+ * which is in the document: the clone is still detached when the width is
+ * needed, and a detached element has no computed style, so reading it there
+ * silently collapses every highlight to the bare increment.
+ */
+
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { Svg } from '@util/svg';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const FALLBACK_COLOR = '#03c809';
+
+/**
+ * Builds a chart whose stroke width comes from a stylesheet rule that only
+ * matches an element inside the `<svg>`, the way a charting library styles its
+ * series. A clone that has not been inserted yet matches nothing.
+ */
+function renderChart(tag: 'line' | 'polyline', strokeWidth: string): SVGElement {
+  document.head.innerHTML = `<style>svg ${tag} { stroke-width: ${strokeWidth}; stroke: #1f77b4; }</style>`;
+
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+  const element = document.createElementNS(SVG_NAMESPACE, tag);
+  svg.appendChild(element);
+  document.body.appendChild(svg);
+
+  return element;
+}
+
+describe('createHighlightElement stroke width', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it.each([
+    { tag: 'polyline' as const, width: '5px', expected: '7px' },
+    { tag: 'line' as const, width: '4px', expected: '6px' },
+  ])('thickens a $tag of $width to $expected', ({ tag, width, expected }) => {
+    const element = renderChart(tag, width);
+
+    const highlight = Svg.createHighlightElement(element, FALLBACK_COLOR);
+
+    expect(highlight.getAttribute('stroke-width')).toBe(expected);
+  });
+
+  it('falls back to the bare increment when the original has no stroke width', () => {
+    const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+    const element = document.createElementNS(SVG_NAMESPACE, 'polyline');
+    svg.appendChild(element);
+    document.body.appendChild(svg);
+
+    const highlight = Svg.createHighlightElement(element, FALLBACK_COLOR);
+
+    expect(highlight.getAttribute('stroke-width')).toBe('2');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Six defects in the highlight, high-contrast and pattern services, found in a codebase audit. Two are visible to a sighted reader; the rest are cost or dead code.

A line's highlight was **always 2px**, never the original width plus two. The width was read from the clone, which is detached from the document and therefore computes nothing from a stylesheet. A chart whose lines are styled in CSS got a highlight thinner than the line it was meant to mark.

The second one leaves the chart wrong after the fact: `setFigure()` during a live update captured the **already-applied** high-contrast colours as the "original" ones. Turning high contrast off then restored the chart to the high-contrast palette, and the original colours were gone for the rest of the session.

## Related Issues

None.

## Changes Made

- **highlight**: the clone's stroke width comes from the computed style already taken from the original element, which is the one attached to the document.
- **high contrast**: `setFigure()` restores before it re-captures. This needed a new private `highContrastApplied` flag, because the setting can be on while the effect is suspended on blur, so the setting alone cannot answer whether the DOM currently shows our colours.
- **high contrast**: restoring writes back the body's own inline declarations rather than its computed colours, so a page that set none is left with none.
- **high contrast**: the colour ramp and the text-ancestor walk are computed once per apply instead of once per element.
- **pattern**: one canvas context is reused for colour parsing instead of a fresh canvas and 2D context per call, twice per element.
- **pattern**: `removePattern` is removed. It had no callers anywhere in `src/`, `test/` or `e2e_tests/`, and would not have undone a style-based fill in any case.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**A behaviour change worth a reviewer's eye.** Restoring the body now writes back its inline declarations rather than its computed colours, so a page that set no inline body colour gets `removeProperty` on restore instead of a pinned computed value. That is the point of the fix, but it means the body is no longer left at a fixed colour after a high-contrast cycle. Nothing in this repository relies on that.

Hoisting the colour ramp also required a smaller change that is easy to miss: `findClosestColor` spliced the background out of the array it was handed, which is why the caller was copying the array every time. That splice is now a filtered copy, and a test pins that a complex path still loses the background without the marks after it losing it too.

Removing `removePattern` is the one change with no failing test first, deliberately: unreachable code cannot be pinned by a test, so the reproduction was a grep across the tree plus the type checker. Say the word if you would rather it were repaired and kept.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (503 suites, 6732 tests) and the esm project under `--experimental-vm-modules` (12 suites, 172 tests), both clean. That split rather than `npm test` because collecting coverage over the whole tree needs about 10 GB on the build machine and does not fit; CI has the headroom and runs it as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_