### PR TITLE
fix(tactile): let the queued blank frames reach the display before releasing it

### DIFF
--- a/src/service/dotPadSession.ts
+++ b/src/service/dotPadSession.ts
@@ -141,6 +141,16 @@ const VENDOR_ASSET_BASE_URL = 'https://cdn.jsdelivr.net/gh/xability/dotpad-sdk-g
 const BRAILLE_LANGUAGE = 'English';
 
 /**
+ * How long closing a device waits for the writes already queued for it.
+ *
+ * Long enough for the frame a caller sends on its way out -- the SDK hands a
+ * payload to the transport and returns without waiting for the device to
+ * settle -- and short enough that a display cannot be held out of the page's
+ * reach by a transport that has stopped answering.
+ */
+const CLOSE_FLUSH_TIMEOUT_MS = 2000;
+
+/**
  * Owns the connection to a tactile display, for as long as the page lives.
  *
  * Deliberately a module-level singleton rather than a service on the MAIDR
@@ -840,15 +850,15 @@ class DotPadSession {
 
   /**
    * Closes the connection.
+   *
+   * The state goes back to disconnected at once, so a caller that asks
+   * immediately afterwards is told the truth and no further write is accepted.
+   * The device itself is closed behind whatever is already queued for it --
+   * see {@link closeWhenQueueDrains}.
    */
   public disconnect(): void {
-    if (this.sdk !== null && this.device !== null) {
-      try {
-        this.sdk.disconnect(this.device);
-      } catch (error) {
-        console.error('DotPad disconnect failed:', error instanceof Error ? error.message : error);
-      }
-    }
+    const sdk = this.sdk;
+    const device = this.device;
     this.device = null;
     // A released device is nobody's adoption, so the flag does not outlive
     // the connection it described.
@@ -860,6 +870,50 @@ class DotPadSession {
       geometry: null,
       message: '',
     });
+    if (sdk !== null && device !== null) {
+      this.closeWhenQueueDrains(sdk, device);
+    }
+  }
+
+  /**
+   * Closes a device once the writes already queued for it have gone out.
+   *
+   * Writes are deferred onto {@link writeChain}, so the last thing a caller
+   * does before handing the display back has not reached the SDK yet when it
+   * asks. Closing there and then shuts the connection under those writes: they
+   * run a microtask later against a device the SDK has already closed, which
+   * is how a released display ends up still holding the chart the reader just
+   * turned braille off on -- the blank frame never arrives.
+   *
+   * Bounded rather than open-ended. A transport that has stopped acknowledging
+   * leaves the queue undrainable, and a close that waited on it would keep the
+   * device checked out for the life of the frame, which no other chart on the
+   * page could then adopt. Past the bound it is closed regardless, which is
+   * only what closing immediately would have done.
+   *
+   * @param sdk - The SDK the device was opened through
+   * @param device - The device to close
+   */
+  private closeWhenQueueDrains(sdk: DotPadVendorSdk, device: DotPadVendorDevice): void {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const bound = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, CLOSE_FLUSH_TIMEOUT_MS);
+    });
+    this.writeChain = Promise.race([this.writeChain, bound])
+      .then(() => {
+        clearTimeout(timer);
+        // A reconnect can beat a bounded wait, and it hands back the same
+        // device. Closing here would then take down a connection the reader
+        // has just made.
+        if (this.device === device) {
+          return;
+        }
+        sdk.disconnect(device);
+      })
+      .catch((error: unknown) => {
+        clearTimeout(timer);
+        console.error('DotPad disconnect failed:', error instanceof Error ? error.message : error);
+      });
   }
 
   /**

--- a/src/service/tactile.ts
+++ b/src/service/tactile.ts
@@ -1510,12 +1510,30 @@ export class TactileService implements Observer<TactileStateUnion>, Disposable {
   /**
    * Releases this chart's subscriptions.
    *
-   * Deliberately does NOT disconnect the device. This runs on every focus-out
-   * and tab switch, and reconnecting needs a user gesture that cannot be asked
-   * for mid-session — dropping the connection here would make the display
-   * unusable in ordinary use.
+   * Deliberately does NOT disconnect a device the reader connected here
+   * themselves. This runs on every focus-out and tab switch, and reconnecting
+   * one needs a user gesture that cannot be asked for mid-session — dropping
+   * that connection here would make the display unusable in ordinary use.
+   *
+   * What it does do is leave the display the way turning braille off leaves
+   * it. Nothing else closes the display on the way out: braille's own
+   * `dispose()` does not fire its toggle, so {@link setShowing} never runs, and
+   * the controller that replaces this one starts with the display off. Pins
+   * left up then point the reader at a chart they have left while every other
+   * channel says nothing is there. An adopted device is handed back for the
+   * same reason: it is checked out to this frame and only this frame can
+   * return it, so keeping it past focus-out is what makes the next chart's `b`
+   * fail on a device another frame still holds — and re-adopting needs no
+   * gesture, which is the whole point of adoption.
    */
   public dispose(): void {
+    // Only what this chart put there. A display it never raised may be another
+    // chart's, and blanking or releasing that would take it from under them.
+    if (this.showing) {
+      this.showing = false;
+      this.blank();
+      dotPadSession.releaseIfAdopted();
+    }
     this.disposed = true;
     for (const disposable of this.disposables) {
       disposable.dispose();

--- a/src/service/tactile.ts
+++ b/src/service/tactile.ts
@@ -1413,8 +1413,20 @@ export class TactileService implements Observer<TactileStateUnion>, Disposable {
     // text, and sending the reader back to "Line part 1" on every one of them
     // made the outer function keys unusable while zoomed in. Only a line that
     // has nothing on it yet is written again.
-    if (description === this.lastDescription && this.lastText !== null) {
-      return;
+    if (description === this.lastDescription) {
+      if (this.lastText !== null) {
+        return;
+      }
+      if (this.textCells.length > 0) {
+        // The same line, with only the payload cached against retransmission
+        // forgotten -- a write failure forgets it along with the frame. So the
+        // window the reader is on is sent again rather than the line being
+        // started over: rewinding to part 1 here would move them back through
+        // a sentence they are half way into, on a failure they cannot see, and
+        // re-translating would spend a round trip on text already translated.
+        this.writeTextWindow(cellCount);
+        return;
+      }
     }
     this.lastDescription = description;
     // Back to the start on every move: the line now describes a different

--- a/src/util/tactile/raster.ts
+++ b/src/util/tactile/raster.ts
@@ -404,19 +404,73 @@ export class DotRaster {
       return;
     }
 
+    const box = this.boxOf(rings);
+    if (box === null) {
+      return;
+    }
+
     // Filled into a scratch buffer and then transferred through the dither, so
     // the even-odd rule that gives a ring its holes is applied once, by the
     // code that already knows how, rather than reimplemented per pin.
-    const solid = new DotRaster(this.width, this.height);
-    solid.fillPolygon(rings);
+    //
+    // The buffer is the size of the ring rather than of the display, and the
+    // rings are moved into it. A heatmap textures one ring per cell per frame,
+    // so a display-sized buffer per cell is the cell count times the pin count
+    // — a 60x60 chart on a DotPad 320 allocated 3,600 buffers and read 8.6
+    // million pins to raise a few thousand, on every navigation move.
+    const solid = new DotRaster(box.right - box.left + 1, box.bottom - box.top + 1);
+    solid.fillPolygon(rings.map(ring => ring.map(
+      point => ({ x: point.x - box.left, y: point.y - box.top }),
+    )));
+
     const tile = DotRaster.DITHER;
-    for (let y = 0; y < this.height; y++) {
-      for (let x = 0; x < this.width; x++) {
-        if (solid.get(x, y) && tile[y % 4][x % 4] < level) {
+    for (let y = box.top; y <= box.bottom; y++) {
+      for (let x = box.left; x <= box.right; x++) {
+        if (solid.get(x - box.left, y - box.top) && tile[y % 4][x % 4] < level) {
           this.set(x, y);
         }
       }
     }
+  }
+
+  /**
+   * The pins a set of rings can reach, clipped to the buffer.
+   *
+   * Each coordinate is bounded on its own, matching how {@link fillPolygon}
+   * reads them: a point with a finite `y` and a non-finite `x` still puts its
+   * row in range, and contributes nothing across.
+   *
+   * @param rings - Closed rings in dot coordinates
+   * @returns Inclusive pin bounds, or null when no ring can raise anything
+   */
+  private boxOf(
+    rings: readonly (readonly { x: number; y: number }[])[],
+  ): { left: number; right: number; top: number; bottom: number } | null {
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const ring of rings) {
+      for (const point of ring) {
+        if (Number.isFinite(point.x)) {
+          minX = Math.min(minX, point.x);
+          maxX = Math.max(maxX, point.x);
+        }
+        if (Number.isFinite(point.y)) {
+          minY = Math.min(minY, point.y);
+          maxY = Math.max(maxY, point.y);
+        }
+      }
+    }
+    if (!Number.isFinite(minX) || !Number.isFinite(minY)) {
+      return null;
+    }
+
+    const left = Math.max(0, Math.round(minX));
+    const right = Math.min(this.width - 1, Math.round(maxX));
+    const top = Math.max(0, Math.round(minY));
+    const bottom = Math.min(this.height - 1, Math.round(maxY));
+    return left > right || top > bottom ? null : { left, right, top, bottom };
   }
 
   /**

--- a/src/util/tactile/svgGeometry.ts
+++ b/src/util/tactile/svgGeometry.ts
@@ -47,7 +47,8 @@ export abstract class TactileSvgGeometry {
   private static readonly MAX_SAMPLES = 512;
 
   /**
-   * Points used to approximate a full circle or ellipse.
+   * Points used to approximate a circle or ellipse large enough to want them
+   * all. A smaller one is sampled to its size — see {@link ellipseSamples}.
    */
   private static readonly ELLIPSE_SAMPLES = 48;
 
@@ -534,12 +535,66 @@ export abstract class TactileSvgGeometry {
     matrix: DOMMatrix,
     viewport: TactileViewport,
   ): DotRing {
+    const samples = this.ellipseSamples(cx, cy, rx, ry, matrix, viewport);
     const points: DotPoint[] = [];
-    for (let i = 0; i < this.ELLIPSE_SAMPLES; i++) {
-      const angle = (i / this.ELLIPSE_SAMPLES) * Math.PI * 2;
+    for (let i = 0; i < samples; i++) {
+      const angle = (i / samples) * Math.PI * 2;
       points.push(this.project(cx + rx * Math.cos(angle), cy + ry * Math.sin(angle), matrix, viewport));
     }
     return { points, closed: true };
+  }
+
+  /**
+   * How finely to sample an ellipse, given the room it takes on the pins.
+   *
+   * A sample every couple of dots, which is what {@link samplePath} spends on
+   * a path, bounded at both ends. The bound that matters is the lower one: a
+   * scatter is thousands of circles, every unfocused one is reduced again on
+   * every navigation move, and each sample is then stroked as its own segment
+   * — so a point that covers a pin or two paid for forty-eight projections and
+   * forty-eight Bresenham runs to raise the pin it would have raised with
+   * eight. That is per mark, per arrow key, in front of a write the reader is
+   * already waiting on.
+   *
+   * Only the projected size decides it, since that is what the pins can
+   * resolve: the same circle wants more samples zoomed in than it does at
+   * whole-plot zoom. Three projections answer the question — the centre and
+   * one end of each axis — because everything between user space and dots is
+   * affine.
+   *
+   * @param cx - Centre x in user space
+   * @param cy - Centre y in user space
+   * @param rx - Horizontal radius in user space
+   * @param ry - Vertical radius in user space
+   * @param matrix - The shape's screen transform
+   * @param viewport - The active zoom and pan
+   * @returns Points to sample around the ellipse
+   */
+  private static ellipseSamples(
+    cx: number,
+    cy: number,
+    rx: number,
+    ry: number,
+    matrix: DOMMatrix,
+    viewport: TactileViewport,
+  ): number {
+    const centre = this.project(cx, cy, matrix, viewport);
+    const across = this.project(cx + rx, cy, matrix, viewport);
+    const down = this.project(cx, cy + ry, matrix, viewport);
+    const a = Math.hypot(across.x - centre.x, across.y - centre.y);
+    const b = Math.hypot(down.x - centre.x, down.y - centre.y);
+    if (!Number.isFinite(a) || !Number.isFinite(b)) {
+      // Unmeasurable: spend the samples rather than draw a shape that is not
+      // the mark's.
+      return this.ELLIPSE_SAMPLES;
+    }
+    // Exact for a circle, and low by a few percent for an eccentric ellipse —
+    // which costs at most a sample or two out of a count already rounded up.
+    const perimeter = Math.PI * (a + b);
+    return Math.min(
+      this.ELLIPSE_SAMPLES,
+      Math.max(this.MIN_SAMPLES, Math.ceil(perimeter / 2)),
+    );
   }
 
   /**

--- a/test/service/dotPadSession.test.ts
+++ b/test/service/dotPadSession.test.ts
@@ -692,6 +692,73 @@ describe('dotPadSession', () => {
 
       expect(session.isConnected).toBe(true);
     });
+
+    it('should let a frame already queued reach the display before closing it', async () => {
+      // Turning braille off lowers every pin and then hands the display back,
+      // and the blank frame goes through the write queue like any other. A
+      // close that does not wait for the queue shuts the device under a frame
+      // still on its way out, so the next chart takes up a display still
+      // holding the chart the reader has just left.
+      const vendor = createVendor();
+      setGrantedNavigator({ ports: [grantedPort(1027, 24592)] });
+      installVendor(vendor);
+      const session = await loadSession();
+      await session.adopt();
+      const closesBeforeTheFrame: number[] = [];
+      vendor.hooks.onGraphic = (): void => {
+        closesBeforeTheFrame.push(vendor.disconnected.length);
+      };
+
+      session.writeGraphic('00');
+      session.releaseIfAdopted();
+      await flushWrites();
+
+      expect(closesBeforeTheFrame).toEqual([0]);
+      expect(vendor.disconnected).toEqual([DEVICE]);
+    });
+
+    it('should close the display even when the queued frame is refused', async () => {
+      // The frame is a courtesy; handing the device back is not. A write the
+      // SDK throws on must not leave the display checked out to a chart the
+      // reader has left.
+      const vendor = createVendor();
+      setGrantedNavigator({ ports: [grantedPort(1027, 24592)] });
+      installVendor(vendor);
+      const session = await loadSession();
+      await session.adopt();
+      vendor.hooks.onGraphic = (): void => {
+        throw new Error('frame dropped');
+      };
+
+      session.writeGraphic('00');
+      session.releaseIfAdopted();
+      await flushWrites();
+
+      expect(vendor.disconnected).toEqual([DEVICE]);
+    });
+
+    it('should close the display rather than wait for ever on a write that never finishes', async () => {
+      // A transport that has stopped acknowledging would otherwise keep the
+      // device checked out of the whole page: nothing drains the queue, so a
+      // close that waits on it never runs and no other chart can adopt.
+      jest.useFakeTimers();
+      try {
+        const vendor = createVendor();
+        setGrantedNavigator({ ports: [grantedPort(1027, 24592)] });
+        installVendor(vendor);
+        const session = await loadSession();
+        await session.adopt();
+        vendor.hooks.onText = (): Promise<void> => new Promise<void>(() => {});
+
+        session.writeText('2801');
+        session.releaseIfAdopted();
+        await jest.advanceTimersByTimeAsync(5000);
+
+        expect(vendor.disconnected).toEqual([DEVICE]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('braille translation', () => {
@@ -1207,11 +1274,16 @@ describe('dotPadSession', () => {
 
       session.disconnect();
 
-      expect(vendor.disconnected).toEqual([DEVICE]);
+      // The state is disconnected at once; the device is closed behind
+      // whatever was already queued for it.
       expect(session.current.status).toBe('disconnected');
       expect(session.current.deviceName).toBeNull();
       expect(session.geometry).toBeNull();
       expect(session.isConnected).toBe(false);
+
+      await flushWrites();
+
+      expect(vendor.disconnected).toEqual([DEVICE]);
     });
 
     it('should stop writes from reaching the device once disconnected', async () => {

--- a/test/service/tactile.test.ts
+++ b/test/service/tactile.test.ts
@@ -545,6 +545,13 @@ describe('tactileService', () => {
     const display = { plot: on.plot } as unknown as DisplayService;
     service.dispose();
     service = new TactileService(display, braille, notification, textService, figure);
+    // The outgoing service lowers the pins it raised, which is what a
+    // controller does on the way out and is asserted in its own case below.
+    // Here it is teardown noise between two frames a test wants to compare, so
+    // the record starts again with the replacement.
+    session.writeGraphic.mockClear();
+    session.writeGraphicRow.mockClear();
+    session.writeText.mockClear();
     if (brailleStub.isEnabled) {
       // The replacement subscribes in its constructor and starts with the
       // display off, as a freshly built controller does. A test that had the
@@ -2290,10 +2297,12 @@ describe('tactileService', () => {
   describe('dispose', () => {
     it('should stop responding to the braille toggle', () => {
       activate();
-      session.writeGraphic.mockClear();
-      session.writeText.mockClear();
 
       service.dispose();
+      // After the frame dispose itself lowers, so what is counted below is
+      // only what the dropped subscription would have added.
+      session.writeGraphic.mockClear();
+      session.writeText.mockClear();
       toggle.fire({ enabled: false, state: traceState(chart, 1) });
 
       expect(session.writeGraphic).not.toHaveBeenCalled();
@@ -2318,6 +2327,46 @@ describe('tactileService', () => {
 
       expect(session.disconnect).not.toHaveBeenCalled();
       expect(session.isConnected).toBe(true);
+    });
+
+    it('should lower the pins the chart raised', () => {
+      // Focus-out disposes the controller, and the replacement starts with the
+      // display off. Pins left up then say a chart is under the reader's
+      // fingers while every other channel says nothing is.
+      activate();
+      session.writeGraphic.mockClear();
+      session.writeText.mockClear();
+
+      service.dispose();
+
+      expect(session.writeGraphic).toHaveBeenCalledWith('00'.repeat(GEOMETRY.cellColumns * GEOMETRY.cellRows));
+      expect(session.writeText).toHaveBeenCalledWith('00'.repeat(GEOMETRY.textCells));
+    });
+
+    it('should hand back a display it took up on its own', () => {
+      // Adoption checks the device out to this frame, and only this frame can
+      // hand it back. Keeping it past focus-out is what makes the next chart's
+      // `b` open on a device another frame still holds.
+      activate();
+
+      service.dispose();
+
+      expect(session.releaseIfAdopted).toHaveBeenCalled();
+    });
+
+    it('should leave the pins alone when the chart never raised them', () => {
+      // Nothing of this chart's is on the display, so there is nothing of its
+      // to take off -- and a device another chart is using must not be
+      // blanked or handed back from here.
+      session.isConnected = true;
+      session.writeGraphic.mockClear();
+      session.writeText.mockClear();
+
+      service.dispose();
+
+      expect(session.writeGraphic).not.toHaveBeenCalled();
+      expect(session.writeText).not.toHaveBeenCalled();
+      expect(session.releaseIfAdopted).not.toHaveBeenCalled();
     });
   });
 

--- a/test/service/tactile.test.ts
+++ b/test/service/tactile.test.ts
@@ -740,6 +740,24 @@ describe('tactileService', () => {
       expect(session.writeText).toHaveBeenCalled();
     });
 
+    it('should leave the text line where the reader scrolled it', async () => {
+      // The failure carries no payload, so a dropped graphic row forgets the
+      // cached text line along with the frame. The repair then describes the
+      // same point, and starting the line over takes the reader from part 3
+      // back to part 1 of a sentence they are half way through -- silently,
+      // and on a key that moves the graphic rather than the line.
+      activate(1);
+      session.fireKey('function4');
+      const scrolled = session.writeText.mock.calls[1][0];
+      session.writeText.mockClear();
+
+      session.fireWriteFailure();
+      await Promise.resolve();
+
+      expect(session.writeText).toHaveBeenCalledTimes(1);
+      expect(session.writeText.mock.calls[0][0]).toBe(scrolled);
+    });
+
     it('should stop repairing a device that never accepts a write', async () => {
       // A repair is itself a write and can fail in turn. Retrying on every
       // failure would spin for as long as the device is unreachable.

--- a/test/util/tactile/render.test.ts
+++ b/test/util/tactile/render.test.ts
@@ -343,6 +343,58 @@ describe('dotRaster', () => {
     });
   });
 
+  describe('fillDithered', () => {
+    /**
+     * One heatmap cell, well inside a display-sized buffer.
+     */
+    const cell = [[
+      { x: 2, y: 2 },
+      { x: 9, y: 2 },
+      { x: 9, y: 9 },
+      { x: 2, y: 9 },
+    ]];
+
+    it('should texture the cell and leave the rest of the buffer alone', () => {
+      const raster = new DotRaster(60, 40);
+
+      raster.fillDithered(cell, 0.5);
+
+      expect(raster.get(2, 2)).toBe(true);
+      expect(raster.get(3, 2)).toBe(false);
+      expect(raster.get(20, 20)).toBe(false);
+    });
+
+    it('should look only at the pins the ring can reach', () => {
+      // A heatmap textures one ring per cell per frame, so scanning the whole
+      // display for each is the cell count times the pin count: a 60x60 chart
+      // on a DotPad 320 reads 8.6 million pins per navigation move to raise a
+      // few thousand.
+      const raster = new DotRaster(60, 40);
+      const reads = jest.spyOn(DotRaster.prototype, 'get');
+
+      raster.fillDithered(cell, 0.5);
+
+      const scanned = reads.mock.calls.length;
+      reads.mockRestore();
+      // The cell covers 64 pins; the display has 2,400.
+      expect(scanned).toBeLessThanOrEqual(100);
+    });
+
+    it('should keep the hole of a ring drawn away from the origin', () => {
+      // The texture has to land on the ring wherever the ring is, so a shape
+      // with a hole keeps its hole and the pins keep their place.
+      const raster = new DotRaster(60, 40);
+
+      raster.fillDithered([
+        [{ x: 10, y: 5 }, { x: 30, y: 5 }, { x: 30, y: 25 }, { x: 10, y: 25 }],
+        [{ x: 16, y: 11 }, { x: 24, y: 11 }, { x: 24, y: 19 }, { x: 16, y: 19 }],
+      ], 0.9);
+
+      expect(raster.get(20, 15)).toBe(false);
+      expect(raster.get(13, 7)).toBe(true);
+    });
+  });
+
   describe('buffer operations', () => {
     it('should report an untouched raster as empty and a written one as not', () => {
       const raster = new DotRaster(4, 4);

--- a/test/util/tactile/svgGeometry.test.ts
+++ b/test/util/tactile/svgGeometry.test.ts
@@ -199,6 +199,82 @@ describe('tactileSvgGeometry.ringsOf on a mark the model supplied', () => {
   });
 });
 
+/**
+ * Tests for how finely `ringsOf` samples a circle.
+ *
+ * A scatter is the chart a pin grid draws best, and a scatter is a few
+ * thousand `<circle>`s. Every unfocused mark is reduced again on every
+ * navigation move, and the outline is then stroked segment by segment, so the
+ * sample count is paid twice per circle per arrow key. At whole-plot zoom a
+ * point projects onto one or two pins, where the samples past the first few
+ * land on pins already raised: work that buys the reader nothing and delays
+ * the frame they are waiting for.
+ *
+ * So the count follows the size the circle actually reaches on the pins. The
+ * cases below pin both ends of that — a mark the size the reader meets on a
+ * dense scatter, and one zoomed in far enough to want the full outline.
+ */
+describe('tactileSvgGeometry.ringsOf on a circle', () => {
+  // A plot whose shape matches the usable grid, so both axes project at the
+  // same scale and a circle stays a circle on the pins: ten user units to the
+  // dot, either way.
+  const viewport = new TactileViewport({ left: 0, top: 0, width: 570, height: 370 }, 60, 40);
+
+  /**
+   * A circle `ringsOf` can measure, under the identity transform.
+   * @param cx - Centre x in user space
+   * @param cy - Centre y in user space
+   * @param r - Radius in user space
+   */
+  function circle(cx: number, cy: number, r: number): SVGGraphicsElement {
+    const created = document.createElementNS(SVG_NS, 'circle');
+    created.setAttribute('cx', String(cx));
+    created.setAttribute('cy', String(cy));
+    created.setAttribute('r', String(r));
+    const graphics = created as unknown as Record<string, unknown>;
+    graphics.getScreenCTM = (): unknown => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 });
+    return created as unknown as SVGGraphicsElement;
+  }
+
+  it('should not sample a scatter point far past the pins it covers', () => {
+    // Three user units across, which is under a third of a pin: every sample
+    // past the first few lands on a pin already raised.
+    const point = circle(285, 185, 1.5);
+
+    const ring = TactileSvgGeometry.ringsOf(point, viewport)[0];
+
+    expect(ring.points.length).toBeLessThanOrEqual(12);
+  });
+
+  it('should still trace an outline large enough to feel', () => {
+    // Forty pins across: a circle the reader follows round rather than lands
+    // on, and one that wants every sample it can have.
+    const blob = circle(285, 185, 200);
+
+    const ring = TactileSvgGeometry.ringsOf(blob, viewport)[0];
+
+    expect(ring.points.length).toBe(48);
+  });
+
+  it('should keep the sampled points on the circle', () => {
+    // Fewer samples must mean a coarser polygon, not a smaller one: every
+    // point still sits on the projected outline, so the mark keeps its size
+    // and its place.
+    const point = circle(285, 185, 30);
+
+    const ring = TactileSvgGeometry.ringsOf(point, viewport)[0];
+
+    // The vertices of a regular polygon average to its centre.
+    const centre = {
+      x: ring.points.reduce((sum, p) => sum + p.x, 0) / ring.points.length,
+      y: ring.points.reduce((sum, p) => sum + p.y, 0) / ring.points.length,
+    };
+    for (const point of ring.points) {
+      expect(Math.hypot(point.x - centre.x, point.y - centre.y)).toBeCloseTo(3, 5);
+    }
+  });
+});
+
 describe('tactileSvgGeometry.ringsOf on a path that walks back to its start', () => {
   const viewport = new TactileViewport({ left: 0, top: 0, width: 60, height: 40 }, 60, 40);
 


### PR DESCRIPTION
# Pull Request

## Description

Five defects in the tactile path, found in a codebase audit. Three of them a reader with a refreshable display would meet directly.

Disconnecting released the adopted display **before** the blank frames queued for it reached the SDK, so the device was handed back still showing the last chart. Disposing on focus-out did the same and worse: it left the chart on the pins and kept an adopted device checked out of a frame the reader had already left.

The third is quieter but costs the reader their place: a dropped graphic write rewound the braille text line to part 1 and re-translated it, losing whatever scroll position they had reached.

## Related Issues

None.

## Changes Made

- **dotPadSession**: `disconnect()` no longer closes the vendor device synchronously. State goes to disconnected at once, so `isConnected` is honest and no new write is accepted, and the close runs behind the already-queued writes.
- **tactile**: `dispose()` blanks the pins and releases the display, but only when this chart raised it. A device another chart is using is left alone.
- **tactile**: a dropped graphic write no longer rewinds the braille line.
- **svgGeometry**: a circle or ellipse is sampled to the number of points it actually projects to, rather than 48 every time regardless.
- **raster**: `fillDithered` works in the ring's own box instead of allocating a full scratch raster and scanning every pin of the display per shaded cell.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**The deferred close is bounded**, because "release it later" must not become "never release it". The wait has a 2 second timeout, and the close skips itself if a reconnect has meanwhile handed back the same device object. Three cases pin it: the queued frame reaching the SDK first, the close still happening when a queued write throws, and the close still happening when a write never settles.

Neither performance change alters output. The circle sampling is still clamped at the old 48, so a circle large enough to trace is traced exactly as before and only small ones are sampled to their projected size. The dither change moves where the scratch buffer lives, not what is written.

**One finding was deliberately not fixed, and this is the interesting one.** The proposal was to cache the per-mark computed styles the shading reads on every move, on the premise that fill colours do not change as the reader navigates. That premise holds for the highlight service, which draws clones and never restyles a mark, but not for the page: high contrast rewrites the fill of every mark it captured, through `setAttribute` on the same elements, so the marks array keeps its identity and a cache keyed on it would serve the old palette's densities. Today the next arrow key repairs that. With the cache it would stay wrong for as long as the chart has focus, on exactly the chart types where the texture *is* the data. Every cheap revalidation tried was a proxy with a hole, and the guard test caught one. The honest invalidation needs the service to learn when the setting that repaints the chart changes, which is a new dependency and controller rewiring, and belongs in its own review rather than inside a low-severity performance fix. The two changes that did land are the larger terms in the same cost anyway.

Three existing tests were adjusted for the new dispose frame, none for their intent; each is explained in the commit that changes it.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (500 suites, 6731 tests) and the esm project under `--experimental-vm-modules` (12 suites, 172 tests), both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_