### PR TITLE
fix(anychart): stamp multi-series marks and heatmap cells where they actually are

### DIFF
--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -1376,12 +1376,15 @@ function collectLineMarkerCandidates(
  *   1. For each line-like series, determine the expected `pointCount`.
  *   2. Run {@link collectLineMarkerCandidates} once over the SVG and sort
  *      candidates left-to-right (matching data-point order).
- *   3. Single-series charts: assign the first `pointCount` candidates as
- *      `0-0 … 0-(N-1)`.
- *   4. Multi-series charts: offset-partition (`candidates[s*N … s*N+N]`)
- *      and emit a one-time warning recommending an explicit `selectors`
- *      entry, because precise per-series attribution requires matching
- *      point coordinates against axis scale transforms (out of scope here).
+ *   3. Hand the candidates out in series order, each line-like series taking
+ *      the next `pointCount` of them and leaving the cursor where it stopped.
+ *      A series this loop skips — the bars of a combined chart, one that
+ *      cannot name its type — consumes nothing, and a series shorter than its
+ *      neighbour does not shift the ones after it.
+ *   4. Multi-series charts also emit a one-time warning recommending an
+ *      explicit `selectors` entry, because precise per-series attribution
+ *      requires matching point coordinates against axis scale transforms
+ *      (out of scope here).
  *
  * The stamp is idempotent — re-running on a chart that has already been
  * stamped is a no-op.
@@ -1404,6 +1407,12 @@ function stampLineAttributes(
   candidates.sort((a, b) => a.x - b.x);
 
   let multiSeriesWarned = false;
+  // How many candidates the series before this one took. A running cursor
+  // rather than `s * pointCount`: `s` counts the series this loop skipped —
+  // the bars of a combined chart, a series that cannot name its type — none
+  // of which consumed a candidate, and `pointCount` is this series' length,
+  // which is a stride only while every series is the same length.
+  let consumed = 0;
 
   for (let s = 0; s < seriesCount; s++) {
     const series = chart.getSeriesAt(s);
@@ -1423,25 +1432,19 @@ function stampLineAttributes(
     if (pointCount === 0)
       continue;
 
-    let stampStart = 0;
-    let stampEnd = 0;
-    if (seriesCount === 1) {
-      stampStart = 0;
-      stampEnd = Math.min(pointCount, candidates.length);
-    } else {
-      if (!multiSeriesWarned) {
-        console.warn(
-          '[maidr/anychart] Multi-series line highlighting uses an offset-'
-          + 'based partition of marker candidates and may misattribute points '
-          + 'across series with overlapping geometry. For precise highlighting, '
-          + 'pass an explicit `selectors` entry to bindAnyChart().',
-        );
-        multiSeriesWarned = true;
-      }
-      const offset = s * pointCount;
-      stampStart = offset;
-      stampEnd = Math.min(offset + pointCount, candidates.length);
+    if (seriesCount > 1 && !multiSeriesWarned) {
+      console.warn(
+        '[maidr/anychart] Multi-series line highlighting uses an offset-'
+        + 'based partition of marker candidates and may misattribute points '
+        + 'across series with overlapping geometry. For precise highlighting, '
+        + 'pass an explicit `selectors` entry to bindAnyChart().',
+      );
+      multiSeriesWarned = true;
     }
+
+    const stampStart = consumed;
+    const stampEnd = Math.min(consumed + pointCount, candidates.length);
+    consumed = stampEnd;
 
     if (stampEnd - stampStart < pointCount) {
       console.warn(
@@ -1484,8 +1487,9 @@ const SCATTER_LIKE_SERIES_TYPES = new Set([
  *
  * Sort order is x-center primary, y-center secondary, matching
  * `ScatterTrace.groupSvgElements`'s X→Y grouping expectation. Multi-series
- * scatter charts use the same offset-partition as line-series and emit the
- * same one-time warning recommending an explicit `selectors` entry.
+ * scatter charts hand the candidates out with the same running cursor as
+ * line-series and emit the same one-time warning recommending an explicit
+ * `selectors` entry.
  *
  * Idempotent — re-running on a chart that has already been stamped is a
  * no-op.
@@ -1547,6 +1551,10 @@ function stampScatterAttributes(
   }
 
   let multiSeriesWarned = false;
+  // See {@link stampLineAttributes}: a running cursor over the candidates the
+  // earlier series took, not `s * pointCount`, which counts the series this
+  // loop skipped and assumes every series is the same length.
+  let consumed = 0;
 
   for (let s = 0; s < seriesCount; s++) {
     const series = chart.getSeriesAt(s);
@@ -1566,25 +1574,19 @@ function stampScatterAttributes(
     if (pointCount === 0)
       continue;
 
-    let stampStart = 0;
-    let stampEnd = 0;
-    if (seriesCount === 1) {
-      stampStart = 0;
-      stampEnd = Math.min(pointCount, candidates.length);
-    } else {
-      if (!multiSeriesWarned) {
-        console.warn(
-          '[maidr/anychart] Multi-series scatter highlighting uses an '
-          + 'offset-based partition of marker candidates and may misattribute '
-          + 'points across series with overlapping geometry. For precise '
-          + 'highlighting, pass an explicit `selectors` entry to bindAnyChart().',
-        );
-        multiSeriesWarned = true;
-      }
-      const offset = s * pointCount;
-      stampStart = offset;
-      stampEnd = Math.min(offset + pointCount, candidates.length);
+    if (seriesCount > 1 && !multiSeriesWarned) {
+      console.warn(
+        '[maidr/anychart] Multi-series scatter highlighting uses an '
+        + 'offset-based partition of marker candidates and may misattribute '
+        + 'points across series with overlapping geometry. For precise '
+        + 'highlighting, pass an explicit `selectors` entry to bindAnyChart().',
+      );
+      multiSeriesWarned = true;
     }
+
+    const stampStart = consumed;
+    const stampEnd = Math.min(consumed + pointCount, candidates.length);
+    consumed = stampEnd;
 
     if (stampEnd - stampStart < pointCount) {
       console.warn(

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -433,19 +433,26 @@ function hasOrdinalXScale(chart: AnyChartInstance): boolean {
  * A horizontal bar runs its categories down the page, and inverting is what
  * puts the first one at the top; a vertical column runs them across, and not
  * inverting is what puts the first one at the left. So the reading is
- * backwards exactly when `inverted()` disagrees with the series' own
- * direction, which is `'bar'` for horizontal and `'column'` for vertical --
- * and an ordinary chart of either kind is left alone.
+ * backwards exactly when `inverted()` disagrees with the **chart's** own
+ * direction -- and an ordinary chart of either kind is left alone.
+ *
+ * The chart's, not the series': only a bar or column series names the
+ * arrangement, and a line, area or step overlaid on `anychart.bar()` reports
+ * `'line'` / `'area'` / `'step-line'` while being drawn down the page like
+ * everything else in that chart. Reading the direction off such a series gets
+ * it backwards both ways -- reversing the default bar chart, which draws in
+ * listed order, and leaving the un-inverted one, which does not.
+ * {@link drawsHorizontally} is the same question {@link HORIZONTAL_CHART_TYPES}
+ * answers for the orientation key.
  *
  * The **x** scale specifically: inverting the value scale was measured to move
  * no category, only which end the bars hang from, so asking "is either scale
  * inverted" would reorder a chart that did not move.
  *
- * Defensive in the same shape as {@link hasOrdinalXScale} -- a chart or series
- * that cannot be asked keeps the reading it has today.
+ * Defensive in the same shape as {@link hasOrdinalXScale} -- a chart that
+ * cannot be asked keeps the reading it has today.
  *
  * @param chart - The chart the series belongs to
- * @param series - The bar or column series being read
  * @returns True when the drawn order is the reverse of the listed order
  */
 /**
@@ -475,8 +482,8 @@ const REVERSIBLE_ON_INVERSION = new Set<AnyChartTraceType>([
  * `anychart.column()` the upright one, and every series inside them follows --
  * a `marker` in a bar chart is a Cleveland dot plot, a `stick` is a sideways
  * lollipop, a `range-bar` a sideways dumbbell. So the question is the chart's
- * rather than the series', which is why {@link drawsCategoriesReversed} can
- * read the series' own name and this cannot.
+ * rather than the series', which is why {@link drawsCategoriesReversed} asks
+ * this too rather than reading the name of the series it is converting.
  *
  * `barmekko` is deliberately absent: AnyChart's bar mekko is a column chart
  * whose widths vary, drawn upright -- measured, `getType()` answers
@@ -494,14 +501,10 @@ function drawsHorizontally(chart: AnyChartInstance): boolean {
   return HORIZONTAL_CHART_TYPES.has(readChartType(chart));
 }
 
-function drawsCategoriesReversed(
-  chart: AnyChartInstance,
-  series: AnyChartSeries,
-): boolean {
+function drawsCategoriesReversed(chart: AnyChartInstance): boolean {
   try {
     const inverted = chart.xScale?.()?.inverted?.() === true;
-    const horizontal = series.seriesType() === 'bar';
-    return inverted !== horizontal;
+    return inverted !== drawsHorizontally(chart);
   } catch {
     return false;
   }
@@ -6505,7 +6508,7 @@ function buildSubplot(
     // and there is nothing to permute (#1035).
     const invertedCategories = REVERSIBLE_ON_INVERSION.has(traceType)
       && !hasSelectorOverrides
-      && drawsCategoriesReversed(chart, series);
+      && drawsCategoriesReversed(chart);
     const layer = buildLayer(
       chart,
       series,

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -6479,7 +6479,20 @@ function buildSubplot(
     if (divergingIndices.has(i))
       continue;
 
-    const anyChartType = series.seriesType();
+    // Guarded like every other `seriesType()` call in this file: the adapter
+    // does not trust it, and unwrapped here the throw leaves `buildSubplot`,
+    // `anyChartToMaidr` and `bindAnyChart` in turn, landing in the caller's
+    // own page script — the chart is not bound, and nothing written after the
+    // bind call runs either.
+    let anyChartType = '';
+    try {
+      anyChartType = series.seriesType();
+    } catch {
+      console.warn(
+        `[maidr/anychart] Series ${i} could not name its type. Skipping it.`,
+      );
+      continue;
+    }
 
     if (anyChartType === 'waterfall') {
       waterfalls.push({ series, index: i });

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -1525,34 +1525,6 @@ function stampScatterAttributes(
   });
   candidates.sort((a, b) => (a.x - b.x) || (a.y - b.y));
 
-  // Diagnostic: surface the candidate count up-front so users / developers
-  // can tell at a glance whether the geometric filter actually found
-  // scatter markers. Zero or far-too-few candidates almost always means the
-  // visibility filter rejected the points (see the Phase 9 / Phase 11B
-  // attribute vs. computed-style issue) — not a downstream stamping bug.
-  let expectedTotalPoints = 0;
-  for (let s = 0; s < seriesCount; s++) {
-    const series = chart.getSeriesAt(s);
-    if (!series)
-      continue;
-    let seriesType = '';
-    try {
-      seriesType = series.seriesType();
-    } catch {
-      continue;
-    }
-    if (!SCATTER_LIKE_SERIES_TYPES.has(seriesType))
-      continue;
-    expectedTotalPoints += extractRawRows(series).length;
-  }
-  if (expectedTotalPoints > 0) {
-    console.warn(
-      `[maidr/anychart] scatter: collected ${candidates.length} marker `
-      + `candidates, expected ${expectedTotalPoints} points across `
-      + `${seriesCount} series.`,
-    );
-  }
-
   let multiSeriesWarned = false;
   // See {@link stampLineAttributes}: a running cursor over the candidates the
   // earlier series took, not `s * pointCount`, which counts the series this
@@ -2080,10 +2052,10 @@ function stampBoxAttributes(
         median.setAttribute(BOX_ATTR, `${stampPrefix}${s}-${b}`);
         median.setAttribute(BOX_PART_ATTR, 'q2');
       } else if (!median) {
-        // DIAGNOSTIC (temporary, removed once box highlighting is verified):
-        // surface the IQR bbox so we can see whether the median scan missed
-        // a real element or AnyChart genuinely didn't emit one for this box
-        // (can happen when median color matches IQR fill).
+        // A box whose median stroke was not found highlights without its
+        // middle line, so this is a real shortfall rather than a trace: the
+        // bbox is what says whether the scan missed an element or AnyChart
+        // drew none (which it can, when the median colour matches the fill).
         console.warn(
           `[maidr/anychart] Box ${s}-${b}: no median found. IQR bbox:`,
           iq.bbox,
@@ -2092,8 +2064,8 @@ function stampBoxAttributes(
 
       const whiskers = findWhiskerElements(svg, iq);
       if (whiskers.length !== 2) {
-        // DIAGNOSTIC (temporary): expected exactly two whisker segments
-        // (min stem + max stem). Other counts indicate a scan miss.
+        // A box has exactly two stems, a min and a max. Any other count means
+        // one of them will not highlight.
         console.warn(
           `[maidr/anychart] Box ${s}-${b}: expected 2 whiskers, found `
           + `${whiskers.length}. IQR cx=${iq.cx.toFixed(1)}, `
@@ -2105,49 +2077,6 @@ function stampBoxAttributes(
           continue;
         el.setAttribute(BOX_ATTR, `${stampPrefix}${s}-${b}`);
         el.setAttribute(BOX_PART_ATTR, isUpper ? 'max' : 'min');
-      }
-    }
-
-    // DIAGNOSTIC: one-line summary per series so we can verify which
-    // per-part stamps succeeded without browser DevTools. Remove once
-    // box highlighting is confirmed working end-to-end.
-    const stampedIq = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="iq"]`,
-    ).length;
-    const stampedQ2 = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="q2"]`,
-    ).length;
-    const stampedMin = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="min"]`,
-    ).length;
-    const stampedMax = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="max"]`,
-    ).length;
-    // Using console.warn (not console.log) so the diagnostic surfaces under
-    // the repo's no-console ESLint rule. This whole block is temporary.
-    console.warn(
-      `[maidr/anychart] stampBoxAttributes series ${s}: ${boxCount} boxes, `
-      + `stamped ${stampedIq} iq / ${stampedQ2} q2 / `
-      + `${stampedMin} min / ${stampedMax} max`,
-    );
-
-    // Per-box detail: report any box missing one or more parts so we can
-    // pinpoint failures from a single console line. Temporary diagnostic.
-    for (let b = 0; b < boxCount; b++) {
-      const base = `[${BOX_ATTR}="${stampPrefix}${s}-${b}"]`;
-      const missing: string[] = [];
-      if (!svg.querySelector(`${base}[${BOX_PART_ATTR}="iq"]`))
-        missing.push('iq');
-      if (!svg.querySelector(`${base}[${BOX_PART_ATTR}="q2"]`))
-        missing.push('q2');
-      if (!svg.querySelector(`${base}[${BOX_PART_ATTR}="min"]`))
-        missing.push('min');
-      if (!svg.querySelector(`${base}[${BOX_PART_ATTR}="max"]`))
-        missing.push('max');
-      if (missing.length > 0) {
-        console.warn(
-          `[maidr/anychart]   Box ${s}-${b} missing: ${missing.join(', ')}`,
-        );
       }
     }
   }

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -2216,10 +2216,13 @@ function findHeatmapCellLayer(svg: SVGElement): Element {
  *
  * Cells are identified via AnyChart's stable auto-id conventions:
  * `ac_layer_*` groups scoped to the layer with the most `ac_rect_*` shapes
- * (see {@link findHeatmapCellLayer}). DOM order within the layer is
- * row-major (top→bottom, then left→right), matching the
- * `HeatmapData { x, y, points }` layout produced by
- * {@link buildHeatmapLayerFromChart}.
+ * (see {@link findHeatmapCellLayer}). AnyChart draws one shape per data row,
+ * in the order the rows were written, so the nth shape carries the nth row's
+ * own `(x, y)` pair — which is what names it, rather than its position among
+ * its siblings. Counting off `row = i / cols` instead was right only for a
+ * grid that is both dense and written row-major: a heat map written
+ * `for x: for y:` had every cell's coordinates transposed, and a sparse one
+ * had every cell after the hole shifted a slot early.
  *
  * Only runs for charts whose `getType()` returns a string containing
  * `'heat'`; on other chart types this is a no-op.
@@ -2257,32 +2260,12 @@ function stampHeatmapAttributes(
   if (!iterator)
     return;
 
-  // Count cells + collect distinct x/y labels in insertion order so we know
-  // the expected grid dimensions and can map flat DOM order to (row,col).
-  const xLabels: string[] = [];
-  const yLabels: string[] = [];
-  const xSet = new Set<string>();
-  const ySet = new Set<string>();
-  let cellCount = 0;
-  iterator.reset();
-  while (iterator.advance()) {
-    cellCount++;
-    const x = asString(iterator.get('x'));
-    const y = asString(iterator.get('y') ?? iterator.get('name'));
-    if (!xSet.has(x)) {
-      xLabels.push(x);
-      xSet.add(x);
-    }
-    if (!ySet.has(y)) {
-      yLabels.push(y);
-      ySet.add(y);
-    }
-  }
-  if (cellCount === 0)
+  // Each row's own (x, y) pair, in the order the rows were written — which is
+  // the order AnyChart draws them in. The coordinates belong to the row, not
+  // to the shape's position among its siblings.
+  const cells = readHeatmapCells(iterator);
+  if (cells.length === 0)
     return;
-
-  const cols = xLabels.length;
-  const rows = yLabels.length;
 
   // Locate the heatmap cell layer via AnyChart's stable id conventions,
   // then collect shape elements directly from that layer. This is the
@@ -2315,19 +2298,57 @@ function stampHeatmapAttributes(
     cellCandidates.push(el);
   }
 
-  // Layer + id-prefix scoping should yield exactly rows*cols cells. Any
-  // mismatch indicates either an unexpected AnyChart DOM layout (perhaps a
-  // future version that changes the auto-id convention) or a chart that
-  // hasn't fully rendered yet. We continue best-effort by stamping as many
-  // cells as we have candidates for.
-  const stampCount = Math.min(cellCandidates.length, rows * cols);
+  // Layer + id-prefix scoping should yield exactly one candidate per drawn
+  // row. Any mismatch indicates either an unexpected AnyChart DOM layout
+  // (perhaps a future version that changes the auto-id convention) or a chart
+  // that hasn't fully rendered yet. We continue best-effort by stamping as
+  // many cells as we have candidates for.
+  const stampCount = Math.min(cellCandidates.length, cells.length);
   for (let i = 0; i < stampCount; i++) {
-    const r = Math.floor(i / cols);
-    const c = i % cols;
     const el = cellCandidates[i];
     if (!el.hasAttribute(HEATMAP_ATTR))
-      el.setAttribute(HEATMAP_ATTR, `${stampPrefix}${r}-${c}`);
+      el.setAttribute(HEATMAP_ATTR, `${stampPrefix}${cells[i].row}-${cells[i].col}`);
   }
+}
+
+/**
+ * One entry per row the chart carries: the pair it names, and the grid
+ * coordinates that pair resolves to.
+ *
+ * `row` indexes the y labels in the order they first appear and `col` the x
+ * labels, which is exactly how {@link buildHeatmapLayerFromChart} fills its
+ * `points` rectangle — so a cell's stamp and its place in the payload are the
+ * same two numbers, whatever order the rows were written in and whether or not
+ * they fill the grid.
+ *
+ * @param iterator - The chart's data iterator
+ * @returns One `{ row, col }` per data row, in the order they are drawn
+ */
+function readHeatmapCells(
+  iterator: AnyChartIterator,
+): Array<{ row: number; col: number }> {
+  const xLabels: string[] = [];
+  const yLabels: string[] = [];
+  const xIndex = new Map<string, number>();
+  const yIndex = new Map<string, number>();
+  const cells: Array<{ row: number; col: number }> = [];
+
+  iterator.reset();
+  while (iterator.advance()) {
+    const x = asString(iterator.get('x'));
+    const y = asString(iterator.get('y') ?? iterator.get('name'));
+    if (!xIndex.has(x)) {
+      xIndex.set(x, xLabels.length);
+      xLabels.push(x);
+    }
+    if (!yIndex.has(y)) {
+      yIndex.set(y, yLabels.length);
+      yLabels.push(y);
+    }
+    cells.push({ row: yIndex.get(y) ?? 0, col: xIndex.get(x) ?? 0 });
+  }
+
+  return cells;
 }
 
 // ---------------------------------------------------------------------------
@@ -4991,28 +5012,42 @@ function buildHeatmapLayerFromChart(
       points[yi][xi] = r.v;
   }
 
+  // One selector per drawn cell, named by the coordinates
+  // `stampHeatmapAttributes` stamped it with — not one prefix resolved in
+  // document order. A prefix pairs elements with cells by position, so a heat
+  // map whose rows do not fill the grid resolves fewer elements than the
+  // rectangle has cells and `Heatmap.mapToSvgElements` withdraws the mapping
+  // whole, costing every drawn cell its highlight too.
+  //
+  // Written bottom-first, because `Heatmap` reverses the payload's rows so
+  // that row 0 is the foot of the grid — the direction navigation counts in.
+  // `null` marks a cell no row named, which the model keeps as a hole rather
+  // than failing the grid over.
+  const scope = panelScope(panel);
+  const prefix = panelStampPrefix(panel);
+  const grid: (string | null)[][] = Array.from(
+    { length: yLabels.length },
+    () => Array.from<string | null>({ length: xLabels.length }).fill(null),
+  );
+  for (const r of rows) {
+    const xi = xLabels.indexOf(r.x);
+    const yi = yLabels.indexOf(r.y);
+    if (xi >= 0 && yi >= 0)
+      grid[yLabels.length - 1 - yi][xi] = `${scope}[${HEATMAP_ATTR}="${prefix}${yi}-${xi}"]`;
+  }
+
   const data: HeatmapData = { x: xLabels, y: yLabels, points };
-  const defaultSelector = `${panelScope(panel)}[${HEATMAP_ATTR}]`;
   return {
     id: '0',
     type: TraceType.HEATMAP,
-    selectors: selectors ?? defaultSelector,
+    selectors: selectors ?? grid,
     data,
-    // `stampHeatmapAttributes` walks the chart's cells in row-major order
-    // (`r * cols + c`). `Heatmap.mapToSvgElements` defaults to a
-    // column-major mapping for <rect> cells unless told otherwise — that
-    // mismatch would either transpose the highlight grid or fail the
-    // `domElements.length === rows * cols` invariant. Mirror the D3
-    // heatmap binder's `domMapping: { order: 'row' }` hint so the model
-    // groups the stamped cells the way they were laid out.
-    //
-    // NOTE: AnyChart's production GraphicsJS renderer emits heatmap cells
-    // as <path> elements, not <rect>. The path branch of
-    // `Heatmap.mapToSvgElements` unconditionally uses row-major with
-    // row-reversal and ignores `domMapping.order` entirely — so this hint
-    // is a no-op for current AnyChart heatmaps. It is retained as
-    // defensive coverage for any alternative AnyChart build (or future
-    // renderer change) that emits <rect> cells instead.
+    // Only read when a caller passed their own single selector, which
+    // `Heatmap.mapToSvgElements` still resolves by position: AnyChart draws
+    // its cells row-major, and the model's <rect> branch would otherwise
+    // group them column-major and transpose the whole grid. The adapter's own
+    // selectors are the per-cell grid above, which names each cell rather than
+    // counting to it, so this says nothing about them.
     domMapping: { order: 'row' },
   };
 }

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -402,6 +402,34 @@ function buildLayers(
   }
 }
 
+/**
+ * The dataset a single-series chart is converted from.
+ *
+ * Frappe's own `dataPrep` substitutes a default dataset only when `datasets`
+ * is missing entirely — an explicit `[]` survives construction, and the
+ * adapter also accepts a plain `{ data }` object Frappe never normalised. That
+ * used to surface as a bare `TypeError` from inside `labels.map`, thrown out
+ * of the settle callback the host page calls the adapter from: on the grid API
+ * it skips every remaining panel, so one malformed panel takes the whole
+ * dashboard down. Naming the fault keeps it local, as the diverging and
+ * panel-grid paths already do for their own malformed input.
+ *
+ * @param data      - The chart's labels and datasets
+ * @param chartName - What to call the chart in the message
+ * @returns The chart's first dataset
+ * @throws If the chart carries no dataset at all
+ */
+function soleDataset(data: FrappeData, chartName: string): FrappeDataset {
+  const dataset = data.datasets[0];
+  if (!dataset) {
+    throw new Error(
+      `[maidr/frappe] A ${chartName} needs at least one dataset; this chart's `
+      + '`datasets` array is empty.',
+    );
+  }
+  return dataset;
+}
+
 function buildBarLayer(
   data: FrappeData,
   containerId: string,
@@ -419,7 +447,7 @@ function buildBarLayer(
     );
   }
 
-  const dataset = data.datasets[0];
+  const dataset = soleDataset(data, 'bar chart');
   const points: BarPoint[] = data.labels.map((label, i) => ({
     x: label,
     y: dataset.values[i],
@@ -500,7 +528,7 @@ function buildScatterLayer(
     );
   }
 
-  const dataset = data.datasets[0];
+  const dataset = soleDataset(data, 'scatter plot');
   const points: ScatterPoint[] = data.labels.map((label, i) => ({
     x: Number(label),
     y: dataset.values[i],
@@ -557,7 +585,7 @@ function buildDotLayer(
     );
   }
 
-  const dataset = data.datasets[0];
+  const dataset = soleDataset(data, 'dot plot');
   const points: BarPoint[] = data.labels.map((label, i) => ({
     x: label,
     y: dataset.values[i],

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -33,7 +33,7 @@ import {
   lineSelectorForDataset,
   nextId,
   percentageBarSelector,
-  scatterSelector,
+  scatterSelectorForDataset,
   sliceSelector,
 } from './selectors';
 
@@ -487,6 +487,19 @@ function buildScatterLayer(
   containerId: string,
   options: FrappeChartAdapterOptions,
 ): MaidrLayer {
+  // Only the first dataset is converted, so scope the selector to its own
+  // `.dataset-0` group, as the bar and dot builders do. The broad line
+  // selector matches every group's circles, and `ScatterTrace` groups its
+  // elements by `cx`/`cy` rather than rejecting the count mismatch — so the
+  // surplus is absorbed silently and the outline lands on a mark belonging to
+  // a series the reader is never told about.
+  if (data.datasets.length > 1) {
+    console.warn(
+      `[maidr/frappe] Scatter plot has ${data.datasets.length} datasets; only the `
+      + 'first is converted. Multi-series scatter plots are not yet supported.',
+    );
+  }
+
   const dataset = data.datasets[0];
   const points: ScatterPoint[] = data.labels.map((label, i) => ({
     x: Number(label),
@@ -496,7 +509,7 @@ function buildScatterLayer(
   return {
     id: nextId('layer'),
     type: TraceType.SCATTER,
-    selectors: scatterSelector(containerId),
+    selectors: scatterSelectorForDataset(containerId, 0),
     axes: buildAxes(options),
     data: points,
   };

--- a/src/adapters/frappe/selectors.ts
+++ b/src/adapters/frappe/selectors.ts
@@ -106,9 +106,18 @@ export function lineSelectorForDataset(containerId: string, index: number): stri
   return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-line.dataset-${index} circle`;
 }
 
-/** Scoped selector for scatter point circles (rendered in the line dataset group). */
-export function scatterSelector(containerId: string): string {
-  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-line circle`;
+/**
+ * Scoped selector for the scatter point circles of one dataset (scatter points
+ * are rendered in the line dataset group).
+ *
+ * Scoped to `.dataset-{index}` for the same reason the bar and dot selectors
+ * are: only one dataset is converted, and the unscoped group selector would
+ * match every dataset's circles. `ScatterTrace` groups its elements by
+ * geometry rather than rejecting a count mismatch, so a surplus is absorbed
+ * silently and highlights a mark the reader is never told about.
+ */
+export function scatterSelectorForDataset(containerId: string, index: number): string {
+  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-line.dataset-${index} circle`;
 }
 
 /**

--- a/src/adapters/frappe/selectors.ts
+++ b/src/adapters/frappe/selectors.ts
@@ -24,8 +24,15 @@
  * (`lineOptions.dotSize > 0`, and no `hideDots`).
  *
  * Every selector is scoped to the container element's `id` so that charts
- * elsewhere on the same page are never matched.
+ * elsewhere on the same page are never matched. HTML5 admits ids that are not
+ * valid CSS identifiers — `my.chart`, `2024-sales` — so the id is run through
+ * `cssEscape` before it is embedded. Unescaped, the first silently matches
+ * nothing (highlighting is dropped while every announcement stays correct) and
+ * the second throws a `SyntaxError` out of `document.querySelectorAll`, which
+ * aborts construction of the whole figure.
  */
+
+import { cssEscape } from '../shared/selectorUtil';
 
 let idCounter = 0;
 
@@ -70,7 +77,7 @@ export function ensureContainerId(container: HTMLElement): void {
  * broad selector rather than the per-dataset one below.
  */
 export function barSelector(containerId: string): string {
-  return `#${containerId} svg.frappe-chart .dataset-units.dataset-bars rect.bar`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-bars rect.bar`;
 }
 
 /**
@@ -81,7 +88,7 @@ export function barSelector(containerId: string): string {
  * every group's rects and highlighting is dropped on the count mismatch).
  */
 export function barSelectorForDataset(containerId: string, index: number): string {
-  return `#${containerId} svg.frappe-chart .dataset-units.dataset-bars.dataset-${index} rect.bar`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-bars.dataset-${index} rect.bar`;
 }
 
 /**
@@ -91,17 +98,17 @@ export function barSelectorForDataset(containerId: string, index: number): strin
  * dots rather than the single `<path>`. Requires `lineOptions.dotSize > 0`.
  */
 export function lineSelector(containerId: string): string {
-  return `#${containerId} svg.frappe-chart .dataset-units.dataset-line circle`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-line circle`;
 }
 
 /** Scoped selector for the per-point dot circles of one line dataset (multi-line charts). */
 export function lineSelectorForDataset(containerId: string, index: number): string {
-  return `#${containerId} svg.frappe-chart .dataset-units.dataset-line.dataset-${index} circle`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-line.dataset-${index} circle`;
 }
 
 /** Scoped selector for scatter point circles (rendered in the line dataset group). */
 export function scatterSelector(containerId: string): string {
-  return `#${containerId} svg.frappe-chart .dataset-units.dataset-line circle`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .dataset-units.dataset-line circle`;
 }
 
 /**
@@ -117,7 +124,7 @@ export function scatterSelector(containerId: string): string {
  * @returns The selector matching one element per slice, in slice order.
  */
 export function sliceSelector(containerId: string, chartType: 'donut' | 'pie'): string {
-  return `#${containerId} svg.frappe-chart .${chartType}-slices path.${chartType}-path`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .${chartType}-slices path.${chartType}-path`;
 }
 
 /**
@@ -132,5 +139,5 @@ export function sliceSelector(containerId: string, chartType: 'donut' | 'pie'): 
  * @returns The selector matching one element per band, in band order.
  */
 export function percentageBarSelector(containerId: string): string {
-  return `#${containerId} svg.frappe-chart .percentage-bars rect.percentage-bar`;
+  return `#${cssEscape(containerId)} svg.frappe-chart .percentage-bars rect.percentage-bar`;
 }

--- a/src/adapters/observable/converters.ts
+++ b/src/adapters/observable/converters.ts
@@ -1131,7 +1131,20 @@ function convertHexbin(facet: MarkFacet, context: ConversionContext): ConvertedM
     layer: {
       id: token,
       type: TraceType.HEXBIN,
-      selectors: stampLayer(ordered.flat().map(bin => bin.element), context.containerId, token),
+      // One selector per bin, in lattice order. A single selector resolves
+      // through `querySelectorAll`, which answers in *document* order, and
+      // Plot draws the hexagons largest-radius-first — so document order is
+      // neither row order nor left-to-right within a row. `HexbinTrace` pairs
+      // the flat match with the bins by position and its count check passes
+      // either way, so one selector silently outlines a bin the reader is not
+      // being told about. `orderElements` is not the answer here as it is for
+      // the tiling marks: hexagons overlap, and re-appending them would put
+      // the small bins behind the large ones.
+      selectors: stampSeries(
+        ordered.flat().map(bin => [bin.element]),
+        context.containerId,
+        token,
+      ),
       axes: axisConfig(context),
       data: ordered.map(row => row.map(({ x, y, count }) => ({ x, y, count }))),
     },

--- a/src/adapters/observable/scales.ts
+++ b/src/adapters/observable/scales.ts
@@ -284,6 +284,29 @@ function rangePixels(scale: PlotScale | undefined): number {
   return Math.abs(hi - lo);
 }
 
+/** One category's span in pixels, as {@link bandIntervals} reports it. */
+interface BandInterval {
+  value: string | number;
+  start: number;
+  end: number;
+  center: number;
+}
+
+/**
+ * The intervals already built for a scale.
+ *
+ * `valueAtPixel` is asked once per drawn element and the answer depends only
+ * on the scale, so without this a mark of N elements over a D-category axis
+ * costs N x D `apply` calls, N x D allocations and N sorts of D entries — and
+ * the watcher re-runs the whole conversion on every OJS redraw, so a slider
+ * drag pays it per frame.
+ *
+ * Keyed on the scale object and weakly held: `readScales` calls
+ * `plot.scale(name)`, which hands back a fresh descriptor per render, so a
+ * redrawn chart is a cache miss rather than a stale hit.
+ */
+const intervalCache = new WeakMap<PlotScale, BandInterval[]>();
+
 /**
  * The pixel intervals a band or point scale assigns to its categories.
  *
@@ -292,12 +315,29 @@ function rangePixels(scale: PlotScale | undefined): number {
  * pixel to a category by equality fails. Intervals let
  * {@link valueAtPixel} ask which band contains a point instead.
  *
+ * Built once per scale. The result describes the scale alone, so every caller
+ * reading the same chart gets the same array back rather than rebuilding it.
+ *
  * @param scale - A band, point, or ordinal scale.
  * @returns One entry per domain value, ordered by pixel position.
  */
-export function bandIntervals(
-  scale: PlotScale,
-): { value: string | number; start: number; end: number; center: number }[] {
+export function bandIntervals(scale: PlotScale): BandInterval[] {
+  const cached = intervalCache.get(scale);
+  if (cached !== undefined)
+    return cached;
+
+  const built = buildBandIntervals(scale);
+  intervalCache.set(scale, built);
+  return built;
+}
+
+/**
+ * Measures a scale's category spans, without consulting the cache.
+ *
+ * @param scale - A band, point, or ordinal scale.
+ * @returns One entry per domain value, ordered by pixel position.
+ */
+function buildBandIntervals(scale: PlotScale): BandInterval[] {
   const apply = scale.apply;
   if (typeof apply !== 'function')
     return [];

--- a/src/adapters/shared/selectorUtil.ts
+++ b/src/adapters/shared/selectorUtil.ts
@@ -34,7 +34,8 @@ export function nextId(prefix: string): string {
  * Escapes a string for use in a CSS selector.
  *
  * Uses the native `CSS.escape` when available (browsers), and falls back to a
- * conservative escape for Node.js / SSR environments where `CSS` is undefined.
+ * conservative escape for Node.js / SSR environments where `CSS` is undefined
+ * — jsdom included, which implements no `CSS` object at all.
  *
  * @param value - The raw string to escape.
  * @returns The escaped string, safe to embed in a CSS selector.
@@ -44,7 +45,14 @@ export function cssEscape(value: string): string {
     return CSS.escape(value);
   }
   // Fallback: escape every character that is special in a CSS identifier.
-  return value.replace(/([^\w-])/g, '\\$1');
+  const escaped = value.replace(/([^\w-])/g, '\\$1');
+  // A leading digit — optionally behind a hyphen — cannot start an identifier
+  // however the rest is escaped, so `#2024-sales` is not a selector that
+  // matches nothing but one the parser rejects outright, throwing out of
+  // `querySelectorAll`. The native `CSS.escape` writes it as a numeric escape
+  // (`\32 024-sales`); digits are U+0030-U+0039, so the code point is always
+  // `3` followed by the digit itself, and the trailing space terminates it.
+  return escaped.replace(/^(-?)(\d)/, (_, hyphen: string, digit: string) => `${hyphen}\\3${digit} `);
 }
 
 /**

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -728,6 +728,30 @@ describe('anyChartToMaidr (single panel, unchanged)', () => {
     const chart = createChart({ series: [createSeries('funnel', [{ x: 'A', value: 1 }])] });
     expect(anyChartToMaidr(chart)).toBeNull();
   });
+
+  it('skips a series that cannot name its type and keeps the rest', () => {
+    // Every other `seriesType()` call in the adapter is wrapped, precisely
+    // because it is not trusted. Unwrapped here, the throw leaves
+    // `anyChartToMaidr`, and through `bindAnyChart` it leaves the caller's own
+    // page script: the chart is not bound and nothing after the bind call
+    // runs either.
+    const broken = {
+      ...createSeries('column', [{ x: 'A', value: 1 }]),
+      seriesType: () => {
+        throw new Error('series type unavailable');
+      },
+    } as unknown as AnyChartSeries;
+    const chart = createChart({
+      title: 'Tips',
+      series: [broken, createBarSeries([['Sat', 87]])],
+    });
+
+    const result = anyChartToMaidr(chart);
+
+    expect(result?.subplots[0][0].layers).toHaveLength(1);
+    expect(result?.subplots[0][0].layers[0].data as BarPoint[])
+      .toEqual([{ x: 'Sat', y: 87 }]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -2306,9 +2306,15 @@ describe('anyChartsToMaidr', () => {
     expect(heatLayer.type).toBe(TraceType.HEATMAP);
     expect(heatLayer.id).toBe('0_0_0');
     expect(heatLayer.title).toBe('Heat');
-    expect(heatLayer.selectors).toBe(
-      '[data-maidr-anychart-panel="fig-0-0"] [data-maidr-anychart-heatmap-cell]',
-    );
+    // One selector per cell, each carrying the panel token twice over: in the
+    // scope, and in the stamped value itself, so two independently bound
+    // figures cannot answer for each other's cells.
+    expect(heatLayer.selectors).toEqual([[
+      '[data-maidr-anychart-panel="fig-0-0"] '
+      + '[data-maidr-anychart-heatmap-cell="fig-0-0:0-0"]',
+      '[data-maidr-anychart-panel="fig-0-0"] '
+      + '[data-maidr-anychart-heatmap-cell="fig-0-0:0-1"]',
+    ]]);
   });
 
   it('applies figure-level axes overrides but keeps per-panel extraction otherwise', () => {

--- a/test/adapters/anychart/heatmapCellMapping.test.ts
+++ b/test/adapters/anychart/heatmapCellMapping.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Which cell of an AnyChart heat map each drawn shape belongs to.
+ *
+ * The stamper derived a cell's coordinates from its position in the DOM —
+ * `row = i / cols`, `col = i % cols` — which is only right when the rows are
+ * dense AND written row-major. AnyChart draws one shape per row it was given,
+ * in the order it was given them, so the coordinates belong to the row, not to
+ * the count.
+ *
+ * Both departures are ordinary. A heat map written `for x: for y:` is drawn
+ * column-major, and one that names only the pairs it has a value for is the
+ * sparse case #1191 already recognises on the data side.
+ */
+
+import type { AnyChartInstance } from '@adapters/anychart/types';
+import type { MaidrLayer } from '@type/grammar';
+import { bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const HEATMAP_ATTR = 'data-maidr-anychart-heatmap-cell';
+
+interface Row { x: string; y: string; heat: number }
+
+/**
+ * A drawn heat map: one `ac_rect_` path per row, in the order the rows were
+ * written, which is the order AnyChart draws them in.
+ */
+function createHeatChart(rows: Row[], id: string): {
+  chart: AnyChartInstance;
+  container: HTMLElement;
+  cells: SVGElement[];
+} {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  const layer = document.createElementNS(SVG_NS, 'g');
+  layer.id = 'ac_layer_1';
+  // `findHeatmapCellLayer` only considers clipped layers, which is what tells
+  // the plot area from the chrome around it.
+  layer.setAttribute('clip-path', 'url(#c)');
+  svg.appendChild(layer);
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  const cells = rows.map((row, i) => {
+    const cell = document.createElementNS(SVG_NS, 'path');
+    cell.id = `ac_rect_${i}`;
+    cell.setAttribute('fill', '#4269d0');
+    // Names the datum the shape was drawn for, so the assertions can say which
+    // cell each resolved element is.
+    cell.setAttribute('data-heat', String(row.heat));
+    layer.appendChild(cell);
+    return cell as unknown as SVGElement;
+  });
+
+  let cursor = -1;
+  const chart = {
+    title: () => 'Heat',
+    container: () => container,
+    getType: () => 'heat-map',
+    getSeriesCount: () => 0,
+    getSeriesAt: () => null,
+    data: () => ({
+      getIterator: () => ({
+        reset: () => {
+          cursor = -1;
+        },
+        advance: () => {
+          cursor += 1;
+          return cursor < rows.length;
+        },
+        get: (key: string) => (rows[cursor] as unknown as Record<string, unknown>)[key],
+      }),
+    }),
+  } as unknown as AnyChartInstance;
+
+  return { chart, container, cells };
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+/** The `data-heat` of whatever one cell selector resolves to. */
+function heatAt(selector: string | null): string | null {
+  if (selector === null) {
+    return null;
+  }
+  return document.querySelector(selector)?.getAttribute('data-heat') ?? null;
+}
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('an anychart heat map written column-major', () => {
+  it('takes each cell\'s coordinates from its own row, not from its position', () => {
+    // `for x: for y:` — X1Y1, X1Y2, X2Y1, X2Y2. Counting off row-major calls
+    // the second shape (0, 1) when it is really (1, 0), and the third (1, 0)
+    // when it is really (0, 1): the two are swapped for the whole grid.
+    const { chart, container, cells } = createHeatChart([
+      { x: 'X1', y: 'Y1', heat: 1 },
+      { x: 'X1', y: 'Y2', heat: 2 },
+      { x: 'X2', y: 'Y1', heat: 3 },
+      { x: 'X2', y: 'Y2', heat: 4 },
+    ], 'heat-colmajor');
+
+    bindAnyChart(chart);
+
+    expect(cells.map(cell => cell.getAttribute(HEATMAP_ATTR)))
+      .toEqual(['0-0', '1-0', '0-1', '1-1']);
+
+    cleanUp(container);
+  });
+});
+
+describe('an anychart heat map whose rows do not fill the grid', () => {
+  /** Y1 has only X1; Y2 has both. The (X2, Y1) cell is never drawn. */
+  const SPARSE: Row[] = [
+    { x: 'X1', y: 'Y1', heat: 3 },
+    { x: 'X1', y: 'Y2', heat: 5 },
+    { x: 'X2', y: 'Y2', heat: 6 },
+  ];
+
+  it('names every drawn cell by the pair its row carries', () => {
+    const { chart, container, cells } = createHeatChart(SPARSE, 'heat-sparse-stamp');
+
+    bindAnyChart(chart);
+
+    expect(cells.map(cell => cell.getAttribute(HEATMAP_ATTR)))
+      .toEqual(['0-0', '1-0', '1-1']);
+
+    cleanUp(container);
+  });
+
+  it('emits a per-cell selector grid with a hole where nothing was drawn', () => {
+    // One prefix selector resolves to three elements for a 2x2 grid, and
+    // `Heatmap.mapToSvgElements` withdraws the whole mapping on that count
+    // mismatch — so a sparse heat map loses highlighting on every cell,
+    // including the ones that were drawn.
+    const { chart, container } = createHeatChart(SPARSE, 'heat-sparse-grid');
+
+    const maidr = bindAnyChart(chart);
+    const layer = maidr?.subplots[0][0].layers[0] as MaidrLayer;
+    const grid = layer.selectors as (string | null)[][];
+
+    // `Heatmap` reverses the payload's rows so row 0 is the foot of the grid,
+    // which is the direction navigation counts in — so the selector grid is
+    // written bottom-first too, as the echarts heat map's is.
+    expect(grid.map(row => row.map(heatAt))).toEqual([
+      ['5', '6'],
+      ['3', null],
+    ]);
+
+    cleanUp(container);
+  });
+});

--- a/test/adapters/anychart/invertedLineOrder.test.ts
+++ b/test/adapters/anychart/invertedLineOrder.test.ts
@@ -74,16 +74,19 @@ function createSeries(seriesType: string): AnyChartSeries {
  * @param options - What the chart declares
  * @param options.seriesType - The AnyChart series type to draw
  * @param options.xInverted - What `xScale().inverted()` answers
+ * @param options.chartType - What `getType()` answers
  * @returns The emitted layer
  */
 function layerFor(options: {
   seriesType?: string;
   xInverted?: boolean;
+  chartType?: string;
 } = {}): MaidrLayer {
   const series = [createSeries(options.seriesType ?? 'line')];
   const chart = {
     title: () => 'Tips',
     container: () => '',
+    getType: () => options.chartType ?? '',
     getSeriesCount: () => series.length,
     getSeriesAt: (i: number) => series[i] ?? null,
     xScale: () => ({ getType: () => 'ordinal', inverted: () => options.xInverted === true }),
@@ -158,5 +161,42 @@ describe('an anychart line on an inverted scale', () => {
 
     expect(layer.type).toBe(TraceType.LINE);
     expect(categoriesOf(layer)).toEqual(DRAWN);
+  });
+});
+
+/**
+ * Which way up the chart is drawn is the chart's own property, not any one
+ * series'. `anychart.bar()` runs its categories down the page and defaults its
+ * x scale to `inverted() === true` so the first one lands at the top; a line
+ * or an area overlaid on that same chart still reports `'line'` / `'area'`,
+ * and there is no such thing as a sideways series inside an upright chart.
+ *
+ * Reading the direction off the series therefore gets a bar chart's overlay
+ * backwards in both directions at once — reversing the one the chart draws in
+ * order, and leaving the one it genuinely draws bottom-up alone.
+ */
+describe('an anychart line overlaid on a sideways bar chart', () => {
+  it('reads a default bar chart in the order it was written', () => {
+    // `anychart.bar()` starts inverted, which is what puts its first category
+    // at the top: nothing is reversed, and announcing it backwards would send
+    // the braille line, the autoplay sweep and the stereo pan the wrong way.
+    const layer = layerFor({ chartType: 'bar', xInverted: true });
+
+    expect(categoriesOf(layer)).toEqual(LISTED);
+    expect(layer.domMapping?.pointOrder).toBeUndefined();
+  });
+
+  it('reads an un-inverted bar chart in the order it is drawn', () => {
+    // The mirror case: `xScale().inverted(false)` on a bar chart genuinely
+    // draws the line bottom-up, so this is the reversal that is needed.
+    const layer = layerFor({ chartType: 'bar' });
+
+    expect(categoriesOf(layer)).toEqual(DRAWN);
+    expect(layer.domMapping?.pointOrder).toBe('reverse');
+  });
+
+  it('reads a band on a bar chart by the chart it is drawn in', () => {
+    expect(categoriesOf(layerFor({ chartType: 'bar', seriesType: 'area', xInverted: true })))
+      .toEqual(LISTED);
   });
 });

--- a/test/adapters/anychart/invertedScaleOrder.test.ts
+++ b/test/adapters/anychart/invertedScaleOrder.test.ts
@@ -38,6 +38,7 @@ import type { AnyChartInstance, AnyChartIterator, AnyChartSeries } from '@adapte
 import type { BarPoint } from '@type/grammar';
 import { bindAnyChart } from '@adapters/anychart/converters';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { Orientation } from '@type/grammar';
 import { JSDOM } from 'jsdom';
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>');
@@ -103,7 +104,7 @@ function createColumnSeries(
  * @param options.xInverted - What `xScale().inverted()` answers
  * @param options.yInverted - What `yScale().inverted()` answers
  * @param options.container - The container the chart drew into
- * @param options.horizontal - Draw a `bar` series rather than a `column` one
+ * @param options.horizontal - Draw `anychart.bar()` rather than `anychart.column()`
  * @returns The chart
  */
 function createChart(options: {
@@ -116,6 +117,10 @@ function createChart(options: {
   return {
     title: () => 'Tips',
     container: () => options.container ?? '',
+    // The chart says which way up it is drawn, and a `bar` series only exists
+    // inside `anychart.bar()`. Naming only the series left the two able to
+    // disagree, which no real chart can.
+    getType: () => (options.horizontal ? 'bar' : 'column'),
     getSeriesCount: () => series.length,
     getSeriesAt: (i: number) => series[i] ?? null,
     xScale: () => ({ getType: () => 'ordinal', inverted: () => options.xInverted === true }),
@@ -170,7 +175,7 @@ function layerFor(options: {
   yInverted?: boolean;
   horizontal?: boolean;
   selectors?: string[];
-} = {}): { type: string; selectors?: string | string[]; data: unknown } {
+} = {}): { type: string; orientation?: string; selectors?: string | string[]; data: unknown } {
   const container = createContainer('ac-inverted');
   const chart = createChart({ ...options, container });
   // `bindAnyChart` rather than `anyChartToMaidr`: stamping the marks is part
@@ -184,12 +189,26 @@ function layerFor(options: {
   const layer = maidr?.subplots[0][0].layers[0];
   if (!layer)
     throw new Error('no layer emitted');
-  return layer as unknown as { type: string; selectors?: string | string[]; data: unknown };
+  return layer as unknown as {
+    type: string;
+    orientation?: string;
+    selectors?: string | string[];
+    data: unknown;
+  };
 }
 
-/** The categories of a bar layer, in the order it emits them. */
-function categoriesOf(layer: { data: unknown }): unknown[] {
-  return (layer.data as BarPoint[]).map(p => p.x);
+/**
+ * The categories of a bar layer, in the order it emits them.
+ *
+ * A sideways chart puts the magnitude on `x` and the category on `y`, which is
+ * what `BarTrace` reads a horizontal layer as — so which field holds the
+ * category follows the orientation the layer declares.
+ */
+function categoriesOf(layer: { orientation?: string; data: unknown }): unknown[] {
+  const category = layer.orientation === Orientation.HORIZONTAL
+    ? (p: BarPoint): unknown => p.y
+    : (p: BarPoint): unknown => p.x;
+  return (layer.data as BarPoint[]).map(category);
 }
 
 beforeEach(() => {

--- a/test/adapters/anychart/multiSeriesStamping.test.ts
+++ b/test/adapters/anychart/multiSeriesStamping.test.ts
@@ -1,0 +1,205 @@
+/**
+ * How a chart with more than one series hands its marks out.
+ *
+ * `stampLineAttributes` and `stampScatterAttributes` collect every marker-sized
+ * shape in the SVG geometrically — AnyChart 8.x gives them no class to aim at —
+ * and then split that one flat list between the series. The split is where the
+ * pairing between what is announced and what is outlined is decided, and it
+ * fails silently: the announcements come from the series' own rows and stay
+ * correct whatever the split does.
+ *
+ * Two shapes of chart are exercised here, because they break the split in
+ * different directions: a combined chart whose first series is not line-like
+ * at all, and two line series of unequal length.
+ */
+
+import type {
+  AnyChartInstance,
+  AnyChartIterator,
+  AnyChartSeries,
+} from '@adapters/anychart/types';
+import { bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const LINE_ATTR = 'data-maidr-anychart-line-point';
+const POINT_ATTR = 'data-maidr-anychart-point';
+
+function createIterator(rows: Array<Record<string, unknown>>): AnyChartIterator {
+  let index = -1;
+  return {
+    advance: () => ++index < rows.length,
+    get: (field: string) => rows[index]?.[field],
+    getIndex: () => index,
+    getRowsCount: () => rows.length,
+    reset: () => {
+      index = -1;
+    },
+  };
+}
+
+/** A drawn series of `count` points, of the given AnyChart type. */
+function createSeries(seriesType: string, count: number, name: string): AnyChartSeries {
+  const rows = Array.from({ length: count }, (_, i) => ({ x: `c${i}`, value: i + 1 }));
+  return {
+    id: () => 0,
+    name: () => name,
+    seriesType: () => seriesType,
+    getIterator: () => createIterator(rows),
+    getPoint: () => ({ get: () => undefined, getIndex: () => 0, exists: () => false }),
+    getStat: () => undefined,
+  };
+}
+
+function createChart(series: AnyChartSeries[], container: HTMLElement): AnyChartInstance {
+  return {
+    title: () => 'Combined',
+    container: () => container,
+    getType: () => '',
+    getSeriesCount: () => series.length,
+    getSeriesAt: (i: number) => series[i] ?? null,
+    xScale: () => ({ getType: () => 'ordinal', inverted: () => false }),
+    yScale: () => ({ inverted: () => false }),
+  } as unknown as AnyChartInstance;
+}
+
+/**
+ * A rendered chart: one marker-sized shape per entry in `markerXs`, plus the
+ * optional oversized rects a column series draws, which the marker filter
+ * must reject on size.
+ *
+ * jsdom implements no `getBBox`, so each shape is given the box the geometric
+ * filter reads. The markers are appended in a scrambled order on purpose: the
+ * stampers sort their candidates by x, so DOM order must not decide anything.
+ */
+function createRenderedChart(
+  id: string,
+  markerXs: number[],
+  barWidths: number[] = [],
+): { container: HTMLElement; markers: SVGElement[] } {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  const layer = document.createElementNS(SVG_NS, 'g');
+  layer.id = 'ac_layer_1';
+  svg.appendChild(layer);
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  const box = (element: Element, x: number, width: number, height: number): void => {
+    Object.defineProperty(element, 'getBBox', {
+      value: () => ({ x, y: 100, width, height }),
+    });
+  };
+
+  barWidths.forEach((width, i) => {
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.id = `ac_path_bar_${i}`;
+    rect.setAttribute('fill', '#888888');
+    box(rect, i * 100, width, 200);
+    layer.appendChild(rect);
+  });
+
+  const markers = markerXs.map((x, i) => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.id = `ac_path_marker_${i}`;
+    path.setAttribute('fill', '#64b5f6');
+    box(path, x, 6, 6);
+    layer.appendChild(path);
+    return path as unknown as SVGElement;
+  });
+
+  return { container, markers };
+}
+
+/** The stamp each marker carries, in the order the markers were listed. */
+function stamps(markers: SVGElement[], attribute: string): (string | null)[] {
+  return markers.map(marker => marker.getAttribute(attribute));
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('bindAnyChart (multi-series line stamping)', () => {
+  it('stamps a line overlay drawn beside a column series', () => {
+    // `anychart.column(); chart.column(bars); chart.line(points)` — the line is
+    // series 1, and the columns are rejected by the marker filter on size, so
+    // the whole candidate list belongs to the line. Offsetting by the series'
+    // own index skips past every candidate there is and stamps nothing, and
+    // the emitted `[…-line-point^="1-"]` selector then resolves to no element:
+    // the series announces correctly and never highlights.
+    const { container, markers } = createRenderedChart('combo', [10, 40, 70, 100], [60, 60, 60, 60]);
+    const chart = createChart(
+      [createSeries('column', 4, 'Revenue'), createSeries('line', 4, 'Margin')],
+      container,
+    );
+
+    bindAnyChart(chart);
+
+    expect(stamps(markers, LINE_ATTR)).toEqual(['1-0', '1-1', '1-2', '1-3']);
+
+    cleanUp(container);
+  });
+
+  it('gives each of two unequal line series its own marks', () => {
+    // Three points then five. The second series must start where the first
+    // stopped; striding by its own length instead starts it two marks late,
+    // so its first point is announced against another series' mark and its
+    // last two marks are never reachable at all.
+    const { container, markers } = createRenderedChart(
+      'unequal',
+      [10, 20, 30, 40, 50, 60, 70, 80],
+    );
+    const chart = createChart(
+      [createSeries('line', 3, 'A'), createSeries('line', 5, 'B')],
+      container,
+    );
+
+    bindAnyChart(chart);
+
+    expect(stamps(markers, LINE_ATTR))
+      .toEqual(['0-0', '0-1', '0-2', '1-0', '1-1', '1-2', '1-3', '1-4']);
+
+    cleanUp(container);
+  });
+});
+
+describe('bindAnyChart (multi-series scatter stamping)', () => {
+  it('gives each of two unequal scatter series its own points', () => {
+    const { container, markers } = createRenderedChart(
+      'scatter-unequal',
+      [10, 20, 30, 40, 50, 60, 70, 80],
+    );
+    const chart = createChart(
+      [createSeries('marker', 3, 'A'), createSeries('marker', 5, 'B')],
+      container,
+    );
+
+    bindAnyChart(chart);
+
+    expect(stamps(markers, POINT_ATTR))
+      .toEqual(['0-0', '0-1', '0-2', '1-0', '1-1', '1-2', '1-3', '1-4']);
+
+    cleanUp(container);
+  });
+});

--- a/test/adapters/anychart/stampDiagnostics.test.ts
+++ b/test/adapters/anychart/stampDiagnostics.test.ts
@@ -1,0 +1,157 @@
+/**
+ * What the stampers say on a bind, and how often.
+ *
+ * The box and scatter stampers shipped with the diagnostics they were
+ * developed against — a per-series summary written on every render, a per-box
+ * line under it, and a scatter line that reports the candidate count whether or
+ * not it matches. They cost four selector scans per series and four more per
+ * box, and they write into the exact console a developer would be reading to
+ * find a real stamping failure: a twenty-box chart buries one genuine warning
+ * under sixty that say nothing is wrong.
+ */
+
+import type { AnyChartInstance, AnyChartIterator, AnyChartSeries } from '@adapters/anychart/types';
+import { bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+let warn: jest.SpiedFunction<typeof console.warn>;
+
+function createIterator(rows: Array<Record<string, unknown>>): AnyChartIterator {
+  let index = -1;
+  return {
+    advance: () => ++index < rows.length,
+    get: (field: string) => rows[index]?.[field],
+    getIndex: () => index,
+    getRowsCount: () => rows.length,
+    reset: () => {
+      index = -1;
+    },
+  };
+}
+
+function createSeries(seriesType: string, rows: Array<Record<string, unknown>>): AnyChartSeries {
+  return {
+    id: () => 0,
+    name: () => seriesType,
+    seriesType: () => seriesType,
+    getIterator: () => createIterator(rows),
+    getPoint: () => ({ get: () => undefined, getIndex: () => 0, exists: () => false }),
+    getStat: () => undefined,
+  };
+}
+
+/** A container holding a rendered chart, with one marker-sized shape per x. */
+function createRendered(id: string, markerXs: number[] = []): HTMLElement {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  const layer = document.createElementNS(SVG_NS, 'g');
+  layer.id = 'ac_layer_1';
+  svg.appendChild(layer);
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  markerXs.forEach((x, i) => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.id = `ac_path_${i}`;
+    path.setAttribute('fill', '#64b5f6');
+    Object.defineProperty(path, 'getBBox', {
+      value: () => ({ x, y: 100, width: 6, height: 6 }),
+    });
+    layer.appendChild(path);
+  });
+
+  return container;
+}
+
+function createChart(series: AnyChartSeries[], container: HTMLElement): AnyChartInstance {
+  return {
+    title: () => 'Chart',
+    container: () => container,
+    getType: () => '',
+    getSeriesCount: () => series.length,
+    getSeriesAt: (i: number) => series[i] ?? null,
+  } as unknown as AnyChartInstance;
+}
+
+/** Everything written to the console during a bind, as plain strings. */
+function messages(): string[] {
+  return warn.mock.calls.map(call => String(call[0]));
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+beforeEach(() => {
+  warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('what binding a scatter chart reports', () => {
+  it('says nothing when it found a candidate for every point', () => {
+    const container = createRendered('scatter-clean', [10, 20, 30]);
+    const chart = createChart(
+      [createSeries('marker', [{ x: 1, value: 1 }, { x: 2, value: 2 }, { x: 3, value: 3 }])],
+      container,
+    );
+
+    bindAnyChart(chart);
+
+    expect(messages()).toEqual([]);
+
+    cleanUp(container);
+  });
+
+  it('still reports a shortfall it cannot stamp round', () => {
+    const container = createRendered('scatter-short', [10]);
+    const chart = createChart(
+      [createSeries('marker', [{ x: 1, value: 1 }, { x: 2, value: 2 }])],
+      container,
+    );
+
+    bindAnyChart(chart);
+
+    expect(messages()).toHaveLength(1);
+    expect(messages()[0]).toContain('Expected 2 scatter marker shapes');
+
+    cleanUp(container);
+  });
+});
+
+describe('what binding a box chart reports', () => {
+  it('reports the one failure once, without a summary of it', () => {
+    // jsdom resolves no computed `fill` for an SVG presentation attribute, so
+    // the IQR filter finds nothing here — which is the failure worth one line.
+    // The temporary diagnostics added three more saying the same thing.
+    const container = createRendered('box-none');
+    const chart = createChart(
+      [createSeries('box', [{ x: 'A', lowest: 1, q1: 2, median: 3, q3: 4, highest: 5 }])],
+      container,
+    );
+
+    bindAnyChart(chart);
+
+    expect(messages()).toHaveLength(1);
+    expect(messages()[0]).toContain('Expected 1 IQR shapes');
+
+    cleanUp(container);
+  });
+});

--- a/test/adapters/frappe/converters.test.ts
+++ b/test/adapters/frappe/converters.test.ts
@@ -309,6 +309,28 @@ describe('createMaidrFromFrappeChart (dot)', () => {
   });
 });
 
+describe('createMaidrFromFrappeChart (empty datasets)', () => {
+  /**
+   * Frappe's own `dataPrep` substitutes a default dataset only when `datasets`
+   * is missing; an explicit `[]` survives construction. The host page calls the
+   * adapter from inside its own settle callback, so an opaque `TypeError` from
+   * a single-dataset builder aborts that callback — and on the grid API takes
+   * every remaining panel down with it. A named error says which panel is at
+   * fault, which is what the diverging and panel-grid paths already do.
+   */
+  // Numeric labels for the scatter case, so it stays on the scatter builder
+  // rather than falling through to the dot one.
+  const cases: [FrappeChartType, FrappeChart][] = [
+    ['bar', { data: { labels: ['A', 'B'], datasets: [] } }],
+    ['dot', { data: { labels: ['A', 'B'], datasets: [] } }],
+    ['scatter', { data: { labels: [10, 20], datasets: [] } }],
+  ];
+
+  it.each(cases)('reports an empty datasets array by name for a %s chart', (chartType, chart) => {
+    expect(() => onlyLayer(chart, chartType)).toThrow(/\[maidr\/frappe\].*dataset/);
+  });
+});
+
 describe('createMaidrFromFrappeChart (diverging)', () => {
   /** Men drawn below the zero line, women above, as Frappe renders them. */
   const pyramid: FrappeChart = {

--- a/test/adapters/frappe/converters.test.ts
+++ b/test/adapters/frappe/converters.test.ts
@@ -272,6 +272,27 @@ describe('createMaidrFromFrappeChart (dot)', () => {
     expect(layer.type).toBe(TraceType.DOT);
   });
 
+  it('warns that only the first dataset of a multi-series scatter is converted', () => {
+    const layer = onlyLayer(
+      {
+        data: {
+          labels: [10, 20],
+          datasets: [{ name: 'One', values: [1, 2] }, { name: 'Two', values: [3, 4] }],
+        },
+      },
+      'scatter',
+    );
+
+    // The layer carries A alone, so its selector has to carry A's dots alone —
+    // the broad line selector matches every dataset group's circles, and the
+    // scatter trace groups the surplus by geometry rather than rejecting it,
+    // outlining a mark that belongs to a series never announced.
+    expect(layer.selectors)
+      .toBe('#chart svg.frappe-chart .dataset-units.dataset-line.dataset-0 circle');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('2 datasets');
+  });
+
   it('warns that only the first dataset of a multi-series dot plot is converted', () => {
     onlyLayer(
       {

--- a/test/adapters/frappe/selectorResolution.test.ts
+++ b/test/adapters/frappe/selectorResolution.test.ts
@@ -219,3 +219,34 @@ describe('frappe layer selectors against the rendered SVG', () => {
     expect(matched(layer.selectors as string)).toEqual(['50', '30', '20']);
   });
 });
+
+describe('frappe layer selectors over an author-supplied container id', () => {
+  /** A two-mark chart, the simplest thing every builder can be pointed at. */
+  const chart: FrappeChart = {
+    data: {
+      labels: ['A', 'B'],
+      datasets: [{ name: 'Sales', values: [7, 8] }],
+    },
+  };
+
+  /** Renders the chart, renames its container, and converts it there. */
+  function convertUnder(id: string, chartType: FrappeChartType): MaidrLayer {
+    render(chart, chartType === 'bar' ? 'bars' : 'line');
+    const container = document.getElementById('chart') as HTMLElement;
+    container.id = id;
+    const maidr = createMaidrFromFrappeChart(chart, container, { chartType });
+    return maidr.subplots[0][0].layers[0];
+  }
+
+  it('still matches the bars when the id holds a dot', () => {
+    const layer = convertUnder('my.chart', 'bar');
+
+    expect(matched(layer.selectors as string)).toEqual(['7', '8']);
+  });
+
+  it('still matches the dots when the id holds a dot', () => {
+    const layer = convertUnder('my.chart', 'dot');
+
+    expect(matched(layer.selectors as string)).toEqual(['7', '8']);
+  });
+});

--- a/test/adapters/frappe/selectorResolution.test.ts
+++ b/test/adapters/frappe/selectorResolution.test.ts
@@ -249,4 +249,15 @@ describe('frappe layer selectors over an author-supplied container id', () => {
 
     expect(matched(layer.selectors as string)).toEqual(['7', '8']);
   });
+
+  // An id beginning with a digit is not a CSS identifier, so unescaped it does
+  // not merely fail to match — `querySelectorAll` throws, and the throw escapes
+  // `Subplot`'s bare `layers.map`, taking the whole figure down with it.
+  // jsdom's selector engine does not resolve numeric escapes, so what is
+  // pinned here is that the emitted selector parses at all.
+  it('emits a selector the CSS parser accepts when the id starts with a digit', () => {
+    const layer = convertUnder('2024-sales', 'bar');
+
+    expect(() => matched(layer.selectors as string)).not.toThrow();
+  });
 });

--- a/test/adapters/observable/scales.test.ts
+++ b/test/adapters/observable/scales.test.ts
@@ -1,0 +1,85 @@
+/**
+ * What reading a categorical axis costs.
+ *
+ * `valueAtPixel` asks a band scale which category contains a pixel, and the
+ * band boundaries are not on the scale — they have to be built by applying it
+ * to every category and sorting the results. The adapter asks that question
+ * once per drawn element, so rebuilding the boundaries each time makes reading
+ * a categorical mark quadratic in the size of its axis: a 20-series by
+ * 200-category stack is 4,000 rects over a 200-entry domain, and the watcher
+ * re-runs the whole conversion on every OJS reactive redraw — a slider drag
+ * re-converts per frame, on the main thread.
+ *
+ * The boundaries are the same for every element of one conversion, so the
+ * count of `apply` calls is the shape worth pinning.
+ */
+
+import type { PlotScale } from '@adapters/observable/types';
+import { observablePlotToMaidr } from '@adapters/observable/converters';
+import { describe, expect, it } from '@jest/globals';
+import { mountFixture } from './helpers';
+
+/**
+ * Mounts a fixture with its x scale's `apply` counted.
+ *
+ * @param key - Which fixture to mount.
+ * @returns The chart, and a reader for the running count.
+ */
+function countingX(key: Parameters<typeof mountFixture>[0]): {
+  element: Element;
+  applyCalls: () => number;
+} {
+  const { element } = mountFixture(key);
+  const source = element as Element & { scale: (name: string) => PlotScale | undefined };
+  const read = source.scale.bind(source);
+  let calls = 0;
+  // Wrapped once per name and cached, so the adapter holds the same scale
+  // object throughout a conversion — which is what Plot hands it too.
+  const wrapped = new Map<string, PlotScale | undefined>();
+
+  Object.defineProperty(element, 'scale', {
+    configurable: true,
+    value: (name: string): PlotScale | undefined => {
+      if (!wrapped.has(name)) {
+        const scale = read(name);
+        const apply = scale?.apply;
+        wrapped.set(
+          name,
+          scale && typeof apply === 'function' && name === 'x'
+            ? {
+                ...scale,
+                apply: (value: unknown) => {
+                  calls += 1;
+                  return apply(value);
+                },
+              }
+            : scale,
+        );
+      }
+      return wrapped.get(name);
+    },
+  });
+
+  return { element, applyCalls: () => calls };
+}
+
+describe('reading a band scale during a conversion', () => {
+  it('walks the category domain once, not once per drawn element', () => {
+    // Three bars over three categories. Rebuilt per element that is nine
+    // `apply` calls and three sorts; built once it is three and one.
+    const { element, applyCalls } = countingX('bar');
+
+    observablePlotToMaidr(element);
+
+    expect(applyCalls()).toBe(3);
+  });
+
+  it('still reads every bar back to its own category', () => {
+    const { element } = countingX('bar');
+
+    const layer = observablePlotToMaidr(element)?.subplots[0][0].layers[0];
+
+    expect((layer?.data as { x: string | number }[]).map(point => point.x))
+      .toEqual(['Mon', 'Tue', 'Wed']);
+  });
+});

--- a/test/adapters/observable/selectorResolution.test.ts
+++ b/test/adapters/observable/selectorResolution.test.ts
@@ -12,8 +12,9 @@
  * check the matches element by element.
  */
 
-import type { BarPoint, LinePoint, SegmentedPoint } from '@type/grammar';
+import type { BarPoint, LinePoint, MaidrLayer, SegmentedPoint } from '@type/grammar';
 import { observablePlotToMaidr } from '@adapters/observable/converters';
+import { TraceType } from '@type/grammar';
 import { mountFixture } from './helpers';
 
 describe('selector resolution', () => {
@@ -89,4 +90,44 @@ describe('selector resolution', () => {
     expect(secondMatches).toHaveLength(2);
     expect(Array.from(firstMatches)).not.toEqual(expect.arrayContaining(Array.from(secondMatches)));
   });
+
+  it('gives a hexbin its hexagons in lattice order, not paint order', () => {
+    // Plot draws the hexagons largest-radius-first, so the crowded fixture's
+    // document order is 7, 5, 4, 3, 2 while the lattice reads [[3, 7, 2],
+    // [5, 4]]. `HexbinTrace` pairs the resolved elements with the bins by
+    // position and its count check passes either way (5 == 5), so a selector
+    // resolved in document order outlines the 7's hexagon while announcing 3.
+    const { document, element } = mountFixture('crowdedHexbin');
+    const maidr = observablePlotToMaidr(element, { markTypes: { dot: TraceType.HEXBIN } });
+    const layer = maidr?.subplots[0][0].layers[0];
+
+    const matched = resolveAsTraceDoes(layer?.selectors, document);
+
+    // The x pixel of each bin in lattice order — bottom row left to right,
+    // then the row above it.
+    expect(matched.map(centreX)).toEqual([30.5, 310.5, 610.5, 150.5, 490.5]);
+  });
 });
+
+/**
+ * Resolves a layer's selectors the way a trace does: a lone string in one
+ * `querySelectorAll`, a list one at a time, flattened in list order.
+ */
+function resolveAsTraceDoes(
+  selectors: MaidrLayer['selectors'],
+  document: Document,
+): Element[] {
+  if (typeof selectors === 'string')
+    return Array.from(document.querySelectorAll(selectors));
+  if (Array.isArray(selectors)) {
+    return (selectors as string[])
+      .flatMap(one => Array.from(document.querySelectorAll(one)));
+  }
+  return [];
+}
+
+/** The x pixel a mark was translated to. */
+function centreX(element: Element): number {
+  const translate = /translate\(\s*(-?[\d.]+)/.exec(element.getAttribute('transform') ?? '');
+  return translate === null ? Number.NaN : Number(translate[1]);
+}

--- a/test/adapters/shared/selectorUtil.test.ts
+++ b/test/adapters/shared/selectorUtil.test.ts
@@ -1,0 +1,55 @@
+import { cssEscape } from '@adapters/shared/selectorUtil';
+import { describe, expect, it } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+/**
+ * `cssEscape` falls back to a hand-rolled escape wherever `CSS.escape` is
+ * missing — Node, SSR, and jsdom, which implements no `CSS` object at all.
+ * The fallback therefore has to reproduce the native result, because a
+ * selector that the fallback leaves invalid throws a `SyntaxError` out of
+ * `document.querySelectorAll` rather than merely failing to match, and every
+ * adapter builds its scoped selectors by embedding an author-supplied
+ * container id.
+ */
+describe('cssEscape in an environment without CSS.escape', () => {
+  /** Parses the selector, returning whether the CSS parser accepted it. */
+  function parses(selector: string): boolean {
+    const dom = new JSDOM('<!doctype html><body></body>');
+    try {
+      dom.window.document.querySelectorAll(selector);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it('escapes a leading digit the way CSS.escape does', () => {
+    const escaped = cssEscape('2024-sales');
+
+    expect(escaped).toBe('\\32 024-sales');
+  });
+
+  it('escapes a leading digit behind a hyphen', () => {
+    const escaped = cssEscape('-2024-sales');
+
+    expect(escaped).toBe('-\\32 024-sales');
+  });
+
+  it('yields an id selector the CSS parser accepts for a digit-led id', () => {
+    const selector = `#${cssEscape('2024-sales')} .bar`;
+
+    expect(parses(selector)).toBe(true);
+  });
+
+  it('escapes a dot so the id is not read as an id plus a class', () => {
+    const escaped = cssEscape('my.chart');
+
+    expect(escaped).toBe('my\\.chart');
+  });
+
+  it('leaves an id that is already a valid identifier alone', () => {
+    const escaped = cssEscape('chart-1_a');
+
+    expect(escaped).toBe('chart-1_a');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Ten defects across the AnyChart, Observable Plot and Frappe adapters, found in a codebase audit. Each was reproduced with a test that failed first.

Most of them point the reader at the wrong mark. A multi-series line or scatter partitioned its markers with the wrong stride, so series two onwards were stamped against the wrong points. A heatmap stamped its cells by flat DOM index rather than by grid position. A Frappe scatter with more than one dataset matched every dataset's circles while reading only the first, so the outline landed on a mark from a series the reader is never told about.

Two take the whole chart down rather than one mark: an unguarded `series.seriesType()` aborted the entire bind, and a Frappe container id was interpolated into a selector without CSS escaping, so an id starting with a digit threw.

## Related Issues

None.

## Changes Made

- **anychart**: the multi-series marker partition uses the right stride.
- **anychart**: `drawsCategoriesReversed` asks the chart whether it is horizontal, not the series.
- **anychart**: heatmap cells are stamped by grid position. The layer now emits a `(string | null)[][]` selector grid rather than one prefix string.
- **anychart**: `series.seriesType()` is guarded, so one odd series no longer aborts the bind.
- **anychart**: temporary box and scatter stamping diagnostics are removed.
- **observable**: a hexbin layer emits one selector per bin rather than one for the lattice.
- **observable**: `bandIntervals` is built once instead of on every `valueAtPixel` call.
- **frappe**: the container id is CSS-escaped.
- **frappe**: a scatter's selector is scoped to `.dataset-0`, so it stops matching circles belonging to datasets it never read, and it warns when a chart has more than one. Multi-series scatter remains unsupported.
- **frappe**: an empty `datasets` array throws a named error rather than an opaque `TypeError`.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**One change reaches beyond this adapter and deserves the closest look.** Escaping the Frappe id did not actually fix the fatal case until `cssEscape` itself was fixed: its Node and SSR fallback in `src/adapters/shared/selectorUtil.ts` left a digit-led id such as `2024-sales` unescaped. That helper is shared with the D3, Recharts, Victory, Vega-Lite and amCharts adapters. It only changes output for ids that start with a digit or a hyphen-digit, so every adapter keeps the selectors it emits today, and jsdom implements no `CSS` object at all, so this fallback is the path every test already exercises.

**Two existing tests were updated, both keeping their intent.** The AnyChart inverted-scale test modelled a horizontal chart by giving its series the type `bar` while leaving the chart itself unnamed, a disagreement no real chart can produce, since a `bar` series only exists inside `anychart.bar()`. Its fixture now names the chart type. The converter test pinned the heatmap's flat prefix selector and now pins the same panel scoping on the per-cell grid.

**Several findings were deliberately left**, and two of those refusals are worth stating. The box-plot performance findings could not be reproduced at all under jest: reaching that code needs `collectIqCandidates` to return a box, and that filter reads a computed `fill`, which jsdom does not resolve from an SVG presentation attribute. No test could fail first, so nothing was changed on faith. And draining the tracked chart set on teardown contradicts the documented contract of `stopObservablePlots`, that charts already bound stay bound; changing that is a decision about public behaviour, not a minimal fix.

**An adjacent bug was found that is not in this branch and needs its own finding:** with `datasets: []`, the Frappe pie and percentage builders sum over an empty array and emit a value of 0 for every label, which is a reading the chart never drew. Same class as #1191.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (505 suites, 6746 tests) and the esm project under `--experimental-vm-modules` (12 suites, 172 tests), both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun