### PR TITLE
fix(echarts): keep a segmented bar's gaps, so later categories are not shifted left

### DIFF
--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -617,23 +617,34 @@ function barLayer(
   }
 
   const stacked = bars.some(seriesModel => Boolean(seriesModel.get('stack')));
-  const data: SegmentedPoint[][] = bars.map((seriesModel, order) => {
+  // A gap keeps its column rather than being dropped from the row.
+  // `SegmentedTrace` pairs the series by column index -- its summary row reads
+  // `barValues.map(row => row[i])` and takes the category off `points[0][i]`
+  // -- so a row one short puts every later category against another series'
+  // value, announces a total no bar on the page adds up to, and drops the last
+  // category from the summary altogether.
+  //
+  // The magnitude is `NaN` and never `0`: a zero sounds like a real low
+  // reading, can be reached as the row's minimum and pulls the range every
+  // other bar's pitch is scaled against, which is what `isMeasured` keeps a
+  // gap out of (#1002).
+  const rows = bars.map((seriesModel, order) => {
     const list = seriesModel.getData();
     const fill = authoredName(seriesModel) || `Series ${order + 1}`;
     const points: SegmentedPoint[] = [];
+    const drew: boolean[] = [];
     for (let index = 0; index < list.count(); index++) {
       const value = magnitudeOf(list, index, axes.horizontal);
-      if (!measured(value)) {
-        continue;
-      }
+      const magnitude = measured(value) ? value : Number.NaN;
       const position = positionOf(list, index);
       points.push(
         axes.horizontal
-          ? { x: value, y: position, z: fill }
-          : { x: position, y: value, z: fill },
+          ? { x: magnitude, y: position, z: fill }
+          : { x: position, y: magnitude, z: fill },
       );
+      drew.push(measured(value));
     }
-    return points;
+    return { points, drew };
   });
 
   return {
@@ -643,11 +654,28 @@ function barLayer(
     // A row per series, not one flat list. `SegmentedTrace` routes an array
     // to `mapGridToSvgElements`, which wants a row per series and declines a
     // flat one -- for the reason it gives itself, that a flat list says which
-    // bars there are but not which cell each one is in.
-    ...(named ? { selectors: named } : {}),
+    // bars there are but not which cell each one is in. A cell the chart drew
+    // nothing at names no element, which the grid says with a `null` and the
+    // trace stands in for -- and which is why the row has to be as long as the
+    // series rather than as long as the marks.
+    ...(named
+      ? { selectors: named.map((marks, order) => paired(marks, rows[order].drew)) }
+      : {}),
     axes: axisConfig(axes),
-    data,
+    data: rows.map(row => row.points),
   };
+}
+
+/**
+ * One selector per cell of a series, `null` where it drew no mark.
+ *
+ * @param marks - The selectors of the marks the series drew, in order
+ * @param drew  - Whether each cell of the series drew one
+ * @returns One entry per cell
+ */
+function paired(marks: string[], drew: boolean[]): (string | null)[] {
+  let mark = 0;
+  return drew.map(drawn => (drawn ? marks[mark++] ?? null : null));
 }
 
 function lineLayer(

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -660,7 +660,7 @@ function barLayer(
     };
   }
 
-  const stacked = bars.some(seriesModel => Boolean(seriesModel.get('stack')));
+  const stacked = oneStack(bars);
   // A gap keeps its column rather than being dropped from the row.
   // `SegmentedTrace` pairs the series by column index -- its summary row reads
   // `barValues.map(row => row[i])` and takes the category off `points[0][i]`
@@ -708,6 +708,27 @@ function barLayer(
     axes: axisConfig(axes),
     data: rows.map(row => row.points),
   };
+}
+
+/**
+ * Whether every bar series is stacked, and stacked on the same pile.
+ *
+ * ECharts stacks the series that share a `stack` name and draws the rest
+ * beside them, so a chart is only a stacked bar chart when they all name the
+ * same one. Two names is grouped stacks -- `'a', 'a', 'b', 'b'` is two stacks
+ * side by side, which ECharts draws routinely -- and a stacked series next to
+ * a plain one is a mixed chart. Calling either a stack tells the reader the
+ * bars sit on top of one another when they do not.
+ *
+ * @param bars - The chart's bar series
+ * @returns True when they are all in one stack
+ */
+function oneStack(bars: EChartsSeriesModel[]): boolean {
+  const first = text(bars[0]?.get('stack'));
+  if (!first) {
+    return false;
+  }
+  return bars.every(seriesModel => text(seriesModel.get('stack')) === first);
 }
 
 /**

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -335,8 +335,14 @@ function buildLayers(
   // A boxplot is excluded alongside a line: it paints one path per box, but
   // that path is box AND whiskers together, which no selector shape wants --
   // counting it would spend a slot and shift every later series' marks.
+  // A line declared with `areaStyle` is the exception among lines: it fills
+  // the band under its curve in the series colour, which is a mark by every
+  // test `isFilledMark` applies. Excluded, the band is found among the
+  // candidates with nothing to account for it, and the mismatch drops the
+  // highlighting of every other series on the chart along with its own.
   const marked = series.filter(seriesModel =>
-    seriesModel.subType !== 'line' && seriesModel.subType !== 'boxplot');
+    seriesModel.subType !== 'boxplot'
+    && (seriesModel.subType !== 'line' || fillsBand(seriesModel)));
   const perDatum = markPerDatum(
     container,
     marked.map(seriesModel => drawnMarks(seriesModel, axes, grid)),
@@ -444,9 +450,29 @@ function drawnMarks(
       return drawnGridCount(seriesModel, grid);
     case 'candlestick':
       return drawnCandleCount(seriesModel);
+    case 'line':
+      // One band for the whole series rather than one mark per sample, and
+      // only when the series fills one -- the same count `markPerSeries`
+      // asks of the stroked curve above it.
+      return fillsBand(seriesModel) ? 1 : 0;
     default:
       return drawnCount(seriesModel, axes.horizontal);
   }
+}
+
+/**
+ * Whether a line series fills the band under its curve.
+ *
+ * `areaStyle` is what fills it, so it is what makes the chart an area chart
+ * rather than a line one -- read off the resolved option so an author cannot
+ * mislabel one as the other. The band is also a filled mark, which is why
+ * the count asks the same question the reading does.
+ *
+ * @param seriesModel - The series to read
+ * @returns True when the series paints a band
+ */
+function fillsBand(seriesModel: EChartsSeriesModel): boolean {
+  return Boolean(seriesModel.get('areaStyle'));
 }
 
 /**
@@ -696,10 +722,7 @@ function lineLayer(
     });
   }
 
-  // `areaStyle` is what fills the band under the curve, so it is what makes
-  // the chart an area chart rather than a line one -- read off the resolved
-  // option so an author cannot mislabel one as the other.
-  const area = Boolean(seriesModel.get('areaStyle'));
+  const area = fillsBand(seriesModel);
   const step = seriesModel.get('step');
   const name = authoredName(seriesModel);
 

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -6,6 +6,7 @@ import type {
   MaidrSubplot,
   ScatterPoint,
   SegmentedPoint,
+  TreemapPoint,
 } from '@type/grammar';
 import type { AxisCategories } from './grid';
 import type {
@@ -27,9 +28,9 @@ import {
   heatmapLayer,
 } from './grid';
 import {
-  drawnNodeCount,
   HIERARCHY,
   hierarchyLayer,
+  hierarchyNodes,
   OUTLINED_HIERARCHY,
 } from './hierarchy';
 import {
@@ -221,7 +222,15 @@ function readOwning(
   // counts disagree and both rings lose their outline. It also unstamps
   // before the count, so a later series with nothing to count would strip the
   // stamps an earlier series' selectors already name.
-  const counts = owning.map(ownedMarkCount);
+  // A hierarchy is walked once and its nodes serve both the count and the
+  // layer: the walk allocates a point per node, copies the ancestor path at
+  // each one and reads every node's and every child's value, so a sunburst of
+  // a few thousand nodes paid all of that twice for a number the first walk
+  // already had.
+  const nodes = owning.map(seriesModel =>
+    HIERARCHY.has(seriesModel.subType) ? hierarchyNodes(seriesModel) : undefined);
+  const counts = owning.map((seriesModel, index) =>
+    ownedMarkCount(seriesModel, nodes[index]));
   const marks = markPerDatum(container, counts);
   const eachMarkOf = (index: number): string[] | undefined =>
     counts[index] > 0 ? marks?.points[index] : undefined;
@@ -249,7 +258,7 @@ function readOwning(
       const layer = radarLayer(seriesModel, model, outlines);
       return layer ? [layer] : [];
     }
-    const layer = hierarchyLayer(seriesModel, eachMarkOf(index));
+    const layer = hierarchyLayer(seriesModel, nodes[index] ?? [], eachMarkOf(index));
     return layer ? [layer] : [];
   });
 }
@@ -265,9 +274,13 @@ function readOwning(
  * never mistaken for a count that merely came out wrong.
  *
  * @param seriesModel - The series to ask
+ * @param nodes       - Its walked nodes, when it carries a hierarchy
  * @returns The number of marks the drawing should hold for it
  */
-function ownedMarkCount(seriesModel: EChartsSeriesModel): number {
+function ownedMarkCount(
+  seriesModel: EChartsSeriesModel,
+  nodes: TreemapPoint[] | undefined,
+): number {
   if (SINGLE_VALUE.has(seriesModel.subType)) {
     return drawnValueCount(seriesModel);
   }
@@ -275,7 +288,7 @@ function ownedMarkCount(seriesModel: EChartsSeriesModel): number {
     return drawnBandCount(seriesModel);
   }
   if (OUTLINED_HIERARCHY.has(seriesModel.subType)) {
-    return drawnNodeCount(seriesModel);
+    return nodes?.length ?? 0;
   }
   return 0;
 }

--- a/src/adapters/echarts/converters.ts
+++ b/src/adapters/echarts/converters.ts
@@ -42,7 +42,7 @@ import {
 import { NETWORK, networkLayer } from './network';
 import { drawnOutlineCount, RADAR, radarLayer } from './radar';
 import { markPerDatum, markPerSeries } from './selectors';
-import { SINGLE_VALUE, singleValueLayers } from './single';
+import { drawnValueCount, SINGLE_VALUE, singleValueLayers } from './single';
 
 /**
  * Options accepted by {@link createMaidrFromEChart}.
@@ -214,17 +214,30 @@ function readOwning(
     );
   }
 
-  return owning.flatMap((seriesModel) => {
+  // Found in one pass for every series, the way the gridded path does it.
+  // `markPerDatum` counts every filled mark in the SVG, so asking it once per
+  // series compares one series' count against the whole chart's marks: a
+  // nested pie -- two pie series, an inner ring and an outer one -- has both
+  // counts disagree and both rings lose their outline. It also unstamps
+  // before the count, so a later series with nothing to count would strip the
+  // stamps an earlier series' selectors already name.
+  const counts = owning.map(ownedMarkCount);
+  const marks = markPerDatum(container, counts);
+  const eachMarkOf = (index: number): string[] | undefined =>
+    counts[index] > 0 ? marks?.points[index] : undefined;
+  const wholeSeriesOf = (index: number): string | undefined =>
+    counts[index] > 0 ? marks?.series[index] : undefined;
+
+  return owning.flatMap((seriesModel, index) => {
     if (SINGLE_VALUE.has(seriesModel.subType)) {
-      return singleValueLayers(seriesModel, container);
+      return singleValueLayers(seriesModel, eachMarkOf(index), wholeSeriesOf(index));
     }
     if (NETWORK.has(seriesModel.subType)) {
       const layer = networkLayer(seriesModel);
       return layer ? [layer] : [];
     }
     if (THEME_RIVER.has(seriesModel.subType)) {
-      const bands = markPerDatum(container, [drawnBandCount(seriesModel)]);
-      const layer = themeRiverLayer(seriesModel, model, bands?.points[0]);
+      const layer = themeRiverLayer(seriesModel, model, eachMarkOf(index));
       return layer ? [layer] : [];
     }
     if (PARALLEL.has(seriesModel.subType)) {
@@ -236,30 +249,35 @@ function readOwning(
       const layer = radarLayer(seriesModel, model, outlines);
       return layer ? [layer] : [];
     }
-    const layer = hierarchyLayer(seriesModel, hierarchyMarks(seriesModel, container));
+    const layer = hierarchyLayer(seriesModel, eachMarkOf(index));
     return layer ? [layer] : [];
   });
 }
 
 /**
- * One selector per node of a hierarchy, when its marks can be paired.
+ * How many per-datum filled marks a whole-chart series drew.
  *
- * Only a sunburst's can -- see `hierarchy.ts` -- so the others are not even
- * counted, which keeps a treemap's leaf-only painting from being mistaken
- * for a count that merely came out wrong.
+ * Zero says the series has no mark this pass can pair, and every reading that
+ * answers zero says so for a measured reason: a gauge draws a track and a
+ * progress arc for its one datum, a graph and a parallel draw no filled
+ * per-datum mark at all, and among the hierarchies only a sunburst's marks
+ * can be paired -- see `hierarchy.ts` -- so a treemap's leaf-only painting is
+ * never mistaken for a count that merely came out wrong.
  *
- * @param seriesModel - The series to read
- * @param container   - The element the chart was rendered into
- * @returns One selector per node in walk order, or `undefined`
+ * @param seriesModel - The series to ask
+ * @returns The number of marks the drawing should hold for it
  */
-function hierarchyMarks(
-  seriesModel: EChartsSeriesModel,
-  container: HTMLElement,
-): string[] | undefined {
-  if (!OUTLINED_HIERARCHY.has(seriesModel.subType)) {
-    return undefined;
+function ownedMarkCount(seriesModel: EChartsSeriesModel): number {
+  if (SINGLE_VALUE.has(seriesModel.subType)) {
+    return drawnValueCount(seriesModel);
   }
-  return markPerDatum(container, [drawnNodeCount(seriesModel)])?.points[0];
+  if (THEME_RIVER.has(seriesModel.subType)) {
+    return drawnBandCount(seriesModel);
+  }
+  if (OUTLINED_HIERARCHY.has(seriesModel.subType)) {
+    return drawnNodeCount(seriesModel);
+  }
+  return 0;
 }
 
 /**

--- a/src/adapters/echarts/grid.ts
+++ b/src/adapters/echarts/grid.ts
@@ -51,7 +51,25 @@ export interface AxisNames {
 }
 
 /**
+ * Whether an axis entry is the per-label object form.
+ *
+ * @param entry - One entry of a category axis' `data`
+ * @returns True when the label is carried on a `value` field
+ */
+function carriesLabel(entry: unknown): entry is { value: unknown } {
+  return typeof entry === 'object' && entry !== null && 'value' in entry;
+}
+
+/**
  * Reads a category axis' own labels.
+ *
+ * An entry is not always the label itself: a category axis' `data` takes a
+ * per-label object -- `{ value: 'Mon', textStyle: { color: 'red' } }` -- so
+ * an author who styles one label writes the whole entry that way. Stringified
+ * whole, that entry reads as `[object Object]`, and these labels are the only
+ * handle a heat grid's reader has: they become `HeatmapData.x` / `.y` and are
+ * announced on every row and column move, while the numbers stay right and
+ * say nothing is wrong.
  *
  * @param axis - The axis component, when the chart declared one
  * @returns The labels in axis order, empty when the axis carries numbers
@@ -61,7 +79,10 @@ export function categoriesOf(axis: EChartsComponentModel | undefined): string[] 
   if (!Array.isArray(data)) {
     return [];
   }
-  return data.map(entry => (typeof entry === 'string' ? entry : String(entry)));
+  return data.map((entry: unknown) => {
+    const label = carriesLabel(entry) ? entry.value : entry;
+    return typeof label === 'string' ? label : String(label);
+  });
 }
 
 /**

--- a/src/adapters/echarts/hierarchy.ts
+++ b/src/adapters/echarts/hierarchy.ts
@@ -73,16 +73,22 @@ const TRACE: Record<string, TraceType> = {
 /**
  * Builds the layer for one hierarchy series.
  *
+ * The walk is the caller's rather than this function's, because the count
+ * check wants its length before the layer is built and walking twice doubles
+ * every allocation and every `getValue()` the walk makes -- see
+ * {@link hierarchyNodes}.
+ *
  * @param seriesModel - The series to read
+ * @param points      - Its nodes, as {@link hierarchyNodes} walked them
  * @param selectors   - One selector per node in walk order, when the series
  *                      is one whose marks can be paired with it
  * @returns The layer, or `undefined` when the series carries no nodes
  */
 export function hierarchyLayer(
   seriesModel: EChartsSeriesModel,
+  points: TreemapPoint[],
   selectors: string[] | undefined,
 ): MaidrLayer | undefined {
-  const points = walk(seriesModel);
   if (points.length === 0) {
     return undefined;
   }
@@ -106,21 +112,12 @@ export function hierarchyLayer(
 }
 
 /**
- * How many nodes a hierarchy series drew.
- *
- * The walk's length, which is what a sunburst paints one mark for. A treemap
- * and a tree never reach the count check -- see the head of this file -- so
- * this is only ever asked of a sunburst.
- *
- * @param seriesModel - The series to read
- * @returns The number of real nodes, the synthetic root excluded
- */
-export function drawnNodeCount(seriesModel: EChartsSeriesModel): number {
-  return walk(seriesModel).length;
-}
-
-/**
  * Every real node of the series, depth first, in the tree's own order.
+ *
+ * Not cheap for its size -- a point per node, the ancestor path copied at
+ * each one, and `getValue()` asked of every node and every child of it -- so
+ * the caller walks once and hands the result to both the count check and
+ * {@link hierarchyLayer}.
  *
  * The order is the tree's rather than the data's on purpose: measured, a
  * sunburst reorders its children (`B` before `A`, `A2` before `A1`) and paints
@@ -130,7 +127,7 @@ export function drawnNodeCount(seriesModel: EChartsSeriesModel): number {
  * @param seriesModel - The series to read
  * @returns One point per node, the synthetic root excluded
  */
-function walk(seriesModel: EChartsSeriesModel): TreemapPoint[] {
+export function hierarchyNodes(seriesModel: EChartsSeriesModel): TreemapPoint[] {
   const root = seriesModel.getData().tree?.root;
   if (!root) {
     return [];

--- a/src/adapters/echarts/selectors.ts
+++ b/src/adapters/echarts/selectors.ts
@@ -26,6 +26,8 @@
  * position is the only handle.
  */
 
+import { cssEscape } from '../shared/selectorUtil';
+
 /**
  * What each mark is stamped with, so a selector names one by position.
  *
@@ -272,10 +274,27 @@ export function markPerSeries(
   return lines.map((_, index) => selectorFor(container, SERIES_ATTRIBUTE, index));
 }
 
+/**
+ * How one stamped mark is addressed.
+ *
+ * The id is escaped rather than interpolated raw. A container id is the
+ * author's, not the adapter's, and it is not necessarily a CSS identifier: a
+ * React `useId()` answers `:r0:`, an id may begin with a digit, and one may
+ * hold a `.` or a space. `Svg.selectElement` guards only on the query being a
+ * string and then calls `document.querySelector`, which throws a SyntaxError
+ * on an invalid selector -- and that throw propagates out of `new Figure(...)`
+ * and takes the whole render with it, so the chart is not merely
+ * unhighlighted but entirely inaccessible.
+ *
+ * @param container - The element the chart was rendered into
+ * @param attribute - Which stamp names the mark
+ * @param index     - The value the stamp was written with
+ * @returns A selector for that mark, scoped to the container
+ */
 function selectorFor(
   container: HTMLElement,
   attribute: string,
   index: number,
 ): string {
-  return `#${container.id} svg [${attribute}="${index}"]`;
+  return `#${cssEscape(container.id)} svg [${attribute}="${index}"]`;
 }

--- a/src/adapters/echarts/single.ts
+++ b/src/adapters/echarts/single.ts
@@ -18,7 +18,6 @@ import type { BarPoint, GaugePoint, MaidrLayer, PiePoint } from '@type/grammar';
 import type { EChartsSeriesModel } from './types';
 import { Orientation, TraceType } from '@type/grammar';
 import { nextId } from '../shared/selectorUtil';
-import { markPerDatum } from './selectors';
 
 /** One datum: what it is called, and what it measures. */
 interface Reading {
@@ -65,13 +64,16 @@ function readValues(seriesModel: EChartsSeriesModel): Reading[] {
  * share a dial; nothing in the grammar carries it, and both min and max come
  * out the same on each, which is as close as it gets.
  *
- * @param seriesModel - The series to read
- * @param container   - The element the chart was rendered into
+ * @param seriesModel  - The series to read
+ * @param eachMark     - One selector per mark of the series, when they were
+ *                       found
+ * @param wholeSeries  - One selector naming the series' marks together
  * @returns The layers, empty when the series drew no reading
  */
 export function singleValueLayers(
   seriesModel: EChartsSeriesModel,
-  container: HTMLElement,
+  eachMark: string[] | undefined,
+  wholeSeries: string | undefined,
 ): MaidrLayer[] {
   const read = readValues(seriesModel);
   if (read.length === 0) {
@@ -82,17 +84,32 @@ export function singleValueLayers(
     return read.map(one => gaugeLayer(seriesModel, one));
   }
 
-  // A pie and a funnel each draw exactly one filled mark per datum --
-  // measured: three slices are three filled paths, and the three unfilled
-  // ones beside them are the label guides, which the paint filter already
-  // declines.
-  const marks = markPerDatum(container, [read.length]);
-
   return [
     seriesModel.subType === 'pie'
-      ? pieLayer(seriesModel, read, marks?.series[0])
-      : funnelLayer(seriesModel, read, marks?.points[0]),
+      ? pieLayer(seriesModel, read, wholeSeries)
+      : funnelLayer(seriesModel, read, eachMark),
   ];
+}
+
+/**
+ * How many filled marks one of these series drew.
+ *
+ * A pie and a funnel each draw exactly one per datum -- measured: three
+ * slices are three filled paths, and the three unfilled ones beside them are
+ * the label guides, which the paint filter already declines.
+ *
+ * A gauge draws **two** for its one datum, the track and the progress arc, so
+ * there is no arrangement in which its count and its marks agree and it is
+ * not counted at all -- which is also why {@link gaugeLayer} names neither.
+ *
+ * @param seriesModel - The series to ask
+ * @returns The number of marks the drawing should hold for it
+ */
+export function drawnValueCount(seriesModel: EChartsSeriesModel): number {
+  if (seriesModel.subType === 'gauge') {
+    return 0;
+  }
+  return readValues(seriesModel).length;
 }
 
 /**

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -827,9 +827,17 @@ function buildBarLayer(
 
   // A dot plot draws its values as point markers and everything else as rects
   // — a lollipop's stem is a thin bar series, and a funnel's stage is a bar.
+  //
+  // The rects of the series the payload was read from, which is not always
+  // the first: the recipe that draws a funnel's trapezoid stacks a
+  // transparent padding series under the counts, so `funnelValueColumn` picks
+  // the second data column and its bars are series 1. Marked as series 0, the
+  // outline lands on the invisible spacer at the start of the stack while the
+  // audio and the text announce the stage.
+  const series = Math.max(dataColumns(dt).indexOf(dataCol), 0);
   const selector = traceType === TraceType.DOT
     ? markPointMarkerElements(chart, container, rows, 'data-maidr-dot', 'Dot plot point')
-    : markBarElements(chart, container, rows, 1);
+    : markBarElements(chart, container, rows, series);
 
   // A reversed category axis draws the bars from the far end while Google goes
   // on emitting the rects in row order, so the payload and the selectors turn
@@ -3321,11 +3329,21 @@ function reversedBarSelectors(containerId: string, rowCount: number): string[] {
   );
 }
 
+/**
+ * Marks the rects one bar series drew, so a layer can point at them.
+ *
+ * @param chart     - The Google Chart instance
+ * @param container - The DOM container element
+ * @param rowCount  - How many categories the series was drawn for
+ * @param series    - Which series' bars carry the reading
+ * @returns CSS selector for the marked rects, or a fallback when the layout
+ *          named none of them
+ */
 function markBarElements(
   chart: GoogleChart,
   container: HTMLElement,
   rowCount: number,
-  seriesCount: number,
+  series: number,
 ): string | undefined {
   const svg = container.querySelector('svg');
   if (!svg)
@@ -3343,19 +3361,17 @@ function markBarElements(
 
   let markedCount = 0;
 
-  // For each series and data point, find the corresponding rect
-  for (let series = 0; series < seriesCount; series++) {
-    for (let dataIndex = 0; dataIndex < rowCount; dataIndex++) {
-      const bbox = layout.getBoundingBox(`bar#${series}#${dataIndex}`);
-      if (!bbox)
-        continue;
+  // For each data point of that series, find the corresponding rect
+  for (let dataIndex = 0; dataIndex < rowCount; dataIndex++) {
+    const bbox = layout.getBoundingBox(`bar#${series}#${dataIndex}`);
+    if (!bbox)
+      continue;
 
-      const rect = findRectByBoundingBox(allRects, bbox);
-      if (rect) {
-        // Mark with series and index for ordered selection
-        rect.setAttribute('data-maidr-bar', `${series}-${dataIndex}`);
-        markedCount++;
-      }
+    const rect = findRectByBoundingBox(allRects, bbox);
+    if (rect) {
+      // Mark with series and index for ordered selection
+      rect.setAttribute('data-maidr-bar', `${series}-${dataIndex}`);
+      markedCount++;
     }
   }
 

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -988,13 +988,32 @@ function buildSegmentedLayer(
   // Google Charts renders DOM in row-major order (all categories for series 0,
   // then all categories for series 1, etc.), so we set domMapping.order='row'
   // to tell MAIDR to iterate in row-major order when mapping SVG elements.
-  const selector = markSegmentedBarElements(chart, container, rows, seriesCount);
+  const marks = markSegmentedBarElements(chart, container, rows, seriesCount);
+
+  // A reversed category axis draws the categories from the far end while
+  // Google goes on emitting the rects in row order, so a layer emitted as
+  // written is announced as the mirror image of the chart -- the reading
+  // order, the stereo pan, the braille line and the direction autoplay sweeps
+  // all backwards (#1020, #1040). The single-series path has turned round
+  // since then; this one routes every chart with two or more data columns, so
+  // adding a series to a chart that read correctly silently broke it.
+  //
+  // The payload and the marks turn round together: with the categories
+  // reversed, document order no longer pairs the rects with the cells, so
+  // each cell names its own mark instead -- the same answer `#995` reached
+  // for a single series.
+  const cells = marks.cells;
+  let selectors: string | (string | null)[][] | undefined = marks.selector;
+  if (cells && drawsCategoriesReversed(chart, rows, horizontal)) {
+    data.forEach(series => series.reverse());
+    selectors = cells.map(row => [...row].reverse());
+  }
 
   return {
     id: nextId('layer'),
     type: traceType,
     orientation,
-    ...(selector ? { selectors: selector } : {}),
+    ...(selectors ? { selectors } : {}),
     // 'row' tells MAIDR that DOM elements are in row-major order (series-first)
     domMapping: { order: 'row' },
     // A stack has no single value column to name — its data columns are the
@@ -3397,6 +3416,19 @@ function markBarElements(
 }
 
 /**
+ * How a segmented chart's marks can be addressed once they are stamped.
+ */
+interface SegmentedMarks {
+  /** One selector naming every mark; document order does the pairing. */
+  selector: string | undefined;
+  /**
+   * One selector per `[series][category]` cell, `null` where the layout named
+   * no rect, or `undefined` when the marks could not be placed at all.
+   */
+  cells: (string | null)[][] | undefined;
+}
+
+/**
  * Uses the Google Charts layout API to find and mark the SVG rect elements
  * for segmented bar charts (stacked, dodged, normalized).
  *
@@ -3408,25 +3440,29 @@ function markBarElements(
  *
  * This function marks elements in the correct order for mapToSvgElements().
  *
+ * It also reports the marks **cell by cell**, which is what a reversed
+ * category axis needs: the payload is turned round to match the drawing, and
+ * document order then no longer pairs the elements with it.
+ *
  * @param chart - The Google Chart instance
  * @param container - The DOM container element
  * @param categoryCount - Number of categories
  * @param seriesCount - Number of data series
- * @returns CSS selector for the marked elements, or undefined if no elements found
+ * @returns The ways the marks can be addressed
  */
 function markSegmentedBarElements(
   chart: GoogleChart,
   container: HTMLElement,
   categoryCount: number,
   seriesCount: number,
-): string | undefined {
+): SegmentedMarks {
   const svg = container.querySelector('svg');
   if (!svg)
-    return undefined;
+    return { selector: undefined, cells: undefined };
 
   const layout = chart.getChartLayoutInterface();
   if (!layout)
-    return buildDataSelector(container, 'rect');
+    return { selector: buildDataSelector(container, 'rect'), cells: undefined };
 
   // Get all rects in the SVG
   const allRects = svg.querySelectorAll('rect');
@@ -3446,27 +3482,30 @@ function markSegmentedBarElements(
   //       svgElements[r].push(domElements[domIndex++])
   //
   // Google Charts' getBoundingBox uses: bar#seriesIndex#categoryIndex
+  // Stamped with the cell it draws rather than with a running count, so a
+  // cell can be named outright and a rect the layout did not place does not
+  // shift the numbering of the ones after it.
+  const cells: (string | null)[][] = [];
   for (let series = 0; series < seriesCount; series++) {
+    const row: (string | null)[] = [];
     for (let category = 0; category < categoryCount; category++) {
       const bbox = layout.getBoundingBox(`bar#${series}#${category}`);
-      if (!bbox) {
-        continue;
-      }
-
-      const rect = findRectByBoundingBox(allRects, bbox);
+      const rect = bbox ? findRectByBoundingBox(allRects, bbox) : null;
       if (rect) {
-        rect.setAttribute('data-maidr-bar', `${markedCount}`);
+        rect.setAttribute('data-maidr-bar', `${series}-${category}`);
+        row.push(`#${container.id} svg rect[data-maidr-bar="${series}-${category}"]`);
         markedCount++;
+      } else {
+        row.push(null);
       }
     }
+    cells.push(row);
   }
 
-  const selector = `#${container.id} svg rect[data-maidr-bar]`;
-
   if (markedCount === 0)
-    return buildDataSelector(container, 'rect');
+    return { selector: buildDataSelector(container, 'rect'), cells: undefined };
 
-  return selector;
+  return { selector: `#${container.id} svg rect[data-maidr-bar]`, cells };
 }
 
 /**

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -3639,7 +3639,20 @@ function markScatterElements(
     return buildDataSelector(container, 'circle');
   }
 
-  return `#${container.id} svg circle[data-maidr-point]`;
+  // Verified before it ships, the way the volcano and Manhattan path already
+  // verifies its own marks. Two coincident points -- routine in binned or
+  // rounded data -- leave the second one sharing the first one's circle and
+  // the list one short, and a chart that emitted its circles in an order
+  // other than the data's would outline a different point from the one being
+  // announced on every move.
+  return pairedCircleSelector(
+    container,
+    allCircles,
+    'data-maidr-point',
+    markedCount,
+    data.length,
+    'Scatter point',
+  );
 }
 
 /**
@@ -4192,14 +4205,6 @@ function markSeriesPointElements(
   // Clear any existing marks from previous initializations
   allCircles.forEach(circle => circle.removeAttribute(attribute));
 
-  const withdraw = (): undefined => {
-    // A partial or out-of-order match is withdrawn rather than shipped: the
-    // marks left behind would resolve to a list that does not line up with the
-    // data, and the next chart drawn into this container would inherit them.
-    allCircles.forEach(circle => circle.removeAttribute(attribute));
-    return undefined;
-  };
-
   // Read once into buckets rather than rescanning the list per point: these
   // charts carry tens of thousands of points, and the scan is what froze the
   // tab before the chart became accessible at all.
@@ -4218,17 +4223,63 @@ function markSeriesPointElements(
     }
   });
 
-  if (markedCount !== marks.length) {
+  return pairedCircleSelector(
+    container,
+    allCircles,
+    attribute,
+    markedCount,
+    marks.length,
+    what,
+  );
+}
+
+/**
+ * The selector for a set of stamped circles, once the pairing is verified.
+ *
+ * Two checks, and a chart that fails either keeps its reading and loses its
+ * outline. **Every** point has to have found a mark: a short list resolves to
+ * circles that do not line up with the data, which `ScatterTrace` declines
+ * outright rather than half-highlighting. And the **document order** has to
+ * be the data's, because a single attribute selector is resolved in document
+ * order while the marks are made in data order -- so a chart that emitted its
+ * circles some other way would highlight a point belonging to a different row
+ * on every move, silently, and only in the highlight.
+ *
+ * @param container   - The DOM container element
+ * @param circles     - Every circle in the chart's SVG
+ * @param attribute   - The marking attribute that was set
+ * @param markedCount - How many points found a circle of their own
+ * @param expected    - How many points there are
+ * @param what        - What the points are, for the warnings
+ * @returns The selector, or `undefined` when the pairing cannot be trusted
+ */
+function pairedCircleSelector(
+  container: HTMLElement,
+  circles: NodeListOf<SVGCircleElement>,
+  attribute: string,
+  markedCount: number,
+  expected: number,
+  what: string,
+): string | undefined {
+  // A partial or out-of-order match is withdrawn rather than shipped: the
+  // marks left behind would resolve to a list that does not line up with the
+  // data, and the next chart drawn into this container would inherit them.
+  const withdraw = (): undefined => {
+    circles.forEach(circle => circle.removeAttribute(attribute));
+    return undefined;
+  };
+
+  if (markedCount !== expected) {
     if (markedCount > 0) {
       console.warn(
-        `[MAIDR] ${what} count mismatch: expected ${marks.length}, marked ${markedCount}. `
+        `[MAIDR] ${what} count mismatch: expected ${expected}, marked ${markedCount}. `
         + 'Visual highlighting is disabled for this chart.',
       );
     }
     return withdraw();
   }
 
-  const drawn = Array.from(svg.querySelectorAll(`circle[${attribute}]`));
+  const drawn = Array.from(container.querySelectorAll(`circle[${attribute}]`));
   if (drawn.some((circle, index) => circle.getAttribute(attribute) !== `${index}`)) {
     console.warn(
       `[MAIDR] ${what} order mismatch: the chart drew its markers in an order other than `

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -1077,7 +1077,10 @@ function buildLineLayer(
       const at = reversed ? rows - 1 - r : r;
       const x = formatCellValue(dt, at, 0);
       const y = numericValue(dt, at, c);
-      const z = dt.getColumnLabel(c) || `Series ${c}`;
+      // Numbered by series rather than by column: a table carrying a role
+      // column before its first series would otherwise announce that series
+      // as "Series 2".
+      const z = dt.getColumnLabel(c) || `Series ${seriesCount + 1}`;
       series.push({ x, y, z });
     }
     data.push(series);
@@ -1099,7 +1102,19 @@ function buildLineLayer(
     ...(reversed ? { domMapping: { pointOrder: 'reverse' as const } } : {}),
     axes: {
       x: { label: dt.getColumnLabel(0) || undefined },
-      y: { label: dt.getColumnLabel(1) || undefined },
+      // The magnitude axis is named only when one series carries it. Column 1
+      // is the *first series* of a multi-series line, area or bump chart, so
+      // naming the axis after it announced every value of every other series
+      // under the first one's name -- the reader told "Sales" while
+      // navigating Costs. The same call `buildSegmentedLayer` makes for a
+      // stack (#961) and `buildSurvivalLayer` for two arms. It also asks
+      // `firstDataColumn` rather than assuming column 1, which may be a
+      // tooltip or an annotation.
+      y: {
+        label: seriesCount === 1
+          ? dt.getColumnLabel(firstDataColumn(dt)) || undefined
+          : undefined,
+      },
     },
     data,
   };

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -61,6 +61,7 @@ import type {
 import type {
   GoogleBoundingBox,
   GoogleChart,
+  GoogleChartLayoutInterface,
   GoogleChartType,
   GoogleDataTable,
   GoogleEvents,
@@ -3282,6 +3283,31 @@ function numberColumn(dt: GoogleDataTable, from: number): number | undefined {
  * @returns CSS selector for the marked elements, or undefined if no elements found
  */
 /**
+ * The chart's layout interface, when the package it was drawn with has one.
+ *
+ * Asked rather than called: a great many packages expose no
+ * `getChartLayoutInterface` at all -- the material builders
+ * (`google.charts.Bar`, `google.charts.Line`), and Calendar, Gauge, Sankey,
+ * OrgChart and TreeMap among the classic ones -- and a build whose interface
+ * differs can throw from inside it. Either way the throw travels out of
+ * `createMaidrFromGoogleChart` inside the caller's own `ready` handler, so
+ * the `maidr` attribute is never set and the chart is not merely
+ * unhighlighted but entirely inaccessible. The intended degradation is no
+ * highlight with the audio, text and braille intact, which every caller's
+ * `if (!layout)` branch already provides.
+ *
+ * @param chart - The drawn Google Chart
+ * @returns The layout interface, or `undefined` when there is none to ask
+ */
+function chartLayout(chart: GoogleChart): GoogleChartLayoutInterface | undefined {
+  try {
+    return chart.getChartLayoutInterface?.();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Whether the chart draws its categories in the opposite order to the rows.
  *
  * `hAxis: {direction: -1}` (or `vAxis` on a bar chart) reverses which end the
@@ -3331,7 +3357,7 @@ function drawsCategoriesReversed(
   if (rowCount < 2)
     return false;
   try {
-    const layout = chart.getChartLayoutInterface();
+    const layout = chartLayout(chart);
     const locate = horizontal ? layout?.getYLocation : layout?.getXLocation;
     const first = locate?.call(layout, 0);
     const last = locate?.call(layout, rowCount - 1);
@@ -3383,7 +3409,7 @@ function markBarElements(
   if (!svg)
     return undefined;
 
-  const layout = chart.getChartLayoutInterface();
+  const layout = chartLayout(chart);
   if (!layout)
     return buildDataSelector(container, 'rect');
 
@@ -3460,7 +3486,7 @@ function markSegmentedBarElements(
   if (!svg)
     return { selector: undefined, cells: undefined };
 
-  const layout = chart.getChartLayoutInterface();
+  const layout = chartLayout(chart);
   if (!layout)
     return { selector: buildDataSelector(container, 'rect'), cells: undefined };
 
@@ -3564,7 +3590,7 @@ function markScatterElements(
   if (!svg)
     return undefined;
 
-  const layout = chart.getChartLayoutInterface();
+  const layout = chartLayout(chart);
   if (!layout)
     return buildDataSelector(container, 'circle');
 
@@ -4153,7 +4179,7 @@ function markSeriesPointElements(
     return undefined;
   }
 
-  const layout = chart.getChartLayoutInterface();
+  const layout = chartLayout(chart);
   if (!layout) {
     return undefined;
   }

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -68,6 +68,7 @@ import type {
   GoogleGaugeOptions,
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
+import { cssEscape } from '../shared/selectorUtil';
 import { buildDataSelector, ensureContainerId, nextId } from './selectors';
 
 /**
@@ -417,7 +418,7 @@ export function createMaidrFromGoogleCharts(
     }
     return {
       layers,
-      selector: `#${panel.container.id} svg`,
+      selector: `#${cssEscape(panel.container.id)} svg`,
     };
   }));
 
@@ -1521,7 +1522,7 @@ function markPieSliceElements(
 
   wedges.forEach((wedge, index) => wedge.setAttribute('data-maidr-slice', `${index}`));
 
-  return `#${container.id} svg path[data-maidr-slice]`;
+  return `#${cssEscape(container.id)} svg path[data-maidr-slice]`;
 }
 
 // ---------------------------------------------------------------------------
@@ -2786,7 +2787,7 @@ function markCalendarCells(
 
   cells.forEach((cell, index) => cell.setAttribute(CALENDAR_DAY_ATTR, `${index}`));
 
-  return index => `#${container.id} svg rect[${CALENDAR_DAY_ATTR}="${index}"]`;
+  return index => `#${cssEscape(container.id)} svg rect[${CALENDAR_DAY_ATTR}="${index}"]`;
 }
 
 /**
@@ -3385,7 +3386,7 @@ function drawsCategoriesReversed(
 function reversedBarSelectors(containerId: string, rowCount: number): string[] {
   return Array.from(
     { length: rowCount },
-    (_, i) => `#${containerId} svg rect[data-maidr-bar="0-${rowCount - 1 - i}"]`,
+    (_, i) => `#${cssEscape(containerId)} svg rect[data-maidr-bar="0-${rowCount - 1 - i}"]`,
   );
 }
 
@@ -3445,7 +3446,7 @@ function markBarElements(
   if (markedCount === 0)
     return buildDataSelector(container, 'rect');
 
-  return `#${container.id} svg rect[data-maidr-bar]`;
+  return `#${cssEscape(container.id)} svg rect[data-maidr-bar]`;
 }
 
 /**
@@ -3533,7 +3534,7 @@ function markSegmentedBarElements(
       const rect = bbox ? findRectByBoundingBox(placed, bbox) : null;
       if (rect) {
         rect.setAttribute('data-maidr-bar', `${series}-${category}`);
-        row.push(`#${container.id} svg rect[data-maidr-bar="${series}-${category}"]`);
+        row.push(`#${cssEscape(container.id)} svg rect[data-maidr-bar="${series}-${category}"]`);
         markedCount++;
       } else {
         row.push(null);
@@ -3545,7 +3546,7 @@ function markSegmentedBarElements(
   if (markedCount === 0)
     return { selector: buildDataSelector(container, 'rect'), cells: undefined };
 
-  return { selector: `#${container.id} svg rect[data-maidr-bar]`, cells };
+  return { selector: `#${cssEscape(container.id)} svg rect[data-maidr-bar]`, cells };
 }
 
 /**
@@ -3894,7 +3895,7 @@ function markLinePointElements(
   for (let series = 0; series < pathsToMark; series++) {
     const path = linePaths[series];
     path.setAttribute('data-maidr-line-series', `${series}`);
-    selectors.push(`#${container.id} svg path[data-maidr-line-series="${series}"]`);
+    selectors.push(`#${cssEscape(container.id)} svg path[data-maidr-line-series="${series}"]`);
   }
 
   return selectors.length > 0 ? selectors : undefined;
@@ -3968,11 +3969,11 @@ function markCandlestickElements(
 
   // Build selector object
   const selector: CandlestickSelector = {
-    body: `#${container.id} svg rect[data-maidr-candle-body]`,
+    body: `#${cssEscape(container.id)} svg rect[data-maidr-candle-body]`,
   };
 
   if (wicksToMark > 0) {
-    selector.wick = `#${container.id} svg rect[data-maidr-candle-wick]`;
+    selector.wick = `#${cssEscape(container.id)} svg rect[data-maidr-candle-wick]`;
   }
 
   return selector;
@@ -4075,7 +4076,7 @@ function markFloatingBarElements(
 
   bodies.forEach((body, index) => body.setAttribute('data-maidr-step', `${index}`));
 
-  return bodies.map((_, index) => `#${container.id} svg rect[data-maidr-step="${index}"]`);
+  return bodies.map((_, index) => `#${cssEscape(container.id)} svg rect[data-maidr-step="${index}"]`);
 }
 
 /**
@@ -4127,7 +4128,7 @@ function markGaugeDialElements(
 
   dials.forEach((dial, index) => dial.setAttribute('data-maidr-dial', `${index}`));
 
-  return dials.map((_, index) => `#${container.id} [data-maidr-dial="${index}"]`);
+  return dials.map((_, index) => `#${cssEscape(container.id)} [data-maidr-dial="${index}"]`);
 }
 
 /**
@@ -4307,7 +4308,7 @@ function pairedCircleSelector(
     return withdraw();
   }
 
-  return `#${container.id} svg circle[${attribute}]`;
+  return `#${cssEscape(container.id)} svg circle[${attribute}]`;
 }
 
 /**
@@ -4359,7 +4360,7 @@ function markFlowRibbonElements(
 
   ribbons.forEach((ribbon, index) => ribbon.setAttribute('data-maidr-flow', `${index}`));
 
-  return `#${container.id} svg path[data-maidr-flow]`;
+  return `#${cssEscape(container.id)} svg path[data-maidr-flow]`;
 }
 
 /**
@@ -4425,5 +4426,5 @@ function markRectCellElements(
 
   cells.forEach((cell, index) => cell.setAttribute(attribute, `${index}`));
 
-  return `#${container.id} svg rect[${attribute}]`;
+  return `#${cssEscape(container.id)} svg rect[${attribute}]`;
 }

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -3506,13 +3506,16 @@ function markScatterElements(
   // Clear any existing marks from previous initializations
   allCircles.forEach(circle => circle.removeAttribute('data-maidr-point'));
 
+  // Read once into buckets rather than rescanning the list per point.
+  const placed = indexCircles(allCircles);
+
   let markedCount = 0;
 
   // Approach 1: Try getBoundingBox('point#series#row') - similar to bar charts
   for (let i = 0; i < data.length; i++) {
     const bbox = layout.getBoundingBox(`point#0#${i}`);
     if (bbox) {
-      const circle = findCircleByBoundingBox(allCircles, bbox);
+      const circle = findCircleByBoundingBox(placed, bbox);
       if (circle && !circle.hasAttribute('data-maidr-point')) {
         circle.setAttribute('data-maidr-point', `${i}`);
         markedCount++;
@@ -3528,7 +3531,7 @@ function markScatterElements(
       const expectedY = layout.getYLocation(point.y);
 
       // Skip circles that are already marked (handles multiple circles per point)
-      const circle = findUnmarkedCircleByPosition(allCircles, expectedX, expectedY);
+      const circle = findUnmarkedCircleByPosition(placed, expectedX, expectedY);
       if (circle) {
         circle.setAttribute('data-maidr-point', `${i}`);
         markedCount++;
@@ -3544,35 +3547,147 @@ function markScatterElements(
 }
 
 /**
+ * One drawn element, with the position a search matches it on.
+ */
+interface PlacedMark<T extends Element> {
+  element: T;
+  /** Where it sits in the document, so a tie is broken as a scan would. */
+  order: number;
+  x: number;
+  y: number;
+}
+
+/**
+ * Drawn marks bucketed by where they were drawn.
+ *
+ * A chart's marks are matched to its data by position, and doing that with a
+ * scan of the whole element list per datum is O(data x elements) with two DOM
+ * reads in the inner loop — run synchronously inside the caller's `ready`
+ * handler. The charts that reach it are the ones that cannot afford it: a
+ * volcano or Manhattan plot "carries tens of thousands of points of which a
+ * few dozen matter", and a 100-category by 12-series stacked column chart is
+ * 1.5M inner iterations. Reading each element once into buckets makes every
+ * later lookup touch a handful of candidates instead.
+ */
+type MarkIndex<T extends Element> = Map<string, PlacedMark<T>[]>;
+
+/**
+ * The side of one bucket, in pixels.
+ *
+ * Twice the tolerance, so a query's tolerance box spans at most two buckets
+ * on each axis and a lookup reads four of them at the most.
+ */
+const INDEX_CELL = POSITION_TOLERANCE * 2;
+
+function cellKey(x: number, y: number): string {
+  return `${Math.floor(x / INDEX_CELL)},${Math.floor(y / INDEX_CELL)}`;
+}
+
+/**
+ * Buckets a list of drawn elements by the position it is matched on.
+ *
+ * @param elements - The drawn elements, in document order
+ * @param at       - Where each one sits
+ * @returns The index
+ */
+function indexMarks<T extends Element>(
+  elements: NodeListOf<T>,
+  at: (element: T) => { x: number; y: number },
+): MarkIndex<T> {
+  const index: MarkIndex<T> = new Map();
+  elements.forEach((element, order) => {
+    const { x, y } = at(element);
+    const key = cellKey(x, y);
+    const cell = index.get(key);
+    const mark: PlacedMark<T> = { element, order, x, y };
+    if (cell) {
+      cell.push(mark);
+    } else {
+      index.set(key, [mark]);
+    }
+  });
+  return index;
+}
+
+/**
+ * The first mark drawn at a position, in document order.
+ *
+ * Document order rather than bucket order: a scan answered with the first
+ * element of the list that matched, and two coincident marks are routine in
+ * binned or rounded data, so anything else would silently pair a datum with a
+ * different element than it used to.
+ *
+ * @param index  - The marks to search
+ * @param x      - The x the mark should sit at
+ * @param y      - The y the mark should sit at
+ * @param accept - An extra condition on the mark, defaulting to none
+ * @returns The matching element, or null when nothing was drawn there
+ */
+function markAt<T extends Element>(
+  index: MarkIndex<T>,
+  x: number,
+  y: number,
+  accept?: (element: T) => boolean,
+): T | null {
+  const first = Math.floor((x - POSITION_TOLERANCE) / INDEX_CELL);
+  const last = Math.floor((x + POSITION_TOLERANCE) / INDEX_CELL);
+  const top = Math.floor((y - POSITION_TOLERANCE) / INDEX_CELL);
+  const bottom = Math.floor((y + POSITION_TOLERANCE) / INDEX_CELL);
+
+  let found: PlacedMark<T> | null = null;
+  for (let column = first; column <= last; column++) {
+    for (let row = top; row <= bottom; row++) {
+      const cell = index.get(`${column},${row}`);
+      if (!cell) {
+        continue;
+      }
+      for (const mark of cell) {
+        if (Math.abs(mark.x - x) > POSITION_TOLERANCE) {
+          continue;
+        }
+        if (Math.abs(mark.y - y) > POSITION_TOLERANCE) {
+          continue;
+        }
+        if (accept && !accept(mark.element)) {
+          continue;
+        }
+        if (found === null || mark.order < found.order) {
+          found = mark;
+        }
+      }
+    }
+  }
+
+  return found === null ? null : found.element;
+}
+
+/**
+ * Indexes a chart's circles by their centres.
+ *
+ * @param circles - NodeList of SVG circle elements
+ * @returns The index the marker searches below read from
+ */
+function indexCircles(circles: NodeListOf<SVGCircleElement>): MarkIndex<SVGCircleElement> {
+  return indexMarks(circles, circle => ({
+    x: Number.parseFloat(circle.getAttribute('cx') || '0'),
+    y: Number.parseFloat(circle.getAttribute('cy') || '0'),
+  }));
+}
+
+/**
  * Finds an SVG circle element that matches the given bounding box.
  *
  * The bounding box center should match the circle's cx/cy position.
  *
- * @param circles - NodeList of SVG circle elements to search
+ * @param circles - Index of the SVG circle elements to search
  * @param bbox - The target bounding box from the chart layout API
  * @returns The matching circle element, or null if not found
  */
 function findCircleByBoundingBox(
-  circles: NodeListOf<SVGCircleElement>,
+  circles: MarkIndex<SVGCircleElement>,
   bbox: GoogleBoundingBox,
 ): SVGCircleElement | null {
-  // Calculate center of bounding box
-  const centerX = bbox.left + bbox.width / 2;
-  const centerY = bbox.top + bbox.height / 2;
-
-  for (const circle of circles) {
-    const cx = Number.parseFloat(circle.getAttribute('cx') || '0');
-    const cy = Number.parseFloat(circle.getAttribute('cy') || '0');
-
-    // Match by center position with tolerance
-    const xMatch = Math.abs(cx - centerX) <= POSITION_TOLERANCE;
-    const yMatch = Math.abs(cy - centerY) <= POSITION_TOLERANCE;
-
-    if (xMatch && yMatch) {
-      return circle;
-    }
-  }
-  return null;
+  return markAt(circles, bbox.left + bbox.width / 2, bbox.top + bbox.height / 2);
 }
 
 /**
@@ -3581,34 +3696,22 @@ function findCircleByBoundingBox(
  * Skips circles that already have the data-maidr-point attribute to handle
  * Google Charts rendering multiple overlapping circles per data point.
  *
- * @param circles - NodeList of SVG circle elements to search
+ * @param circles - Index of the SVG circle elements to search
  * @param expectedX - Expected x-coordinate (center)
  * @param expectedY - Expected y-coordinate (center)
  * @returns The matching unmarked circle element, or null if not found
  */
 function findUnmarkedCircleByPosition(
-  circles: NodeListOf<SVGCircleElement>,
+  circles: MarkIndex<SVGCircleElement>,
   expectedX: number,
   expectedY: number,
 ): SVGCircleElement | null {
-  for (const circle of circles) {
-    // Skip already-marked circles
-    if (circle.hasAttribute('data-maidr-point')) {
-      continue;
-    }
-
-    const cx = Number.parseFloat(circle.getAttribute('cx') || '0');
-    const cy = Number.parseFloat(circle.getAttribute('cy') || '0');
-
-    // Match by center position with tolerance
-    const xMatch = Math.abs(cx - expectedX) <= POSITION_TOLERANCE;
-    const yMatch = Math.abs(cy - expectedY) <= POSITION_TOLERANCE;
-
-    if (xMatch && yMatch) {
-      return circle;
-    }
-  }
-  return null;
+  return markAt(
+    circles,
+    expectedX,
+    expectedY,
+    circle => !circle.hasAttribute('data-maidr-point'),
+  );
 }
 
 /**
@@ -4001,13 +4104,18 @@ function markSeriesPointElements(
     return undefined;
   };
 
+  // Read once into buckets rather than rescanning the list per point: these
+  // charts carry tens of thousands of points, and the scan is what froze the
+  // tab before the chart became accessible at all.
+  const placed = indexCircles(allCircles);
+
   let markedCount = 0;
   marks.forEach((mark, index) => {
     const bbox = layout.getBoundingBox(`point#${mark.series}#${mark.row}`);
     if (!bbox) {
       return;
     }
-    const circle = findCircleByBoundingBox(allCircles, bbox);
+    const circle = findCircleByBoundingBox(placed, bbox);
     if (circle && !circle.hasAttribute(attribute)) {
       circle.setAttribute(attribute, `${index}`);
       markedCount++;

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -3419,6 +3419,13 @@ function markBarElements(
   // Clear any existing marks from previous initializations
   allRects.forEach(rect => rect.removeAttribute('data-maidr-bar'));
 
+  // Read once into buckets rather than rescanning the list per bar: a
+  // segmented chart draws about as many rects as it has bars, so a scan each
+  // time is quadratic in chart size -- 1.5M inner iterations and some 6M DOM
+  // reads on a 100-category by 12-series stack, all of it synchronous inside
+  // the caller's `ready` handler.
+  const placed = indexRects(allRects);
+
   let markedCount = 0;
 
   // For each data point of that series, find the corresponding rect
@@ -3427,7 +3434,7 @@ function markBarElements(
     if (!bbox)
       continue;
 
-    const rect = findRectByBoundingBox(allRects, bbox);
+    const rect = findRectByBoundingBox(placed, bbox);
     if (rect) {
       // Mark with series and index for ordered selection
       rect.setAttribute('data-maidr-bar', `${series}-${dataIndex}`);
@@ -3496,6 +3503,13 @@ function markSegmentedBarElements(
   // Clear any existing marks from previous initializations
   allRects.forEach(rect => rect.removeAttribute('data-maidr-bar'));
 
+  // Read once into buckets rather than rescanning the list per bar: a
+  // segmented chart draws about as many rects as it has bars, so a scan each
+  // time is quadratic in chart size -- 1.5M inner iterations and some 6M DOM
+  // reads on a 100-category by 12-series stack, all of it synchronous inside
+  // the caller's `ready` handler.
+  const placed = indexRects(allRects);
+
   let markedCount = 0;
 
   // Mark elements in ROW-MAJOR order (series-first, then categories within each series)
@@ -3516,7 +3530,7 @@ function markSegmentedBarElements(
     const row: (string | null)[] = [];
     for (let category = 0; category < categoryCount; category++) {
       const bbox = layout.getBoundingBox(`bar#${series}#${category}`);
-      const rect = bbox ? findRectByBoundingBox(allRects, bbox) : null;
+      const rect = bbox ? findRectByBoundingBox(placed, bbox) : null;
       if (rect) {
         rect.setAttribute('data-maidr-bar', `${series}-${category}`);
         row.push(`#${container.id} svg rect[data-maidr-bar="${series}-${category}"]`);
@@ -3535,36 +3549,40 @@ function markSegmentedBarElements(
 }
 
 /**
+ * Indexes a chart's rects by their top-left corners.
+ *
+ * @param rects - NodeList of SVG rect elements
+ * @returns The index {@link findRectByBoundingBox} reads from
+ */
+function indexRects(rects: NodeListOf<SVGRectElement>): MarkIndex<SVGRectElement> {
+  return indexMarks(rects, rect => ({
+    x: Number.parseFloat(rect.getAttribute('x') || '0'),
+    y: Number.parseFloat(rect.getAttribute('y') || '0'),
+  }));
+}
+
+/**
  * Finds an SVG rect element that matches the given bounding box coordinates.
  *
  * Due to floating-point precision issues in Google Charts rendering,
  * we use a small tolerance when comparing positions.
  *
- * @param rects - NodeList of SVG rect elements to search
+ * @param rects - Index of the SVG rect elements to search
  * @param bbox - The target bounding box from the chart layout API
  * @returns The matching rect element, or null if not found
  */
 function findRectByBoundingBox(
-  rects: NodeListOf<SVGRectElement>,
+  rects: MarkIndex<SVGRectElement>,
   bbox: GoogleBoundingBox,
 ): SVGRectElement | null {
-  for (const rect of rects) {
-    const x = Number.parseFloat(rect.getAttribute('x') || '0');
-    const y = Number.parseFloat(rect.getAttribute('y') || '0');
+  // The corner narrows the candidates to a handful; the size then tells two
+  // bars that start at the same place apart, as the full scan did.
+  return markAt(rects, bbox.left, bbox.top, (rect) => {
     const width = Number.parseFloat(rect.getAttribute('width') || '0');
     const height = Number.parseFloat(rect.getAttribute('height') || '0');
-
-    // Match by position and size with tolerance
-    const xMatch = Math.abs(x - bbox.left) <= POSITION_TOLERANCE;
-    const yMatch = Math.abs(y - bbox.top) <= POSITION_TOLERANCE;
-    const widthMatch = Math.abs(width - bbox.width) <= POSITION_TOLERANCE;
-    const heightMatch = Math.abs(height - bbox.height) <= POSITION_TOLERANCE;
-
-    if (xMatch && yMatch && widthMatch && heightMatch) {
-      return rect;
-    }
-  }
-  return null;
+    return Math.abs(width - bbox.width) <= POSITION_TOLERANCE
+      && Math.abs(height - bbox.height) <= POSITION_TOLERANCE;
+  });
 }
 
 /**

--- a/src/adapters/google-charts/selectors.ts
+++ b/src/adapters/google-charts/selectors.ts
@@ -25,6 +25,8 @@
  * from other charts on the same page.
  */
 
+import { cssEscape } from '../shared/selectorUtil';
+
 let idCounter = 0;
 
 /**
@@ -88,12 +90,12 @@ export function buildDataSelector(
   const clippedSelector = `g[clip-path] > ${elementSelector}`;
   const clippedCandidates = svg.querySelectorAll(clippedSelector);
   if (clippedCandidates.length > 0)
-    return `#${container.id} svg ${clippedSelector}`;
+    return `#${cssEscape(container.id)} svg ${clippedSelector}`;
 
   // Fallback: any matching element in the SVG.
   const candidates = svg.querySelectorAll(elementSelector);
   if (candidates.length > 0)
-    return `#${container.id} svg ${elementSelector}`;
+    return `#${cssEscape(container.id)} svg ${elementSelector}`;
 
   return undefined;
 }

--- a/src/adapters/google-charts/types.ts
+++ b/src/adapters/google-charts/types.ts
@@ -86,9 +86,18 @@ export interface GoogleChart {
   /**
    * Returns the chart layout interface for accessing element positions.
    *
+   * Optional, because a great many packages do not have one: the material
+   * builders (`google.charts.Bar`, `google.charts.Line`), and Calendar,
+   * Gauge, Sankey, OrgChart and TreeMap among the classic ones. On those a
+   * call throws `chart.getChartLayoutInterface is not a function`, so it is
+   * asked through `chartLayout()` rather than called directly -- a throw here
+   * travels out of the conversion inside the caller's own `ready` handler and
+   * costs the chart its reading altogether, where the intended degradation is
+   * no highlight with the audio, text and braille intact.
+   *
    * @see https://developers.google.com/chart/interactive/docs/gallery/columnchart#methods
    */
-  getChartLayoutInterface: () => GoogleChartLayoutInterface;
+  getChartLayoutInterface?: () => GoogleChartLayoutInterface;
 }
 
 /**

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -272,6 +272,27 @@ describe('an eCharts bar chart', () => {
       { x: 'C', y: 2, z: 'Two' },
     ]);
   });
+
+  it('is stacked only when every series is in the same stack', () => {
+    // ECharts stacks the series that share a `stack` name and draws the rest
+    // beside them, so `stack: 'a', 'a', 'b', 'b'` is two stacks side by side
+    // and a stacked series next to a plain one is a mixed chart. Calling
+    // either one stacked tells the reader the bars sit on top of each other
+    // when they do not.
+    const grouped = [
+      { type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'One', stack: 'a' },
+      { type: 'bar', names: CATEGORIES, values: [3, 1, 2], name: 'Two', stack: 'b' },
+    ];
+    expect(layersOf({ series: grouped }, drawnChart(6, 0))[0].type)
+      .toBe(TraceType.DODGED);
+
+    const mixed = [
+      { type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'One', stack: 'a' },
+      { type: 'bar', names: CATEGORIES, values: [3, 1, 2], name: 'Two' },
+    ];
+    expect(layersOf({ series: mixed }, drawnChart(6, 0))[0].type)
+      .toBe(TraceType.DODGED);
+  });
 });
 
 describe('an eCharts line chart', () => {

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -220,6 +220,38 @@ describe('an eCharts bar chart', () => {
     expect(layer.selectors).toHaveLength(2);
   });
 
+  it('keeps a category one series has no bar at, so the rows stay aligned', () => {
+    // `SegmentedTrace` pairs its rows by column index, so a row shortened by
+    // a gap puts every later category against another series' value and
+    // drops the last one from the summary altogether (#1002).
+    const [layer] = layersOf(
+      {
+        series: [
+          { type: 'bar', names: CATEGORIES, values: [1, null, 3], name: 'One', stack: 'total' },
+          { type: 'bar', names: CATEGORIES, values: [4, 5, 6], name: 'Two', stack: 'total' },
+        ],
+      },
+      drawnChart(5, 0),
+    );
+
+    const rows = layer.data as SegmentedPoint[][];
+
+    expect(rows.map(row => row.map(point => point.x))).toEqual([
+      ['A', 'B', 'C'],
+      ['A', 'B', 'C'],
+    ]);
+    // A gap and not a zero, which would be announced as a reading, reached as
+    // the row's minimum, and would pull the range every other bar is scaled
+    // against.
+    expect(rows[0][1].y).toBeNaN();
+    // The chart drew no mark there, so the cell names none -- keeping the
+    // selectors paired with the cells they belong to.
+    expect(layer.selectors).toEqual([
+      [expect.any(String), null, expect.any(String)],
+      [expect.any(String), expect.any(String), expect.any(String)],
+    ]);
+  });
+
   it('is stacked when the series share a stack, and dodged when they do not', () => {
     const series = [
       { type: 'bar', names: CATEGORIES, values: [1, 2, 3], name: 'One' },

--- a/test/adapters/echarts/cartesian.test.ts
+++ b/test/adapters/echarts/cartesian.test.ts
@@ -582,6 +582,31 @@ describe('what the adapter will not claim', () => {
     expect(layer.data as BarPoint[]).toHaveLength(3);
   });
 
+  it('counts an area series band, which is painted as a mark too', () => {
+    // A line series declared with `areaStyle` paints a filled band under the
+    // curve in the series colour, which is exactly what `isFilledMark`
+    // accepts. Left out of the count, the band is found among the candidates
+    // and nothing accounts for it, so the totals disagree and the whole
+    // chart -- the bars included -- loses its highlighting.
+    const [bar, area] = layersOf(
+      {
+        series: [
+          { type: 'bar', names: CATEGORIES, values: [1, 2, 3] },
+          { type: 'line', names: CATEGORIES, values: [3, 2, 1], areaStyle: {} },
+        ],
+      },
+      drawnChart(4, 1),
+    );
+
+    expect(bar.type).toBe(TraceType.BAR);
+    expect(bar.selectors).toHaveLength(3);
+    expect(area.type).toBe(TraceType.AREA);
+    // The band is not the area's outline: a line layer is highlighted by its
+    // stroked polyline, which is one selector for the whole series.
+    expect(typeof area.selectors).toBe('string');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('names a layer only when the author named the series', () => {
     // ECharts always resolves a name, inventing one for a series declared
     // without any, and emitting that would name a layer after a counter.

--- a/test/adapters/echarts/gridValue.test.ts
+++ b/test/adapters/echarts/gridValue.test.ts
@@ -88,10 +88,13 @@ function fakeSeriesModel(series: FakeSeries): EChartsSeriesModel {
   };
 }
 
+/** A category axis label, plain or in the per-label object form. */
+type FakeLabel = string | { value: string; textStyle?: { color: string } };
+
 interface FakeChart {
   series: FakeSeries[];
-  xData?: string[];
-  yData?: string[];
+  xData?: FakeLabel[];
+  yData?: FakeLabel[];
   xName?: string;
   yName?: string;
 }
@@ -235,6 +238,20 @@ describe('an eCharts heat grid', () => {
       y: ['r1', 'r0'],
       points: [[10, 11, 12], [0, 1, 2]],
     });
+  });
+
+  it('reads a label the author styled, rather than stringifying the object', () => {
+    // A category axis' `data` officially takes a per-label object -- the way
+    // an author colours one weekday -- and those labels are the only handle
+    // a heat grid's reader has: they are announced on every row and column
+    // move. Stringified, that whole row announces as "[object Object]",
+    // while the numbers stay right and say nothing is wrong.
+    const [layer] = layersOf(
+      { ...GRID, yData: ['r0', { value: 'r1', textStyle: { color: 'red' } }] },
+      drawnChart(6, true),
+    );
+
+    expect((layer.data as HeatmapData).y).toEqual(['r1', 'r0']);
   });
 
   it('names both axes after the titles the chart carries', () => {

--- a/test/adapters/echarts/hierarchy.test.ts
+++ b/test/adapters/echarts/hierarchy.test.ts
@@ -264,6 +264,41 @@ describe('which hierarchies can be outlined', () => {
     ]);
   });
 
+  it('walks a sunburst once, for the count and the payload together', () => {
+    // The walk allocates a point per node, copies the ancestor path at every
+    // one of them, and asks each node and each of its children for a value.
+    // Asking for the count and then again for the payload doubles all of it,
+    // on the one hierarchy large enough to notice.
+    let reads = 0;
+    const series: FakeSeries = { type: 'sunburst', nodes: FOREST };
+    const instance: EChartsInstance = {
+      getModel: () => ({
+        eachSeries: (callback) => {
+          callback({
+            subType: series.type,
+            name: 'series 0',
+            getData: () => {
+              reads += 1;
+              return fakeList(series);
+            },
+            get: () => undefined,
+          } as EChartsSeriesModel, 0);
+        },
+        eachComponent: () => {},
+      }),
+    };
+
+    const layer = createMaidrFromEChart(instance, drawnChart(5))
+      .subplots[0][0]
+      .layers[0];
+
+    expect(reads).toBe(1);
+    // And the reading is the one the double walk produced.
+    expect((layer.data as TreemapPoint[]).map(point => point.x))
+      .toEqual(['A', 'A1', 'A2', 'B', 'B1']);
+    expect(layer.selectors).toHaveLength(5);
+  });
+
   it('leaves a treemap unoutlined, because it paints only its leaves', () => {
     // Five nodes, three leaves. A count against the node total could never
     // match, so it is not attempted -- which keeps a structural mismatch

--- a/test/adapters/echarts/highlightBinding.test.ts
+++ b/test/adapters/echarts/highlightBinding.test.ts
@@ -295,6 +295,26 @@ describe('an eCharts dodged bar layer', () => {
   });
 });
 
+describe('a chart whose container id is not a bare identifier', () => {
+  it('still outlines the bar the reader is on', () => {
+    // React's `useId()` answers `:r0:`, and an id may also begin with a digit
+    // or hold a `.` -- none of which is a CSS identifier. Interpolated raw,
+    // the selector is invalid, `document.querySelectorAll` throws a
+    // SyntaxError, and the throw propagates out of `new Figure(...)`: the
+    // chart is not merely unhighlighted, it is entirely inaccessible.
+    const container = drawnChart(3, 0);
+    container.id = ':r0:';
+    const layer = createMaidrFromEChart(
+      fakeInstance([{ type: 'bar', names: CATEGORIES, values: [1, 2, 3] }]),
+      container,
+    ).subplots[0][0].layers[0];
+
+    const trace = new BarTrace(layer);
+
+    expect(highlighted(trace, 0, 1)).toEqual(['mark-1']);
+  });
+});
+
 describe('an eCharts scatter layer', () => {
   it('outlines the point the reader is on, not nothing at all', () => {
     const layer = layerFor(

--- a/test/adapters/echarts/highlightBinding.test.ts
+++ b/test/adapters/echarts/highlightBinding.test.ts
@@ -244,6 +244,40 @@ describe('an eCharts stacked bar layer', () => {
   });
 });
 
+describe('an eCharts stacked bar layer with a gap', () => {
+  it('totals each category against its own series', () => {
+    // Five marks: the first series drew nothing at B. `SegmentedTrace` pairs
+    // its rows by column index, so a row shortened by that gap would sum B's
+    // segment into C and announce C's total as one no bar on the page adds
+    // up to -- and drop the last category from the summary entirely.
+    const layer = layerFor(
+      [
+        { type: 'bar', names: CATEGORIES, values: [1, null, 3], name: 'one', stack: 'total' },
+        { type: 'bar', names: CATEGORIES, values: [4, 5, 6], name: 'two', stack: 'total' },
+      ],
+      5,
+      0,
+    );
+    const trace = new SegmentedTrace(layer);
+
+    // Row 2 is the summary row the trace appends after the two series.
+    const totals = [0, 1, 2].map((column) => {
+      trace.moveToIndex(2, column);
+      const state = trace.state as Extract<TraceState, { empty: false }>;
+      return [state.text.main.value, state.text.cross?.value];
+    });
+
+    expect(totals).toEqual([['A', 5], ['B', 5], ['C', 9]]);
+    // Nothing was drawn at B for the first series, so the cell stands in with
+    // the trace's own empty placeholder -- which carries none of the fixture's
+    // ids -- while the categories either side still find their own mark.
+    expect(highlighted(trace, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(trace, 0, 1)).toEqual(['']);
+    expect(highlighted(trace, 0, 2)).toEqual(['mark-1']);
+    expect(highlighted(trace, 1, 1)).toEqual(['mark-3']);
+  });
+});
+
 describe('an eCharts dodged bar layer', () => {
   it('outlines the bar the reader is on, not nothing at all', () => {
     const layer = layerFor(

--- a/test/adapters/echarts/singleValue.test.ts
+++ b/test/adapters/echarts/singleValue.test.ts
@@ -204,6 +204,33 @@ describe('an eCharts pie chart', () => {
   });
 });
 
+describe('an eCharts nested pie', () => {
+  it('outlines both rings, whose slices are counted together', () => {
+    // ECharts' own "Nested Pies": two pie series, an inner ring of two
+    // slices and an outer of three, five filled paths in all. Counted one
+    // series at a time against every mark on the chart, each count
+    // disagrees with the drawing and both rings lose their outline.
+    const container = drawnChart(5);
+    const layers = createMaidrFromEChart(
+      fakeInstance([
+        { type: 'pie', names: ['A', 'B'], values: [1, 2], name: 'Inner' },
+        { type: 'pie', names: ['C', 'D', 'E'], values: [3, 4, 5], name: 'Outer' },
+      ]),
+      container,
+    ).subplots[0][0].layers;
+
+    expect(layers).toHaveLength(2);
+    const inner = new PieTrace(layers[0]);
+    const outer = new PieTrace(layers[1]);
+
+    expect(highlighted(inner, 0, 0)).toEqual(['mark-0']);
+    expect(highlighted(inner, 0, 1)).toEqual(['mark-1']);
+    expect(highlighted(outer, 0, 0)).toEqual(['mark-2']);
+    expect(highlighted(outer, 0, 2)).toEqual(['mark-4']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('a single-value datum with no number', () => {
   it('is left out rather than announced as a slice of nothing', () => {
     // ECharts draws nothing for it, so reading it would put a slice on the

--- a/test/adapters/google-charts/area.test.ts
+++ b/test/adapters/google-charts/area.test.ts
@@ -161,7 +161,63 @@ describe('createMaidrFromGoogleChart with an AreaChart', () => {
         { x: '2022', y: 1120, z: 'Expenses' },
       ],
     ]);
-    expect(layer.axes).toEqual({ x: { label: 'Year' }, y: { label: 'Sales' } });
+    // Column 1 is the first series, not the axis, so a two-series chart has
+    // no single quantity to name -- and naming it 'Sales' would announce
+    // every Expenses value as a sale. The same call `buildSegmentedLayer`
+    // makes for a stack (#961) and `buildSurvivalLayer` for two arms.
+    expect(layer.axes).toEqual({ x: { label: 'Year' }, y: { label: undefined } });
+  });
+
+  it('names the magnitude axis when the chart draws one series', () => {
+    const single = makeAreaContainer(1);
+    const maidr = createMaidrFromGoogleChart(
+      AREA_CHART,
+      {
+        getNumberOfRows: () => ROWS.length,
+        getNumberOfColumns: () => 2,
+        getValue: (r, c) => ROWS[r][c],
+        getFormattedValue: (r, c) => String(ROWS[r][c]),
+        getColumnLabel: c => LABELS[c],
+        getColumnType: c => (c === 0 ? 'string' : 'number'),
+      },
+      single,
+      { chartType: 'AreaChart' },
+    );
+
+    expect(maidr.subplots[0][0].layers[0].axes?.y).toEqual({ label: 'Sales' });
+  });
+
+  it('skips a role column when naming the axis and the series', () => {
+    // `[Year, {role: 'tooltip'}, Sales]`: the series loop already knows to
+    // skip the tooltip, and the axis block and the `z` fallback have to ask
+    // the same question -- otherwise the axis is named after the tooltip and
+    // the chart's only series is announced as "Series 2".
+    const roleTable = (seriesLabel: string): GoogleDataTable => ({
+      getNumberOfRows: () => ROWS.length,
+      getNumberOfColumns: () => 3,
+      getValue: (r, c) => (c === 1 ? 'note' : ROWS[r][c === 0 ? 0 : 1]),
+      getFormattedValue: (r, c) => String(c === 1 ? 'note' : ROWS[r][c === 0 ? 0 : 1]),
+      getColumnLabel: c => (['Year', 'Note', seriesLabel])[c],
+      getColumnType: c => (c === 0 ? 'string' : 'number'),
+      getColumnRole: c => (c === 1 ? 'tooltip' : ''),
+    });
+
+    const named = createMaidrFromGoogleChart(
+      AREA_CHART,
+      roleTable('Sales'),
+      makeAreaContainer(1),
+      { chartType: 'AreaChart' },
+    ).subplots[0][0].layers[0];
+    expect(named.axes?.y).toEqual({ label: 'Sales' });
+
+    const unnamed = createMaidrFromGoogleChart(
+      AREA_CHART,
+      roleTable(''),
+      makeAreaContainer(1),
+      { chartType: 'AreaChart' },
+    ).subplots[0][0].layers[0];
+    // The chart's first series, however many role columns precede it.
+    expect((unnamed.data as LinePoint[][])[0][0].z).toBe('Series 1');
   });
 
   it.each([

--- a/test/adapters/google-charts/barMarks.test.ts
+++ b/test/adapters/google-charts/barMarks.test.ts
@@ -428,3 +428,32 @@ describe('createMaidrFromGoogleChart with a FunnelChart', () => {
     expect(marked.map(element => element.id)).toEqual(['count-0', 'count-1', 'count-2']);
   });
 });
+
+describe('a Google Charts container whose id is not a bare identifier', () => {
+  it('builds a selector the DOM will accept', () => {
+    // React's `useId()` answers `:r0:`, and an author's id may equally begin
+    // with a digit or hold a `.`. None of those is a CSS identifier, so
+    // interpolated raw the selector is invalid and `querySelectorAll` throws a
+    // SyntaxError -- which propagates out of `new Figure(...)`, leaving the
+    // chart not merely unhighlighted but entirely unreachable. The same fix
+    // landed for eCharts in this branch; these selectors are built the same
+    // way and needed it too.
+    //
+    // An id that merely *starts* with a digit is a separate gap, in
+    // `cssEscape`'s own non-browser fallback rather than here, and is fixed on
+    // the branch that hardens that helper. Escaping at this call site is what
+    // this test pins.
+    const container = makeContainer();
+    container.id = ':r0:';
+    const { layer } = build(
+      'ColumnChart',
+      makeDataTable(STAGES, ['Stage', 'Count']),
+      container,
+    );
+
+    const selectors = layer.selectors as string;
+
+    expect(selectors).toContain('#\\:r0\\:');
+    expect(() => container.ownerDocument.querySelectorAll(selectors)).not.toThrow();
+  });
+});

--- a/test/adapters/google-charts/barMarks.test.ts
+++ b/test/adapters/google-charts/barMarks.test.ts
@@ -164,6 +164,43 @@ function makeStackedContainer(rowCount = STAGES.length): HTMLElement {
   return container;
 }
 
+describe('a chart drawn by a package with no layout interface', () => {
+  /**
+   * The material packages (`google.charts.Bar`, `google.charts.Line`) expose
+   * no `getChartLayoutInterface`, so calling it throws a TypeError. Every
+   * marking helper called it unguarded, and the throw travelled out of
+   * `createMaidrFromGoogleChart` inside the caller's own `ready` handler --
+   * so the `maidr` attribute was never set and the chart was not merely
+   * unhighlighted but entirely inaccessible.
+   */
+  const NO_LAYOUT: GoogleChart = {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => {
+      throw new TypeError('chart.getChartLayoutInterface is not a function');
+    },
+  };
+
+  it.each([
+    ['BarChart', 1],
+    ['StackedColumnChart', 2],
+    ['ScatterChart', 1],
+    ['VolcanoChart', 1],
+  ] as [GoogleChartType, number][])('still reads a %s', (chartType, series) => {
+    const dt = series === 1
+      ? makeDataTable(STAGES, ['Stage', 'People'])
+      : makeDataTable(
+          STAGES.map(([stage, value]) => [stage, value, value] as MarkRow),
+          ['Stage', 'People', 'Others'],
+        );
+
+    const maidr = createMaidrFromGoogleChart(NO_LAYOUT, dt, makeContainer(), { chartType });
+
+    // The reading survives; only the outline may be missing.
+    expect(maidr.subplots[0][0].layers[0].data).toBeDefined();
+  });
+});
+
 describe('createMaidrFromGoogleChart with a DotChart', () => {
   it('reads a dot plot as a bar chart that announces itself as a dot plot', () => {
     const dt = makeDataTable(STAGES, ['Stage', 'People']);

--- a/test/adapters/google-charts/barMarks.test.ts
+++ b/test/adapters/google-charts/barMarks.test.ts
@@ -105,6 +105,65 @@ function build(
   return { layer: maidr.subplots[0][0].layers[0], container };
 }
 
+/**
+ * Where the padded funnel recipe puts bar `index` of `series`.
+ *
+ * Series 0 is the transparent spacer that centres the stage, so it sits at the
+ * start of the stack and the visible stage bar follows it.
+ */
+function stackedBarBox(series: number, index: number): GoogleBoundingBox {
+  return series === 0
+    ? { left: 10, top: 30 + index * 40, width: 30, height: 24 }
+    : { left: 40, top: 30 + index * 40, width: 120, height: 24 };
+}
+
+/** A chart drawn with the padding series stacked under the counts. */
+function makeStackedChart(rowCount = STAGES.length): GoogleChart {
+  return {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => ({
+      getBoundingBox: (id) => {
+        const bar = /^bar#(\d+)#(\d+)$/.exec(id);
+        if (!bar) {
+          return null;
+        }
+        const index = Number(bar[2]);
+        return index < rowCount ? stackedBarBox(Number(bar[1]), index) : null;
+      },
+      getXLocation: value => Number(value),
+      getYLocation: value => Number(value),
+    }),
+  };
+}
+
+/** The rects that recipe draws: a padding rect and a stage rect per row. */
+function makeStackedContainer(rowCount = STAGES.length): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="funnel-chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('funnel-chart') as HTMLElement;
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+
+  const add = (id: string, box: GoogleBoundingBox): void => {
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('id', id);
+    rect.setAttribute('x', `${box.left}`);
+    rect.setAttribute('y', `${box.top}`);
+    rect.setAttribute('width', `${box.width}`);
+    rect.setAttribute('height', `${box.height}`);
+    svg.appendChild(rect);
+  };
+
+  for (let i = 0; i < rowCount; i++) {
+    add(`pad-${i}`, stackedBarBox(0, i));
+    add(`count-${i}`, stackedBarBox(1, i));
+  }
+
+  return container;
+}
+
 describe('createMaidrFromGoogleChart with a DotChart', () => {
   it('reads a dot plot as a bar chart that announces itself as a dot plot', () => {
     const dt = makeDataTable(STAGES, ['Stage', 'People']);
@@ -205,5 +264,30 @@ describe('createMaidrFromGoogleChart with a FunnelChart', () => {
     ]);
     // The counts' own label travels to `x` with them.
     expect(layer.axes?.x).toEqual({ label: 'People' });
+  });
+
+  it('outlines the stage bars, not the padding stacked under them', () => {
+    // The payload is read off the counts column, so the highlight has to be
+    // asked for the same series. Asked for series 0, it outlines a
+    // transparent rect that starts where the stack does and is as wide as the
+    // spacer -- a sighted collaborator sees the outline on the wrong
+    // geometry while the audio and the text are right.
+    const padded = makeDataTable(
+      STAGES.map(([stage, count]) => [stage, (10000 - count) / 2, count] as MarkRow),
+      ['Stage', 'Padding', 'People'],
+    );
+    const container = makeStackedContainer();
+
+    const layer = createMaidrFromGoogleChart(
+      makeStackedChart(),
+      padded,
+      container,
+      { chartType: 'FunnelChart' },
+    ).subplots[0][0].layers[0];
+
+    const marked = Array.from(
+      container.ownerDocument.querySelectorAll(String(layer.selectors)),
+    );
+    expect(marked.map(element => element.id)).toEqual(['count-0', 'count-1', 'count-2']);
   });
 });

--- a/test/adapters/google-charts/barMarks.test.ts
+++ b/test/adapters/google-charts/barMarks.test.ts
@@ -164,6 +164,106 @@ function makeStackedContainer(rowCount = STAGES.length): HTMLElement {
   return container;
 }
 
+/**
+ * How many times the run reads a rect's left edge from the DOM.
+ *
+ * Matching a bar to its rect is a DOM read per candidate, so the count says
+ * whether the search makes one pass over the rects or one pass per bar.
+ *
+ * @param container - The container whose document to instrument
+ * @param run       - The conversion to measure
+ * @returns How many `x` reads it made
+ */
+function countLeftEdgeReads(container: HTMLElement, run: () => void): number {
+  const view = container.ownerDocument.defaultView;
+  if (!view) {
+    throw new Error('the fixture has no window');
+  }
+
+  const proto = view.Element.prototype;
+  const original = proto.getAttribute;
+  let reads = 0;
+  proto.getAttribute = function (name: string): string | null {
+    if (name === 'x') {
+      reads += 1;
+    }
+    return original.call(this, name);
+  };
+
+  try {
+    run();
+  } finally {
+    proto.getAttribute = original;
+  }
+
+  return reads;
+}
+
+describe('a segmented chart of many bars', () => {
+  it('finds each rect without rescanning the whole SVG for every one', () => {
+    // `series x categories x rects` with four attribute reads in the inner
+    // loop, and a segmented chart draws about as many rects as it has bars --
+    // so the cost is quadratic in chart size, all of it synchronous inside
+    // the caller's `ready` handler.
+    const categories = 60;
+    const series = 4;
+    const box = (s: number, c: number): GoogleBoundingBox =>
+      ({ left: 20 + c * 20, top: 30 + s * 120, width: 10, height: 100 });
+
+    const rows: MarkRow[] = Array.from(
+      { length: categories },
+      (_, c) => [`c${c}`, ...Array.from({ length: series }, (_, s) => c + s)] as MarkRow,
+    );
+    const dt = makeDataTable(
+      rows,
+      ['Category', ...Array.from({ length: series }, (_, s) => `S${s}`)],
+    );
+
+    const chart: GoogleChart = {
+      getSelection: () => [],
+      setSelection: () => {},
+      getChartLayoutInterface: () => ({
+        getBoundingBox: (id) => {
+          const bar = /^bar#(\d+)#(\d+)$/.exec(id);
+          if (!bar || Number(bar[1]) >= series || Number(bar[2]) >= categories) {
+            return null;
+          }
+          return box(Number(bar[1]), Number(bar[2]));
+        },
+        getXLocation: value => 20 + Number(value) * 20,
+        getYLocation: value => 30 + Number(value) * 20,
+      }),
+    };
+
+    const dom = new JSDOM('<!doctype html><body><div id="many-bars"></div></body>');
+    const doc = dom.window.document;
+    const container = doc.getElementById('many-bars') as HTMLElement;
+    const svg = doc.createElementNS(SVG_NS, 'svg');
+    container.appendChild(svg);
+    for (let s = 0; s < series; s++) {
+      for (let c = 0; c < categories; c++) {
+        const rect = doc.createElementNS(SVG_NS, 'rect');
+        const at = box(s, c);
+        rect.setAttribute('x', `${at.left}`);
+        rect.setAttribute('y', `${at.top}`);
+        rect.setAttribute('width', `${at.width}`);
+        rect.setAttribute('height', `${at.height}`);
+        svg.appendChild(rect);
+      }
+    }
+
+    const reads = countLeftEdgeReads(container, () => {
+      createMaidrFromGoogleChart(chart, dt, container, { chartType: 'StackedColumnChart' });
+    });
+
+    // Every bar still found.
+    expect(container.querySelectorAll('[data-maidr-bar]'))
+      .toHaveLength(series * categories);
+    // A handful of reads per rect, not a scan per bar.
+    expect(reads).toBeLessThanOrEqual(series * categories * 4);
+  });
+});
+
 describe('a chart drawn by a package with no layout interface', () => {
   /**
    * The material packages (`google.charts.Bar`, `google.charts.Line`) expose

--- a/test/adapters/google-charts/bump.test.ts
+++ b/test/adapters/google-charts/bump.test.ts
@@ -93,10 +93,13 @@ describe('createMaidrFromGoogleChart with a BumpChart', () => {
     expect(data[1].map(point => point.y)).toEqual([2, 1, 3]);
   });
 
-  it('names the axes from the table', () => {
+  it('names the period axis and leaves the rank axis to the competitors', () => {
     const { layer } = build();
 
-    expect(layer.axes).toEqual({ x: { label: 'Week' }, y: { label: 'Arsenal' } });
+    // Column 1 is Arsenal, a competitor rather than the quantity the axis
+    // carries -- and naming the axis after it would announce every one of
+    // Chelsea's ranks as an Arsenal one.
+    expect(layer.axes).toEqual({ x: { label: 'Week' }, y: { label: undefined } });
   });
 
   it('marks one line path per competitor for highlighting', () => {

--- a/test/adapters/google-charts/reversedAxisOrder.test.ts
+++ b/test/adapters/google-charts/reversedAxisOrder.test.ts
@@ -45,7 +45,7 @@ import type {
   GoogleChart,
   GoogleDataTable,
 } from '@adapters/google-charts/types';
-import type { BarPoint, MaidrLayer } from '@type/grammar';
+import type { BarPoint, MaidrLayer, SegmentedPoint } from '@type/grammar';
 import { createMaidrFromGoogleChart } from '@adapters/google-charts/converters';
 import { describe, expect, it } from '@jest/globals';
 import { Orientation } from '@type/grammar';
@@ -173,6 +173,102 @@ function categoriesOf(layer: MaidrLayer): unknown[] {
   return (layer.data as BarPoint[]).map(p => (horizontal ? p.y : p.x));
 }
 
+/**
+ * A two-column table, which routes a `ColumnChart` to the segmented reading.
+ * @returns The fake table
+ */
+function makeSegmentedDataTable(): GoogleDataTable {
+  const labels = ['Day', 'Tips', 'Bills'];
+  const valueAt = (r: number, c: number): number =>
+    (c === 2 ? ROWS[r][1] / 2 : (ROWS[r][c] as number));
+  return {
+    getNumberOfRows: () => ROWS.length,
+    getNumberOfColumns: () => labels.length,
+    getValue: (r, c) => (c === 0 ? ROWS[r][0] : valueAt(r, c)),
+    getFormattedValue: (r, c) => String(c === 0 ? ROWS[r][0] : valueAt(r, c)),
+    getColumnLabel: c => labels[c],
+    getColumnType: c => (c === 0 ? 'string' : 'number'),
+  };
+}
+
+/**
+ * Where the two-series chart draws bar `index` of `series`.
+ * @param series - Which series
+ * @param index - The row
+ * @param reversed - Whether the category axis is reversed
+ * @returns The bar's box
+ */
+function segmentBox(series: number, index: number, reversed: boolean): GoogleBoundingBox {
+  return { left: leftOf(index, reversed), top: 30 + series * 200, width: 24, height: 100 };
+}
+
+/**
+ * A drawn two-series chart whose layout places both series.
+ * @param reversed - Whether the category axis is reversed
+ * @returns The fake chart
+ */
+function makeSegmentedChart(reversed: boolean): GoogleChart {
+  return {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => ({
+      getBoundingBox: (id) => {
+        const bar = /^bar#(\d+)#(\d+)$/.exec(id);
+        if (!bar)
+          return null;
+        const index = Number(bar[2]);
+        return index < ROWS.length ? segmentBox(Number(bar[1]), index, reversed) : null;
+      },
+      getXLocation: value => leftOf(Number(value), reversed),
+      getYLocation: value => 100 + Number(value) * 4,
+    }),
+  };
+}
+
+/**
+ * A rendered two-series chart, its rects in series-major DOM order.
+ * @param reversed - Whether the category axis is reversed
+ * @returns The container
+ */
+function makeSegmentedContainer(reversed: boolean): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="rev-seg-chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('rev-seg-chart') as HTMLElement;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+
+  for (let series = 0; series < 2; series++) {
+    for (let i = 0; i < ROWS.length; i++) {
+      const box = segmentBox(series, i, reversed);
+      const rect = doc.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('x', `${box.left}`);
+      rect.setAttribute('y', `${box.top}`);
+      rect.setAttribute('width', `${box.width}`);
+      rect.setAttribute('height', `${box.height}`);
+      rect.setAttribute('data-datum', `s${series}-${LISTED[i]}`);
+      svg.appendChild(rect);
+    }
+  }
+
+  return container;
+}
+
+/**
+ * The segmented layer a two-series chart converts to.
+ * @param reversed - Whether the category axis is reversed
+ * @returns The layer and its container
+ */
+function buildSegmented(reversed: boolean): { layer: MaidrLayer; container: HTMLElement } {
+  const container = makeSegmentedContainer(reversed);
+  const maidr = createMaidrFromGoogleChart(
+    makeSegmentedChart(reversed),
+    makeSegmentedDataTable(),
+    container,
+    { chartType: 'ColumnChart' },
+  );
+  return { layer: maidr.subplots[0][0].layers[0], container };
+}
+
 describe('a google chart on a reversed category axis', () => {
   it('leads with the category drawn leftmost', () => {
     // Before the fix this was ['Sat', 'Sun', 'Thu', 'Fri'] — the exact reverse
@@ -232,5 +328,38 @@ describe('the highlight follows the categories', () => {
 
   it('leaves an ordinary chart on its single selector', () => {
     expect(typeof build(false).layer.selectors).toBe('string');
+  });
+});
+
+describe('a two-series google chart on a reversed category axis', () => {
+  it('reads its categories the way the chart drew them', () => {
+    // Adding a second series routes the same ColumnChart to the segmented
+    // builder, which never asked which way the categories were drawn -- so a
+    // chart that read correctly with one series is announced as its own
+    // mirror image with two.
+    const rows = buildSegmented(true).layer.data as SegmentedPoint[][];
+
+    expect(rows).toHaveLength(2);
+    rows.forEach(series => expect(series.map(point => point.x)).toEqual(DRAWN));
+  });
+
+  it('names each cell so the highlight follows the reading', () => {
+    const { layer, container } = buildSegmented(true);
+    const grid = layer.selectors as string[][];
+    const doc = container.ownerDocument;
+    const found = grid.map(row =>
+      row.map(cell => doc.querySelector(cell)?.getAttribute('data-datum')));
+
+    expect(found).toEqual([
+      ['s0-Fri', 's0-Thu', 's0-Sun', 's0-Sat'],
+      ['s1-Fri', 's1-Thu', 's1-Sun', 's1-Sat'],
+    ]);
+  });
+
+  it('leaves an ordinary two-series chart on its single selector', () => {
+    const { layer } = buildSegmented(false);
+
+    expect(typeof layer.selectors).toBe('string');
+    expect((layer.data as SegmentedPoint[][])[0].map(point => point.x)).toEqual(LISTED);
   });
 });

--- a/test/adapters/google-charts/scatterMarks.test.ts
+++ b/test/adapters/google-charts/scatterMarks.test.ts
@@ -1,0 +1,166 @@
+/**
+ * A Google scatter's circles are paired with its points by **position**, and
+ * that pairing has to be checked before it is shipped.
+ *
+ * `markSeriesPointElements` -- the volcano and Manhattan path -- already does:
+ * it withdraws the marks when it could not match every point, and again when
+ * the chart drew its circles in an order other than the data's, "so a
+ * highlight would sit on a different point from the one being announced --
+ * silently, and only in the highlight". A plain scatter and a bubble go
+ * through `markScatterElements`, which shipped whatever it managed to stamp.
+ *
+ * Two ways that goes wrong, both routine:
+ *
+ * - **Coincident points.** Two rows at the same x and y are ordinary in
+ *   binned or rounded data. The search answers with the first circle at that
+ *   position for both, the already-marked guard skips the second, and the
+ *   selector then resolves to one circle fewer than there are points --
+ *   which `ScatterTrace.buildGridCells` declines outright, with nothing said
+ *   anywhere.
+ * - **Circles out of data order.** A single attribute selector is resolved in
+ *   document order while the marks are made in data order, so every highlight
+ *   lands on someone else's point.
+ */
+
+import type {
+  GoogleBoundingBox,
+  GoogleChart,
+  GoogleDataTable,
+} from '@adapters/google-charts/types';
+import type { MaidrLayer } from '@type/grammar';
+import { createMaidrFromGoogleChart } from '@adapters/google-charts/converters';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** Four points, the last two drawn at the same place as the first two. */
+const SPREAD: [number, number][] = [[1, 10], [2, 20], [3, 30], [4, 40]];
+
+/** Minimal DataTable fake for a two-column scatter. */
+function makeDataTable(rows: [number, number][]): GoogleDataTable {
+  const labels = ['Weight', 'Height'];
+  return {
+    getNumberOfRows: () => rows.length,
+    getNumberOfColumns: () => labels.length,
+    getValue: (r, c) => rows[r][c],
+    getFormattedValue: (r, c) => String(rows[r][c]),
+    getColumnLabel: c => labels[c],
+    getColumnType: () => 'number',
+  };
+}
+
+/** Where the fake layout puts the marker for row `index`. */
+function pointBox(index: number): GoogleBoundingBox {
+  return { left: 20 + index * 30, top: 40, width: 6, height: 6 };
+}
+
+/** A chart whose layout places one marker per row. */
+function makeChart(rowCount: number): GoogleChart {
+  return {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => ({
+      getBoundingBox: (id) => {
+        const match = /^point#0#(\d+)$/.exec(id);
+        if (!match || Number(match[1]) >= rowCount) {
+          return null;
+        }
+        return pointBox(Number(match[1]));
+      },
+      getXLocation: value => Number(value),
+      getYLocation: value => Number(value),
+    }),
+  };
+}
+
+/**
+ * A rendered scatter whose circles sit at the boxes named by `drawn`.
+ *
+ * @param drawn - The row each circle was drawn for, in document order
+ * @returns The container
+ */
+function makeContainer(drawn: number[]): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="scatter-chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('scatter-chart') as HTMLElement;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+
+  for (const row of drawn) {
+    const box = pointBox(row);
+    const circle = doc.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('cx', `${box.left + box.width / 2}`);
+    circle.setAttribute('cy', `${box.top + box.height / 2}`);
+    circle.setAttribute('data-datum', `${row}`);
+    svg.appendChild(circle);
+  }
+
+  return container;
+}
+
+function build(drawn: number[], rows = SPREAD): {
+  layer: MaidrLayer;
+  container: HTMLElement;
+} {
+  const container = makeContainer(drawn);
+  const maidr = createMaidrFromGoogleChart(
+    makeChart(rows.length),
+    makeDataTable(rows),
+    container,
+    { chartType: 'ScatterChart' },
+  );
+  return { layer: maidr.subplots[0][0].layers[0], container };
+}
+
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+afterAll(() => {
+  warnSpy.mockRestore();
+});
+
+describe('a google scatter whose circles pair with its points', () => {
+  it('names them when every point found its own circle, in order', () => {
+    const { layer, container } = build([0, 1, 2, 3]);
+
+    const marked = Array.from(
+      container.ownerDocument.querySelectorAll(String(layer.selectors)),
+    );
+    expect(marked.map(circle => circle.getAttribute('data-datum')))
+      .toEqual(['0', '1', '2', '3']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('a google scatter the circles cannot be paired with', () => {
+  it('withdraws the marks when two points share a circle', () => {
+    // Rows 2 and 3 are drawn where rows 0 and 1 are, so the search answers
+    // with the same circle twice and two points end up with no mark of their
+    // own. A short list is not a pairing, and it is the highlight that would
+    // be wrong rather than the reading.
+    const { layer, container } = build([0, 1, 0, 1]);
+
+    expect(layer.selectors).toBeUndefined();
+    expect(container.querySelectorAll('[data-maidr-point]')).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('count mismatch'),
+    );
+  });
+
+  it('withdraws the marks when the circles run against the data', () => {
+    // Every point finds a circle, so the count agrees -- and the selector is
+    // still resolved in document order, which here is the reverse of the
+    // data's. Shipped, every move would outline someone else's point.
+    const { layer, container } = build([3, 2, 1, 0]);
+
+    expect(layer.selectors).toBeUndefined();
+    expect(container.querySelectorAll('[data-maidr-point]')).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('order mismatch'),
+    );
+  });
+});

--- a/test/adapters/google-charts/volcano.test.ts
+++ b/test/adapters/google-charts/volcano.test.ts
@@ -138,6 +138,43 @@ function build(
   return { layer: maidr.subplots[0][0].layers[0], container };
 }
 
+/**
+ * How many times the run reads a circle's centre from the DOM.
+ *
+ * The marker search is the cost that matters on these charts, and it is a
+ * DOM read per candidate. Counting the reads says whether the search makes
+ * one pass over the circles or one pass per point, which is what separates a
+ * chart that becomes accessible from one that freezes the tab.
+ *
+ * @param container - The container whose document to instrument
+ * @param run       - The conversion to measure
+ * @returns How many `cx` reads it made
+ */
+function countCentreReads(container: HTMLElement, run: () => void): number {
+  const view = container.ownerDocument.defaultView;
+  if (!view) {
+    throw new Error('the fixture has no window');
+  }
+
+  const proto = view.Element.prototype;
+  const original = proto.getAttribute;
+  let reads = 0;
+  proto.getAttribute = function (name: string): string | null {
+    if (name === 'cx') {
+      reads += 1;
+    }
+    return original.call(this, name);
+  };
+
+  try {
+    run();
+  } finally {
+    proto.getAttribute = original;
+  }
+
+  return reads;
+}
+
 // The order-mismatch case warns on purpose.
 const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -232,6 +269,38 @@ describe('createMaidrFromGoogleChart with a ManhattanChart', () => {
     expect(marked).toHaveLength(4);
     expect(marked.map(circle => circle.getAttribute('data-maidr-hit')))
       .toEqual(['0', '1', '2', '3']);
+  });
+
+  it('finds every marker without rescanning the circles for each one', () => {
+    // `buildVolcanoLayer` says these charts "carry tens of thousands of
+    // points of which a few dozen matter". Searching the whole circle list
+    // per point is O(points x circles) with two DOM reads in the inner loop,
+    // run synchronously inside the caller's `ready` handler -- at twenty
+    // thousand points that is a tab frozen for minutes before the chart
+    // becomes accessible at all.
+    const count = 300;
+    const rows: ManhattanRow[] = Array.from(
+      { length: count },
+      (_, index) => [index, index / 5, null, `rs${index}`],
+    );
+    const markers: [number, number][] = rows.map((_, index) => [0, index]);
+    const container = makeScatterContainer(markers);
+    const dt = makeScatterDataTable(
+      rows,
+      ['Position', 'chr1', 'chr2', ''],
+      [undefined, undefined, undefined, 'annotation'],
+    );
+
+    let selectors: unknown;
+    const reads = countCentreReads(container, () => {
+      selectors = build('ManhattanChart', dt, markers, container).layer.selectors;
+    });
+
+    // Every marker still found, in data order.
+    expect(selectors).toBeDefined();
+    expect(container.querySelectorAll('[data-maidr-hit]')).toHaveLength(count);
+    // A handful of reads per circle, not a scan per point.
+    expect(reads).toBeLessThanOrEqual(count * 4);
   });
 
   it('withdraws the marks when the chart drew its series out of data order', () => {


### PR DESCRIPTION
# Pull Request

## Description

Fourteen defects across the ECharts and Google Charts adapters, found in a codebase audit. Every one was reproduced with a test that failed first.

The worst of them give the reader numbers that were never in the chart. A segmented bar layer **dropped gap data**, shifting every later category one place left and announcing wrong totals, so a reader walking the bars was told the wrong category's value throughout. A category axis declared with per-label objects read its heatmap rows and columns as `[object Object]`. A multi-series Google Charts line named its whole y axis after the first series.

Several others take highlighting away entirely: an area series' fill counted as a data mark, so any chart mixing an area line with bars or scatter lost all highlighting; a nested pie lost it too; and an unescaped container id threw and took the whole figure down.

One made the tab hang: quadratic point-marker matching on a volcano or Manhattan plot.

## Related Issues

None.

## Changes Made

**ECharts**

- A segmented bar keeps its gaps, so payloads are rectangular and later categories stay where they belong.
- An area series' fill is no longer counted as a data mark.
- The container id is escaped before it reaches a selector.
- Whole-chart series share one mark count, so a nested pie highlights.
- A category axis declared with per-label objects is read by label.
- One stacked series among several no longer makes every bar series read as one stack.
- A sunburst's node walk is built once per conversion rather than twice.

**Google Charts**

- The funnel layer marks the bars it read, rather than series zero's transparent padding.
- Point-marker matching is no longer quadratic.
- Multi-series line, area, bump and their stacked variants leave `axes.y.label` unset rather than naming it after the first series.
- The reversed-category correction reaches stacked, dodged and diverging layers.
- `getChartLayoutInterface()` is guarded, so a chart without one no longer aborts the conversion.
- `markScatterElements` withdraws a partial or out-of-order mark set instead of shipping it.
- Bar and segmented marking no longer rescans every SVG rect per bar.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**A gap is now `NaN`, never zero.** That is the Tableau adapter's established sentinel and `isMeasured` keeps it out of ranges. Zero would be a reading the chart never drew, which is the failure mode this whole sweep keeps finding.

**Two existing tests were updated**, both pinning the old reading rather than the intended one: the Google Charts area and bump suites asserted a y-axis label taken from the first series of several. The new behaviour follows the rule `buildSegmentedLayer` (#961) and `buildSurvivalLayer` already apply.

**Behaviour changes worth a reviewer's eye.** A mixed or grouped-stack ECharts bar chart is now announced as dodged rather than stacked; only the announced type changes, since both route to `SegmentedTrace`. `markScatterElements` now highlights nothing where it used to highlight the wrong point, which is the safer failure but is a visible difference. `GoogleChart.getChartLayoutInterface` became optional in the adapter's types, which is honest about the material, Calendar, Gauge and Sankey packages; no call site broke. And `markBarElements`' fourth parameter changed meaning from a series count that was always 1 to the index of the series to mark.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (501 suites, 6741 tests) and the esm project under `--experimental-vm-modules` (12 suites, 170 tests), both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_