### PR TITLE
fix(ui): stop the extrema dialog corrupting numbers and double-announcing

### DIFF
--- a/src/state/hook/useCredentialProbe.ts
+++ b/src/state/hook/useCredentialProbe.ts
@@ -1,0 +1,101 @@
+import type { Llm } from '@type/llm';
+import { LlmValidationService } from '@service/llmValidation';
+import { useEffect, useState } from 'react';
+
+/** How long typing settles before a probe is sent, in milliseconds. */
+const DEBOUNCE_MS = 500;
+
+/**
+ * What the settings dialog knows about an LLM credential.
+ */
+export interface CredentialProbe {
+  /** True while a probe is in flight. */
+  isValidating: boolean;
+  /** Whether the credential works, or null before anything has been probed. */
+  isValid: boolean | null;
+  /**
+   * Why the last probe failed, as the probe itself described it, or null when
+   * there is nothing more specific to say than "invalid". Kept so a rate limit
+   * or a provider outage is not reported as a bad credential.
+   */
+  error: string | null;
+  /**
+   * Models this credential can actually reach, from the provider's models API
+   * (or the local Ollama server). Replaces the curated suggestion list.
+   */
+  models: string[];
+}
+
+const IDLE: CredentialProbe = {
+  isValidating: false,
+  isValid: null,
+  error: null,
+  models: [],
+};
+
+/**
+ * Probes an LLM credential as the user types it.
+ *
+ * This lives in the state layer rather than in the settings dialog because a
+ * network side effect is not a component's to own — see `rules/ui.md`. It is
+ * the sibling of {@link useOllamaModels}, which reaches the same service for
+ * the same reason.
+ *
+ * The debounce only spaces out request starts; it cannot cancel a request
+ * already in flight, so a superseded cycle (a newer keystroke, a provider
+ * switch, or unmount) discards its own response. A slow early probe can
+ * therefore never overwrite the state of a newer one.
+ *
+ * @param modelKey - Which provider the credential belongs to
+ * @param credential - The API key, or the server URL for Ollama
+ * @param enabled - Whether the provider is switched on; probes are skipped
+ * when it is not
+ * @returns What is currently known about the credential
+ */
+export function useCredentialProbe(
+  modelKey: Llm,
+  credential: string,
+  enabled: boolean,
+): CredentialProbe {
+  const [probe, setProbe] = useState<CredentialProbe>(IDLE);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!enabled || !credential.trim()) {
+      // Also clears the spinner: a superseded in-flight request skips its own
+      // cleanup as stale, so this cycle owns the state.
+      setProbe(IDLE);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setProbe(current => ({ ...current, isValidating: true }));
+      // A single probe answers both credential validity and the live list of
+      // models the credential can access, for every provider.
+      LlmValidationService.probeProvider(modelKey, credential)
+        .then((result) => {
+          if (!cancelled) {
+            setProbe({
+              isValidating: false,
+              isValid: result.isValid,
+              error: result.error ?? null,
+              models: result.models,
+            });
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setProbe({ isValidating: false, isValid: false, error: null, models: [] });
+          }
+        });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [modelKey, credential, enabled]);
+
+  return probe;
+}

--- a/src/state/hook/useMaidrController.ts
+++ b/src/state/hook/useMaidrController.ts
@@ -28,9 +28,16 @@ interface UseMaidrControllerResult {
  * Handles:
  * - Controller creation on focus-in (deferred -- no throwaway Controller on mount)
  * - Controller disposal on focus-out
- * - Visibility change re-creation
  * - Timer cleanup and stale-closure prevention
  * - Unmount cleanup
+ *
+ * Returning to a hidden tab deliberately does nothing. Disposing and
+ * rebuilding the controller there put the cursor back on the first point,
+ * reset every slice (text, braille, any open dialog) and aborted an in-flight
+ * chat answer along with the conversation -- all without an announcement,
+ * because focus never left the figure and so no focus-in followed. A suspended
+ * AudioContext needs no rebuild: `AudioService` defers its cues behind
+ * `resume()` already.
  *
  * @param data - The MAIDR configuration describing the plot
  * @param store - The per-instance Redux store
@@ -142,33 +149,6 @@ export function useMaidrController(data: MaidrData, store: AppStore): UseMaidrCo
     }, 0);
   }, [disposeController]);
 
-  const onVisibilityChange = useCallback((): void => {
-    if (document.visibilityState === 'visible') {
-      // Only recreate the controller if the chart previously had focus.
-      // Without this guard, switching tabs would create a Controller for
-      // every mounted <Maidr> instance, even ones never interacted with.
-      if (!controllerRef.current)
-        return;
-
-      if (focusInTimerRef.current) {
-        clearTimeout(focusInTimerRef.current);
-        focusInTimerRef.current = null;
-      }
-      if (focusOutTimerRef.current) {
-        clearTimeout(focusOutTimerRef.current);
-        focusOutTimerRef.current = null;
-      }
-      disposeController();
-      const ctrl = createControllerRef.current();
-      if (!ctrl)
-        return;
-      controllerRef.current = ctrl;
-      setContextValue(ctrl.getContextValue());
-      ctrl.initializeHighContrast();
-      hasAnnouncedRef.current = false;
-    }
-  }, [disposeController]);
-
   // Register this chart with the live data manager so external producers
   // (script-tag consumers via window.maidrLive, or React prop updates routed
   // through setData) can replace or append data at runtime. When an update
@@ -217,14 +197,6 @@ export function useMaidrController(data: MaidrData, store: AppStore): UseMaidrCo
       liveDataManager.updateStoredData(data);
     }
   }, [data]);
-
-  // Register visibility change listener.
-  useEffect(() => {
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    return () => {
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-    };
-  }, [onVisibilityChange]);
 
   // Clean up pending timers and controller on unmount.
   useEffect(() => {

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -25,6 +25,52 @@ export interface XValueOption {
   label: string;
 }
 
+/**
+ * The separator every extrema label puts in front of its x value, in
+ * `Max Bar at Q1` and `Global Maximum: 0.95 at 9, 2` alike.
+ */
+const X_VALUE_SEPARATOR = ' at ';
+
+/**
+ * Rewrites the x value of an extrema label with its formatted form.
+ *
+ * The x value is the only part of the label the formatter has anything to say
+ * about, and it is written directly after the label's final ` at `. Every
+ * other number in there belongs to something else: the extremum's own value
+ * and, on a heatmap, the y coordinate. Rewriting every occurrence of the raw x
+ * corrupted those too whenever they shared its digits — an x of 9 formatted to
+ * one decimal turned `Global Maximum: 0.95 at 9, 2` into
+ * `Global Maximum: 0.9.05 at 9.0, 2`, which is the value the dialog shows and
+ * the screen reader announces.
+ *
+ * Earlier separators are tried in turn so a group label containing ` at ` (a
+ * label reads `Max Data at rest at 7`) still formats; a label whose x value is
+ * nowhere to be found after one is returned untouched rather than guessed at.
+ * @param label - The target label as the model built it.
+ * @param raw - The x value, stringified.
+ * @param formatted - The x value as the layer's formatter writes it.
+ * @returns The label with its x value formatted.
+ */
+function replaceXValueInLabel(label: string, raw: string, formatted: string): string {
+  const starts: number[] = [];
+  for (
+    let index = label.indexOf(X_VALUE_SEPARATOR);
+    index !== -1;
+    index = label.indexOf(X_VALUE_SEPARATOR, index + 1)
+  ) {
+    starts.push(index + X_VALUE_SEPARATOR.length);
+  }
+
+  for (let i = starts.length - 1; i >= 0; i--) {
+    const start = starts[i];
+    if (label.startsWith(raw, start)) {
+      return label.slice(0, start) + formatted + label.slice(start + raw.length);
+    }
+  }
+
+  return label;
+}
+
 export interface GoToExtremaState {
   visible: boolean;
   targets: any[];
@@ -216,6 +262,8 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
    * which is what the announcement says, and a dialog label that disagreed with
    * the announcement for the same point would be worse than either. A value the
    * formatter leaves alone is detected below and passes through untouched.
+   *
+   * Only the x value itself is rewritten — see {@link replaceXValueInLabel}.
    */
   private formatTargetLabels(targets: ExtremaTarget[], layerId: string): ExtremaTarget[] {
     const formatter = this.formatter;
@@ -234,7 +282,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       }
       return {
         ...target,
-        label: target.label.replaceAll(raw, formatted),
+        label: replaceXValueInLabel(target.label, raw, formatted),
       };
     });
   }

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -5,7 +5,7 @@ import type { AppStore } from '@state/store';
 import type { ExtremaTarget } from '@type/extrema';
 import type { TraceType } from '@type/grammar';
 import type { XValue } from '@type/navigation';
-import type { TraceState } from '@type/state';
+import type { AxisType, TraceState } from '@type/state';
 import { createSlice } from '@reduxjs/toolkit';
 import { AbstractViewModel } from '@state/viewModel/viewModel';
 
@@ -157,7 +157,11 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       const extremaTargets = activeTrace.getExtremaTargets();
 
       // Apply formatting to target labels using FormatterService
-      const formattedTargets = this.formatTargetLabels(extremaTargets, state.layerId);
+      const formattedTargets = this.formatTargetLabels(
+        extremaTargets,
+        state.layerId,
+        state.text.mainAxis ?? 'x',
+      );
 
       // Generate description based on current trace type
       const description = this.generateDescription(state.traceType);
@@ -264,8 +268,22 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
    * formatter leaves alone is detected below and passes through untouched.
    *
    * Only the x value itself is rewritten — see {@link replaceXValueInLabel}.
+   *
+   * `axis` is the trace's main axis, not always 'x': a horizontal trace reports
+   * its category as `xValue` while that category lives on the y axis, and the
+   * announcement for the same point formats it with the y formatter. Formatting
+   * here with 'x' applied the value axis's format to a category, which is the
+   * dialog/announcement disagreement this method exists to avoid.
+   * @param targets - The extrema targets as the trace built them.
+   * @param layerId - The layer whose formatters apply.
+   * @param axis - The axis the trace reports its main value on.
+   * @returns The targets, with formatted labels.
    */
-  private formatTargetLabels(targets: ExtremaTarget[], layerId: string): ExtremaTarget[] {
+  private formatTargetLabels(
+    targets: ExtremaTarget[],
+    layerId: string,
+    axis: AxisType,
+  ): ExtremaTarget[] {
     const formatter = this.formatter;
     if (!formatter) {
       return targets;
@@ -275,7 +293,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       if (target.xValue === undefined) {
         return target;
       }
-      const formatted = formatter.formatSingleValue(target.xValue, layerId, 'x');
+      const formatted = formatter.formatSingleValue(target.xValue, layerId, axis);
       const raw = String(target.xValue);
       if (formatted === raw) {
         return target;
@@ -324,11 +342,11 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     }
 
     const formatter = this.formatter;
-    const layerId = this.activeLayerId();
+    const layer = this.activeLayerFormat();
     // Same rule the extrema target labels follow (formatTargetLabels): format
     // whenever there is a formatter and a layer to look it up by, so these
     // labels round the way the announcement does.
-    if (!formatter || layerId === null) {
+    if (!formatter || layer === null) {
       return rawValues.map(value => ({ value, label: String(value) }));
     }
 
@@ -338,20 +356,27 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     // tolerance of formatTargetLabels.
     return rawValues.map(value => ({
       value,
-      label: String(formatter.formatSingleValue(value, layerId, 'x')),
+      label: String(formatter.formatSingleValue(value, layer.layerId, layer.axis)),
     }));
   }
 
   /**
-   * Layer id of the active trace, or null when the active plot is not a
-   * non-empty trace. The plot stack is unchanged while the modal is open (the
-   * GO_TO_EXTREMA scope is a keyboard scope only), so context.state resolves to
-   * the same trace whose X values are being listed.
-   * @returns The active layer id, or null.
+   * Layer id and main-axis identity of the active trace, or null when the
+   * active plot is not a non-empty trace. The plot stack is unchanged while the
+   * modal is open (the GO_TO_EXTREMA scope is a keyboard scope only), so
+   * context.state resolves to the same trace whose X values are being listed.
+   *
+   * The axis is the trace's own main axis rather than always 'x', for the
+   * reason formatTargetLabels gives: on a horizontal trace the value listed
+   * here is the category, and the category sits on y.
+   * @returns The active layer id and its main axis, or null.
    */
-  private activeLayerId(): string | null {
+  private activeLayerFormat(): { layerId: string; axis: AxisType } | null {
     const state = this.context.state;
-    return state.type === 'trace' && !state.empty ? state.layerId : null;
+    if (state.type !== 'trace' || state.empty) {
+      return null;
+    }
+    return { layerId: state.layerId, axis: state.text.mainAxis ?? 'x' };
   }
 
   /**

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -14,6 +14,11 @@ interface PlotWithXValues {
   getAvailableXValues: () => XValue[];
 }
 
+// Type for plots that can be moved to a chosen X value
+interface PlotWithMoveToXValue {
+  moveToXValue: (value: XValue) => boolean;
+}
+
 /**
  * An X value paired with its display label. `value` is the raw XValue used for
  * navigation (moveToXValue matches on the raw value); `label` is the x-axis
@@ -184,10 +189,6 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     this.goToExtremaService.returnToTraceScope();
   }
 
-  public get activeContext(): Context {
-    return this.context;
-  }
-
   public moveUp(): void {
     const currentState = this.state;
 
@@ -232,12 +233,23 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     if (currentState.targets.length > 0 && currentState.selectedIndex !== undefined) {
       const target = currentState.targets[currentState.selectedIndex];
       if (target) {
-        this.handleTargetSelect(target as ExtremaTarget);
+        this.selectTarget(target as ExtremaTarget);
       }
     }
   }
 
-  private handleTargetSelect(target: ExtremaTarget): void {
+  /**
+   * Closes the dialog and navigates the active trace to a chosen target.
+   *
+   * The only way into the model from the dialog, so every selection path — a
+   * click, an Enter in the listbox, the hotkey — closes and moves in the same
+   * order and gets the same guard. A trace can advertise extrema support
+   * without implementing the jump (the base `navigateToExtrema` throws), which
+   * would otherwise leave the reader in the GO_TO_EXTREMA scope with the
+   * dialog open and nothing announced.
+   * @param target - The extrema target to navigate to.
+   */
+  public selectTarget(target: ExtremaTarget): void {
     // Get the active trace and navigate to the selected target
     const activeTrace = this.context.active;
 
@@ -256,6 +268,31 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     } else {
       this.goToExtremaService.returnToTraceScope();
     }
+  }
+
+  /**
+   * Closes the dialog and moves the active trace to a chosen X value.
+   *
+   * The search half of {@link selectTarget}, guarded the same way so a trace
+   * that cannot honour the move cannot strand the reader in the dialog.
+   * @param value - The raw X value to move to.
+   * @returns True when the trace could be moved, false when it offers no
+   * X-value navigation and the dialog was therefore left alone.
+   */
+  public moveToXValue(value: XValue): boolean {
+    const activeTrace = this.context.active;
+
+    if (!this.supportsMoveToXValue(activeTrace)) {
+      return false;
+    }
+
+    try {
+      this.hide();
+      activeTrace.moveToXValue(value);
+    } catch (error) {
+      this.goToExtremaService.returnToTraceScope();
+    }
+    return true;
   }
 
   /**
@@ -398,6 +435,18 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       && typeof plot === 'object'
       && 'getAvailableXValues' in plot
       && typeof (plot as any).getAvailableXValues === 'function';
+  }
+
+  /**
+   * Check if a plot can be moved to a chosen X value
+   * @param plot The plot to check
+   * @returns True if the plot supports moveToXValue
+   */
+  private supportsMoveToXValue(plot: unknown): plot is PlotWithMoveToXValue {
+    return plot !== null
+      && typeof plot === 'object'
+      && 'moveToXValue' in plot
+      && typeof (plot as any).moveToXValue === 'function';
   }
 }
 

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -262,7 +262,10 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
         // Then navigate to the target
         activeTrace.navigateToExtrema(target);
       } catch (error) {
-        // If navigation fails, ensure we're back in trace scope
+        // If navigation fails, ensure we're back in trace scope. Log it: the
+        // reader sees the dialog close and nothing move, which is
+        // indistinguishable from a target that was simply already current.
+        console.error('[GoToExtremaViewModel] navigating to an extremum failed', error);
         this.goToExtremaService.returnToTraceScope();
       }
     } else {
@@ -290,6 +293,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       this.hide();
       activeTrace.moveToXValue(value);
     } catch (error) {
+      console.error('[GoToExtremaViewModel] moving to an x value failed', error);
       this.goToExtremaService.returnToTraceScope();
     }
     return true;

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -70,6 +70,62 @@ export function clampEchoDuration(value: number): number {
   return Math.min(MAX_ECHO_DURATION, Math.max(MIN_ECHO_DURATION, value));
 }
 
+/**
+ * Bounds on the sonification pitch range, in Hz.
+ *
+ * The floor is roughly where hearing begins and the ceiling roughly where it
+ * ends; anything outside is silence to the listener rather than a quieter
+ * tone.
+ */
+export const MIN_FREQUENCY_HZ = 20;
+export const MAX_FREQUENCY_HZ = 20000;
+
+/** The pitch range before the user changes it. */
+export const DEFAULT_MIN_FREQUENCY = 200;
+export const DEFAULT_MAX_FREQUENCY = 1000;
+
+/**
+ * Brings the sonification pitch range into something a listener can hear.
+ *
+ * Both Settings fields are free-typed, and `AudioService` interpolates every
+ * data point into this range with no clamp of its own, so whatever is
+ * persisted here is what the chart sounds like — and it survives a reload,
+ * since it lives in localStorage. A cleared field reads back as 0, which maps
+ * the whole chart below hearing; a min above the max inverts the mapping, so
+ * higher values sound lower. Neither is a range, so both fall back to the
+ * defaults rather than being persisted.
+ *
+ * @param min - The raw lower bound, in Hz
+ * @param max - The raw upper bound, in Hz
+ * @returns An audible, rising pitch range
+ */
+export function clampFrequencyRange(
+  min: number,
+  max: number,
+): { minFrequency: number; maxFrequency: number } {
+  const low = clampFrequency(min);
+  const high = clampFrequency(max);
+  if (low !== null && high !== null && low < high) {
+    return { minFrequency: low, maxFrequency: high };
+  }
+  return {
+    minFrequency: DEFAULT_MIN_FREQUENCY,
+    maxFrequency: DEFAULT_MAX_FREQUENCY,
+  };
+}
+
+/**
+ * One end of the pitch range, or null when it is not an audible frequency.
+ * @param value - The raw setting value in Hz
+ * @returns The frequency, or null
+ */
+function clampFrequency(value: number): number | null {
+  if (!Number.isFinite(value) || value < MIN_FREQUENCY_HZ || value > MAX_FREQUENCY_HZ) {
+    return null;
+  }
+  return value;
+}
+
 export const BRAILLE_DISPLAY_KINDS = ['single', 'multi', 'manual'] as const;
 export type BrailleDisplayKind = (typeof BRAILLE_DISPLAY_KINDS)[number];
 
@@ -206,8 +262,8 @@ export const DEFAULT_SETTINGS: Settings = {
     brailleDisplayKind: DEFAULT_BRAILLE_DISPLAY_KIND,
     brailleDisplayPresetId: null,
     tactileDisplayDeviceId: null,
-    minFrequency: 200,
-    maxFrequency: 1000,
+    minFrequency: DEFAULT_MIN_FREQUENCY,
+    maxFrequency: DEFAULT_MAX_FREQUENCY,
     autoplayDuration: 4000,
     ariaMode: 'assertive',
     hoverMode: 'pointermove',

--- a/src/ui/component/Chat.tsx
+++ b/src/ui/component/Chat.tsx
@@ -1,6 +1,7 @@
 import type { Message } from '@type/llm';
 import { Close, Send } from '@mui/icons-material';
 import {
+  Box,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -289,15 +290,22 @@ const Chat: React.FC = () => {
               },
             }}
           >
-            {messages.map((message: Message) => (
-              <MessageBubble
-                key={message.id}
-                message={message}
-                disabled={disabled}
-                _onOpenSettings={handleOpenSettings}
-                onTypingUpdate={handleTypingUpdate}
-              />
-            ))}
+            {/* A real list, so the bubbles' `listitem` role has the owner ARIA
+                requires and the reader is told how many messages there are and
+                which one they are on. Bullets and indentation are reset; the
+                scroll anchor below stays outside it, since a list may only
+                contain list items. */}
+            <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0 }}>
+              {messages.map((message: Message) => (
+                <MessageBubble
+                  key={message.id}
+                  message={message}
+                  disabled={disabled}
+                  _onOpenSettings={handleOpenSettings}
+                  onTypingUpdate={handleTypingUpdate}
+                />
+              ))}
+            </Box>
             <div ref={messagesEndRef} />
           </Grid>
 

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -42,9 +42,12 @@ import { useViewModel } from '@state/hook/useViewModel';
 import {
   clampEchoCount,
   clampEchoDuration,
+  clampFrequencyRange,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MAX_ECHO_COUNT,
+  MAX_FREQUENCY_HZ,
+  MIN_FREQUENCY_HZ,
 } from '@type/settings';
 import {
   clampBrailleLines,
@@ -678,6 +681,11 @@ const Settings: React.FC = () => {
       // hint rather than a limit; persist a value the audio service can use.
       echoCount: clampEchoCount(generalSettings.echoCount),
       echoDuration: clampEchoDuration(generalSettings.echoDuration),
+      // Both frequency fields are free-typed too, and AudioService maps every
+      // point into this range without a clamp of its own — a cleared field
+      // (which reads back as 0) or an inverted range would leave the chart
+      // silent or its pitch running backwards until Reset.
+      ...clampFrequencyRange(generalSettings.minFrequency, generalSettings.maxFrequency),
     };
     viewModel.saveAndClose({ general: safeGeneral, llm: llmSettings });
     // Update the welcome bubble's model info in place instead of resetting the
@@ -1254,7 +1262,8 @@ const Settings: React.FC = () => {
                       input: {
                         inputProps: {
                           'aria-label': 'Minimum Frequency',
-                          'min': 0,
+                          'min': MIN_FREQUENCY_HZ,
+                          'max': MAX_FREQUENCY_HZ,
                         },
                       },
                     }}
@@ -1282,7 +1291,8 @@ const Settings: React.FC = () => {
                       input: {
                         inputProps: {
                           'aria-label': 'Maximum Frequency',
-                          'min': 0,
+                          'min': MIN_FREQUENCY_HZ,
+                          'max': MAX_FREQUENCY_HZ,
                         },
                       },
                     }}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -35,8 +35,8 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { LlmValidationService } from '@service/llmValidation';
 import { getValidVersion, MODEL_VERSIONS } from '@service/modelVersions';
+import { useCredentialProbe } from '@state/hook/useCredentialProbe';
 import { useModalContainer } from '@state/hook/useModalContainer';
 import { useViewModel } from '@state/hook/useViewModel';
 import {
@@ -232,16 +232,15 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
 }) => {
   const validVersion = getValidVersion(modelKey, modelSettings.version);
   const { modalRef, container } = useModalContainer();
-  const [isValidating, setIsValidating] = useState(false);
-  const [isValid, setIsValid] = useState<boolean | null>(null);
-  // Why the last probe failed, as the probe itself described it. Kept so a
-  // rate limit or a provider outage is not reported as a bad credential:
-  // null whenever there is nothing more specific to say.
-  const [probeError, setProbeError] = useState<string | null>(null);
-  // Models available to this credential, probed from the provider's models
-  // API (or the local Ollama server) when the credential validates; replaces
-  // the curated suggestion list so users pick from what actually exists.
-  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  // The probe is a network side effect, so it belongs to the state layer
+  // rather than to this component; `useCredentialProbe` owns the debounce and
+  // the staleness handling that go with it.
+  const {
+    isValidating,
+    isValid,
+    error: probeError,
+    models: availableModels,
+  } = useCredentialProbe(modelKey, modelSettings.apiKey, modelSettings.enabled);
 
   // Ollama is a local server: the credential field holds its base URL and
   // "validation" means reachability, so most labels differ from the cloud
@@ -279,59 +278,6 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
       return probeError ?? (isOllama ? 'Ollama server is unreachable' : 'API key is invalid');
     return '';
   };
-
-  // The debounce only spaces out request starts; it cannot cancel a request
-  // already in flight. isStale lets a superseded cycle (newer keystroke or
-  // unmount) discard its response so a slow early probe can never overwrite
-  // the state of a newer one.
-  const validateApiKey = async (apiKey: string, isStale: () => boolean): Promise<void> => {
-    if (!modelSettings.enabled || !apiKey.trim()) {
-      if (!isStale()) {
-        setIsValid(null);
-        setProbeError(null);
-        setAvailableModels([]);
-        // Also clear the spinner: a superseded in-flight request skips its
-        // own finally-cleanup as stale, so this cycle owns the state.
-        setIsValidating(false);
-      }
-      return;
-    }
-
-    setIsValidating(true);
-    try {
-      // A single probe answers both credential validity and the live list of
-      // models the credential can access, for every provider.
-      const probe = await LlmValidationService.probeProvider(modelKey, apiKey);
-      if (isStale()) {
-        return;
-      }
-      setIsValid(probe.isValid);
-      setProbeError(probe.error ?? null);
-      setAvailableModels(probe.models);
-    } catch (error) {
-      if (!isStale()) {
-        setIsValid(false);
-        setProbeError(null);
-        setAvailableModels([]);
-      }
-    } finally {
-      if (!isStale()) {
-        setIsValidating(false);
-      }
-    }
-  };
-
-  useEffect(() => {
-    let cancelled = false;
-    const debounceTimer = setTimeout(() => {
-      validateApiKey(modelSettings.apiKey, () => cancelled);
-    }, 500);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(debounceTimer);
-    };
-  }, [modelSettings.apiKey, modelSettings.enabled, modelKey]);
 
   const renderMenuItems = (): React.ReactNode[] => {
     const config = MODEL_VERSIONS[modelKey];

--- a/src/ui/components/GoToExtrema.tsx
+++ b/src/ui/components/GoToExtrema.tsx
@@ -92,7 +92,11 @@ const TargetOptionRow = React.memo(({ target, index, isSelected, onSelect, optio
       role="option"
       aria-selected={isSelected}
       aria-label={displayLabel}
-      tabIndex={0}
+      // Roving tabindex (WAI-ARIA listbox), as the sibling listboxes do: the
+      // selection effect moves focus here, and only the selected option is a
+      // tab stop, so Tab leaves the list rather than walking every one of the
+      // hundreds an intersection-heavy layer produces.
+      tabIndex={isSelected ? 0 : -1}
       sx={getTargetBoxSx(isSelected)}
     >
       <Typography variant="body2" sx={{ fontWeight: 600 }}>
@@ -451,7 +455,7 @@ export const GoToExtrema: React.FC = () => {
       aria-label={option.label}
       aria-setsize={totalOptionCount}
       aria-posinset={idx + 1}
-      tabIndex={0}
+      tabIndex={dropdownSelectedIndex === idx ? 0 : -1}
       onClick={() => handleOptionSelect(option.value)}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {

--- a/src/ui/components/GoToExtrema.tsx
+++ b/src/ui/components/GoToExtrema.tsx
@@ -302,12 +302,11 @@ export const GoToExtrema: React.FC = () => {
         setDropdownSelectedIndex(0);
         announceToScreenReader('Moved to search. Type to filter X values.');
       } else {
+        // The selection effect moves real DOM focus onto the new option, and
+        // that focus move is the announcement ("<label>, option, N of M").
+        // Writing the same label into the assertive region as well says it
+        // twice, which is why CandlestickDeltaSettings has no region at all.
         goToExtremaViewModel.moveDown();
-        // Announce the newly selected option (same rich label the row shows).
-        const newOption = state.targets[state.selectedIndex + 1];
-        if (newOption) {
-          announceToScreenReader(`Selected: ${buildTargetDisplayLabel(newOption)}`);
-        }
       }
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
@@ -317,11 +316,6 @@ export const GoToExtrema: React.FC = () => {
         announceToScreenReader('At first extrema option');
       } else {
         goToExtremaViewModel.moveUp();
-        // Announce the newly selected option (same rich label the row shows).
-        const newOption = state.targets[state.selectedIndex - 1];
-        if (newOption) {
-          announceToScreenReader(`Selected: ${buildTargetDisplayLabel(newOption)}`);
-        }
       }
     } else if (event.key === 'Home') {
       // WAI-ARIA listbox: jump to the first extrema option.
@@ -329,10 +323,6 @@ export const GoToExtrema: React.FC = () => {
       event.stopPropagation();
       if (state.targets.length > 0) {
         goToExtremaViewModel.moveToIndex(0);
-        const first = state.targets[0];
-        if (first) {
-          announceToScreenReader(`Selected: ${buildTargetDisplayLabel(first)}`);
-        }
       }
     } else if (event.key === 'End') {
       // WAI-ARIA listbox: jump to the last extrema option (not the virtual
@@ -340,12 +330,7 @@ export const GoToExtrema: React.FC = () => {
       event.preventDefault();
       event.stopPropagation();
       if (state.targets.length > 0) {
-        const lastIndex = state.targets.length - 1;
-        goToExtremaViewModel.moveToIndex(lastIndex);
-        const last = state.targets[lastIndex];
-        if (last) {
-          announceToScreenReader(`Selected: ${buildTargetDisplayLabel(last)}`);
-        }
+        goToExtremaViewModel.moveToIndex(state.targets.length - 1);
       }
     } else if (event.key === 'Enter') {
       event.preventDefault();
@@ -640,17 +625,25 @@ export const GoToExtrema: React.FC = () => {
                           : renderDropdownOption(filteredOptions[item.index], item.index))}
                     </List>
                   )}
-                  {/* Assertive live region for immediate announcement of highlighted option */}
-                  <div
-                    ref={liveRegionRef}
-                    id="sr-active-option-announcer"
-                    aria-live="assertive"
-                    aria-atomic="true"
-                    style={{ position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }}
-                  />
                 </Box>
               )}
             </Box>
+
+            {/*
+              Assertive live region for what focus does not already announce:
+              the listbox boundaries, and the highlighted search result, which
+              the combobox tracks with aria-activedescendant rather than focus.
+              It sits here rather than inside the search option because only
+              three trace types offer that option — mounted in there, a bar or
+              a heatmap had no region at all and every message was dropped.
+            */}
+            <div
+              ref={liveRegionRef}
+              id="sr-active-option-announcer"
+              aria-live="assertive"
+              aria-atomic="true"
+              style={{ position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }}
+            />
           </Box>
         </>
       )

--- a/src/ui/components/GoToExtrema.tsx
+++ b/src/ui/components/GoToExtrema.tsx
@@ -56,20 +56,6 @@ function getTargetBoxSx(isSelected: boolean): object {
   };
 }
 
-// Type guard to check if plot supports navigateToExtrema
-function hasNavigateToExtrema(plot: unknown): plot is { navigateToExtrema: (target: ExtremaTarget) => void } {
-  return plot !== null
-    && typeof plot === 'object'
-    && typeof (plot as Record<string, unknown>).navigateToExtrema === 'function';
-}
-
-// Type guard to check if plot supports moveToXValue
-function hasMoveToXValue(plot: unknown): plot is { moveToXValue: (value: XValue) => void } {
-  return plot !== null
-    && typeof plot === 'object'
-    && typeof (plot as Record<string, unknown>).moveToXValue === 'function';
-}
-
 /**
  * Fixed X-value dropdown row height in px. Rows are given exactly this height
  * so scroll offsets map 1:1 to option indices for windowed rendering.
@@ -250,12 +236,11 @@ export const GoToExtrema: React.FC = () => {
     }
   }, [dropdownSelectedIndex, isDropdownOpen]);
 
+  // Selection goes out through the view model, which hides the dialog before
+  // it navigates (so the scope change and its close cue happen once) and puts
+  // the reader back in TRACE scope if the trace cannot honour the jump.
   const handleTargetSelect = useCallback((target: ExtremaTarget): void => {
-    const activeTrace = goToExtremaViewModel.activeContext?.active;
-    if (activeTrace && hasNavigateToExtrema(activeTrace)) {
-      activeTrace.navigateToExtrema(target);
-    }
-    goToExtremaViewModel.hide();
+    goToExtremaViewModel.selectTarget(target);
   }, [goToExtremaViewModel]);
 
   const handleClose = (): void => {
@@ -281,13 +266,12 @@ export const GoToExtrema: React.FC = () => {
   };
 
   const handleOptionSelect = (value: XValue): void => {
-    const activeTrace = goToExtremaViewModel.activeContext?.active;
-    if (activeTrace && hasMoveToXValue(activeTrace)) {
-      activeTrace.moveToXValue(value);
+    // The view model closes the dialog itself; only the search box's own
+    // state is this component's to reset, and only once the move was accepted.
+    if (goToExtremaViewModel.moveToXValue(value)) {
       setIsDropdownOpen(false);
       setDropdownSelectedIndex(-1);
       setInputValue('');
-      goToExtremaViewModel.hide();
     }
   };
 

--- a/src/ui/components/MessageBubble.tsx
+++ b/src/ui/components/MessageBubble.tsx
@@ -28,12 +28,12 @@ export const MessageBubble: React.FC<MessageBubbleProps> = memo(({ message, disa
 
   return (
     <Box
+      component="li"
       sx={{
         display: 'flex',
         justifyContent: message.isUser ? 'flex-end' : 'flex-start',
         mb: 2,
       }}
-      role="listitem"
     >
       <Box
         sx={{

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -152,49 +152,67 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
     <Box style={containerStyle}>
       {/* Visual typing effect for users */}
       <div className={`chat-message-content ${isUser ? 'user' : ''}`}>
-        <ReactMarkdown
-          rehypePlugins={[
-            // Before rehypeSanitize, so KaTeX's own markup goes through the
-            // allowlist rather than around it.
-            ...mathPlugins,
-            [rehypeSanitize, SANITIZE_SCHEMA],
-            // After it, and it has to be: the sanitiser renames `id` and the
-            // ARIA references but not `href`, so a footnote anchor is left
-            // naming where its target used to be. Scoping both sides here puts
-            // them back in agreement and makes the ids unique to this message,
-            // which they are not otherwise — footnotes are numbered per
-            // document and a transcript is one DOM. See `footnoteScope`.
-            [rehypeScopeIds, { messageId }],
-          ]}
-          remarkPlugins={[remarkGfm, remarkMath]}
-          components={{
-            pre: ({ node, ...props }) => (
-              <pre {...props} role="text" aria-label="Code block" />
-            ),
-            // No `a` override. A link's accessible name comes from its own
-            // text, which is right in every case and needs no help: the one
-            // this used to build — `Link: ${children}` — was a worse copy of
-            // that when children was a string, and `[object Object]` when it
-            // was anything else. `aria-label` replaces the name rather than
-            // supplementing it, so there was no fallback to the visible text.
-            //
-            // Dropping it also lets the footnote backref keep the label
-            // remark-gfm gives it, without a fallback expression to get wrong.
-            img: ({ node, ...props }) => (
-              <img {...props} alt={props.alt || 'Image in message'} />
-            ),
-            // The footnotes heading arrives as `<h2 class="sr-only">`, which
-            // mdast-util-to-hast hardcodes and expects a stylesheet to honour.
-            // Nothing can style pipeline-generated markup inline, so the class
-            // is matched here instead — see `visuallyHidden` for why not a rule.
-            h2: ({ node, className, ...props }) => {
-              const hidden = (className ?? '').split(/\s+/).includes('sr-only');
-              return <h2 {...props} className={className} style={hidden ? visuallyHidden : undefined} />;
-            },
-          }}
-        >
-          {displayedText}
-        </ReactMarkdown>
+        {/*
+          While the animation runs the prefix is shown as text, and the
+          markdown pipeline runs once, on the finished message.
+          `<ReactMarkdown>` re-parses and re-transforms its children on every
+          render, so feeding it a one-character-longer prefix every 10 ms cost
+          one full parse per character — quadratic, and past a couple of
+          thousand characters a tick no longer fits in the interval, so the
+          callbacks queue and the main thread stalls for the length of the
+          reply. A prefix is not a document either: `**bold` renders as
+          literal asterisks until its closing delimiter arrives, so the
+          structure flickered as it typed. Nothing is lost by waiting — the
+          live region below stays deliberately silent until the message is
+          complete.
+        */}
+        {isTyping
+          ? <span style={{ whiteSpace: 'pre-wrap' }}>{displayedText}</span>
+          : (
+              <ReactMarkdown
+                rehypePlugins={[
+                  // Before rehypeSanitize, so KaTeX's own markup goes through the
+                  // allowlist rather than around it.
+                  ...mathPlugins,
+                  [rehypeSanitize, SANITIZE_SCHEMA],
+                  // After it, and it has to be: the sanitiser renames `id` and the
+                  // ARIA references but not `href`, so a footnote anchor is left
+                  // naming where its target used to be. Scoping both sides here puts
+                  // them back in agreement and makes the ids unique to this message,
+                  // which they are not otherwise — footnotes are numbered per
+                  // document and a transcript is one DOM. See `footnoteScope`.
+                  [rehypeScopeIds, { messageId }],
+                ]}
+                remarkPlugins={[remarkGfm, remarkMath]}
+                components={{
+                  pre: ({ node, ...props }) => (
+                    <pre {...props} role="text" aria-label="Code block" />
+                  ),
+                  // No `a` override. A link's accessible name comes from its own
+                  // text, which is right in every case and needs no help: the one
+                  // this used to build — `Link: ${children}` — was a worse copy of
+                  // that when children was a string, and `[object Object]` when it
+                  // was anything else. `aria-label` replaces the name rather than
+                  // supplementing it, so there was no fallback to the visible text.
+                  //
+                  // Dropping it also lets the footnote backref keep the label
+                  // remark-gfm gives it, without a fallback expression to get wrong.
+                  img: ({ node, ...props }) => (
+                    <img {...props} alt={props.alt || 'Image in message'} />
+                  ),
+                  // The footnotes heading arrives as `<h2 class="sr-only">`, which
+                  // mdast-util-to-hast hardcodes and expects a stylesheet to honour.
+                  // Nothing can style pipeline-generated markup inline, so the class
+                  // is matched here instead — see `visuallyHidden` for why not a rule.
+                  h2: ({ node, className, ...props }) => {
+                    const hidden = (className ?? '').split(/\s+/).includes('sr-only');
+                    return <h2 {...props} className={className} style={hidden ? visuallyHidden : undefined} />;
+                  },
+                }}
+              >
+                {displayedText}
+              </ReactMarkdown>
+            )}
       </div>
       {/* Visually hidden live region for screen readers */}
       <div

--- a/test/state/hook/maidrControllerVisibility.esm-test.tsx
+++ b/test/state/hook/maidrControllerVisibility.esm-test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * What returning to the tab does to a reader's place in the chart.
+ *
+ * This is an `esm-test` because rendering `Maidr` mounts the whole app, and
+ * the chat bubbles in it import `react-markdown` — ESM-only, and unloadable
+ * from the CommonJS project.
+ */
+
+import type { Maidr as MaidrData } from '@type/grammar';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { TraceType } from '@type/grammar';
+import { Maidr } from '../../../src/maidr-component';
+
+const DATA: MaidrData = {
+  id: 'visibility-bar',
+  subplots: [[{
+    layers: [{
+      id: 'bar-layer',
+      type: TraceType.BAR,
+      axes: { x: { label: 'Category' }, y: { label: 'Value' } },
+      data: [
+        { x: 'A', y: 1 },
+        { x: 'B', y: 2 },
+        { x: 'C', y: 3 },
+      ],
+    }],
+  }]],
+};
+
+/**
+ * Renders the chart and activates it, the way a focus-in does.
+ *
+ * The controller is built on focus-in behind a zero-delay timer, so the timer
+ * is run before the assertions.
+ */
+function activateChart(): void {
+  render(
+    <Maidr data={DATA}>
+      <svg />
+    </Maidr>,
+  );
+
+  const figure = screen.getByRole('img').parentElement as HTMLElement;
+  act(() => {
+    fireEvent.focus(figure);
+    jest.runOnlyPendingTimers();
+  });
+}
+
+/**
+ * The text the chart is currently announcing, as the Text component shows it.
+ * @returns The announced text, or '' when nothing is announced.
+ */
+function announcedText(): string {
+  return document.querySelector('#maidr-figure-visibility-bar')?.textContent ?? '';
+}
+
+// jsdom implements neither structuredClone nor the Web Audio API, both of
+// which the controller reaches for as it starts. Stubbed at that boundary, the
+// way test/service/audio.*.test.ts stubs the same API.
+const realStructuredClone = globalThis.structuredClone;
+
+/** A Web Audio node that accepts every call the audio service makes of it. */
+function audioNode(): Record<string, unknown> {
+  const param = {
+    value: 0,
+    setValueAtTime: jest.fn(),
+    linearRampToValueAtTime: jest.fn(),
+    exponentialRampToValueAtTime: jest.fn(),
+    setValueCurveAtTime: jest.fn(),
+  };
+  return {
+    type: '',
+    frequency: param,
+    gain: param,
+    pan: param,
+    threshold: param,
+    knee: param,
+    ratio: param,
+    attack: param,
+    release: param,
+    buffer: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+  };
+}
+
+/** A stand-in AudioContext, running from the start. */
+function audioContext(): Record<string, unknown> {
+  return {
+    currentTime: 0,
+    state: 'running',
+    sampleRate: 44100,
+    destination: {},
+    createOscillator: audioNode,
+    createGain: audioNode,
+    createStereoPanner: audioNode,
+    createDynamicsCompressor: audioNode,
+    createConvolver: audioNode,
+    createBuffer: () => ({ getChannelData: () => new Float32Array(1) }),
+    createBufferSource: audioNode,
+    resume: () => Promise.resolve(),
+    close: jest.fn(),
+  };
+}
+
+/**
+ * A structured clone good enough for plain chart data.
+ * @param value - The value to copy.
+ * @returns A deep copy of it.
+ */
+function jsonClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+beforeAll(() => {
+  globalThis.structuredClone = jsonClone as typeof structuredClone;
+  (globalThis as unknown as { AudioContext: unknown }).AudioContext
+    = function AudioContextStub(): Record<string, unknown> {
+      return audioContext();
+    } as unknown as typeof AudioContext;
+});
+
+afterAll(() => {
+  globalThis.structuredClone = realStructuredClone;
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+describe('returning to the tab', () => {
+  it('should leave the reader where they were, still announcing', () => {
+    // Coming back from another tab used to dispose the controller and build a
+    // new one: the cursor went back to the first point, every slice was reset
+    // (text, braille, chat, any open dialog) and nothing was announced,
+    // because focus had never left and so no focus-in followed.
+    activateChart();
+    const before = announcedText();
+
+    expect(before).not.toBe('');
+
+    act(() => {
+      fireEvent(document, new Event('visibilitychange'));
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(announcedText()).toBe(before);
+  });
+});

--- a/test/state/viewModel/goToExtremaViewModel.test.ts
+++ b/test/state/viewModel/goToExtremaViewModel.test.ts
@@ -11,7 +11,7 @@ import type { Context } from '@model/context';
 import type { GoToExtremaService } from '@service/goToExtrema';
 import type { ExtremaTarget } from '@type/extrema';
 import type { AxisFormat } from '@type/grammar';
-import type { TraceState } from '@type/state';
+import type { AxisType, TraceState } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
 import { FormatterService } from '@service/formatter';
 import { createMaidrStore } from '@state/store';
@@ -43,7 +43,7 @@ function createTraceStub(
 }
 
 /** A FormatterService over one layer, with no `AxisFormat` unless given. */
-function createRealFormatter(format?: AxisFormat): FormatterService {
+function createRealFormatter(format?: AxisFormat, yFormat?: AxisFormat): FormatterService {
   return new FormatterService({
     id: 'chart',
     subplots: [[{
@@ -52,7 +52,7 @@ function createRealFormatter(format?: AxisFormat): FormatterService {
         type: TraceType.BAR,
         axes: {
           x: { label: 'Quarter', ...(format ? { format } : {}) },
-          y: { label: 'Share' },
+          y: { label: 'Share', ...(yFormat ? { format: yFormat } : {}) },
         },
         data: [],
       }],
@@ -60,11 +60,19 @@ function createRealFormatter(format?: AxisFormat): FormatterService {
   });
 }
 
-/** Context stub whose `active` is the trace and whose `state` carries layerId. */
-function createContextStub(active: unknown, layerId: string | null): Context {
+/**
+ * Context stub whose `active` is the trace and whose `state` carries layerId.
+ * `mainAxis` is the axis the trace reports its main value on — 'x' for a
+ * vertical trace, 'y' for a horizontal one, as `TextState.mainAxis` does.
+ */
+function createContextStub(
+  active: unknown,
+  layerId: string | null,
+  mainAxis: AxisType = 'x',
+): Context {
   const state = layerId === null
     ? { type: 'trace', empty: true }
-    : { type: 'trace', empty: false, layerId };
+    : { type: 'trace', empty: false, layerId, text: { mainAxis } };
   return { active, state } as unknown as Context;
 }
 
@@ -80,6 +88,19 @@ const TRACE_STATE = {
   empty: false,
   layerId: 'layer-1',
   traceType: 'candlestick',
+  text: { mainAxis: 'x' },
+} as unknown as TraceState;
+
+/**
+ * A horizontal trace: the value it calls `xValue` sits on the y axis, which is
+ * what `TextState.mainAxis` reports and what the announcement formats with.
+ */
+const HORIZONTAL_TRACE_STATE = {
+  type: 'trace',
+  empty: false,
+  layerId: 'layer-1',
+  traceType: 'bar',
+  text: { mainAxis: 'y' },
 } as unknown as TraceState;
 
 describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
@@ -131,6 +152,26 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const options = vm.getAvailableXValueOptions();
     expect(options).toEqual([{ value: 5, label: '500' }, { value: 6, label: '600' }]);
     expect(typeof options[0].label).toBe('string');
+  });
+
+  test('formats a horizontal trace\u2019s categories with its main axis, not always x', () => {
+    // A horizontal bar reports its category as `xValue`, but that category
+    // lives on the y axis \u2014 which is what `TextState.mainAxis` says and what
+    // the announcement for the same point formats with. Formatting these
+    // options with x applied the value axis\u2019s currency format to a category,
+    // so the option read "$2,019.00" while the announcement said "2019".
+    const store = createMaidrStore();
+    const trace = createTraceStub([2019, 2020]);
+    const context = createContextStub(trace, 'layer-1', 'y');
+    const formatter = createRealFormatter({ type: 'currency' });
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, formatter);
+
+    expect(vm.getAvailableXValueOptions()).toEqual([
+      { value: 2019, label: '2019' },
+      { value: 2020, label: '2020' },
+    ]);
+
+    formatter.dispose();
   });
 
   test('falls back to String(value) when no formatter is injected', () => {
@@ -308,6 +349,50 @@ describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
     vm.toggle(TRACE_STATE);
 
     expect(store.getState().goToExtrema.targets[0].label).toBe('Max Data at rest at 7.0');
+
+    formatter.dispose();
+  });
+
+  test('formats a horizontal trace\u2019s label with its main axis, not always x', () => {
+    // The label half of the same bug: the dialog announced "Max Bar at
+    // $2,019.00" for a category the trace itself announces as "2019".
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Max Bar at 2019',
+      xValue: 2019,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter({ type: 'currency' });
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1', 'y'),
+      formatter,
+    );
+
+    vm.toggle(HORIZONTAL_TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label).toBe('Max Bar at 2019');
+
+    formatter.dispose();
+  });
+
+  test('formats a horizontal trace\u2019s label with the y format the announcement uses', () => {
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Max Bar at 57.14285714285714',
+      xValue: 57.14285714285714,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter({ type: 'currency' }, { type: 'fixed', decimals: 1 });
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1', 'y'),
+      formatter,
+    );
+
+    vm.toggle(HORIZONTAL_TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label).toBe('Max Bar at 57.1');
 
     formatter.dispose();
   });

--- a/test/state/viewModel/goToExtremaViewModel.test.ts
+++ b/test/state/viewModel/goToExtremaViewModel.test.ts
@@ -243,6 +243,75 @@ describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
     formatter.dispose();
   });
 
+  test('rewrites only the x value, leaving the extremum value and y coordinate alone', () => {
+    // A heatmap target names the value and both coordinates, so rewriting every
+    // occurrence of the raw x corrupted the number the reader is being sent to:
+    // "Global Maximum: 0.95 at 9, 2" with x=9 came out as
+    // "Global Maximum: 0.9.05 at 9.0, 2".
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Global Maximum: 0.95 at 9, 2',
+      xValue: 9,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter({ type: 'fixed', decimals: 1 });
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1'),
+      formatter,
+    );
+
+    vm.toggle(TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label)
+      .toBe('Global Maximum: 0.95 at 9.0, 2');
+
+    formatter.dispose();
+  });
+
+  test('rewrites only the x value when the y coordinate shares its digits', () => {
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Row Maximum: 4 at 1, 12',
+      xValue: 1,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter({ type: 'fixed', decimals: 1 });
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1'),
+      formatter,
+    );
+
+    vm.toggle(TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label)
+      .toBe('Row Maximum: 4 at 1.0, 12');
+
+    formatter.dispose();
+  });
+
+  test('rewrites the x value after the last " at " when a group label carries one too', () => {
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Max Data at rest at 7',
+      xValue: 7,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter({ type: 'fixed', decimals: 1 });
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1'),
+      formatter,
+    );
+
+    vm.toggle(TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label).toBe('Max Data at rest at 7.0');
+
+    formatter.dispose();
+  });
+
   test('still honours an author-supplied format on the same path', () => {
     const store = createMaidrStore();
     const trace = createTraceStub([], [{

--- a/test/ui/chatMessageList.esm-test.tsx
+++ b/test/ui/chatMessageList.esm-test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * How the chat transcript is exposed to a screen reader.
+ *
+ * A message bubble declares itself a list item, and ARIA requires a list item
+ * to be owned by a list. Left orphaned in a plain region, the role is dropped
+ * to generic by Chromium and NVDA loses list navigation, so the reader is
+ * never told how many messages there are or which one they are on.
+ *
+ * This is an `esm-test` because `MessageBubble` renders `TypingEffect`, which
+ * imports `react-markdown` — ESM-only, and unloadable from the CommonJS
+ * project.
+ */
+
+import type { CommandExecutor } from '@service/commandExecutor';
+import type { ChatViewModel } from '@state/viewModel/chatViewModel';
+import type { SettingsViewModel } from '@state/viewModel/settingsViewModel';
+import { describe, expect, it, jest } from '@jest/globals';
+import { MaidrContext } from '@state/context';
+import { createMaidrStore } from '@state/store';
+import { chatActions } from '@state/viewModel/chatViewModel';
+import { ViewModelRegistry } from '@state/viewModel/registry';
+import { render, screen } from '@testing-library/react';
+import Chat from '@ui/component/Chat';
+import { Provider } from 'react-redux';
+import '@testing-library/jest-dom/jest-globals';
+
+/** The `ChatViewModel` surface `Chat` actually calls. */
+type ChatStub = Pick<ChatViewModel, 'canSend' | 'toggle' | 'sendMessage'>;
+
+/** The `SettingsViewModel` surface `Chat` actually calls. */
+type SettingsStub = Pick<SettingsViewModel, 'toggle'>;
+
+/** How many bubbles the transcript below holds. */
+const MESSAGE_COUNT = 2;
+
+/**
+ * Renders the chat dialog over a real store holding the messages above.
+ *
+ * The store is the production one because `Chat` and `TypingEffect` both read
+ * their state through `useViewModelState`; only the view models' own methods
+ * are stubbed.
+ */
+function renderChat(): void {
+  const chat: ChatStub = {
+    canSend: true,
+    toggle: jest.fn(),
+    sendMessage: jest.fn(async () => {}),
+  };
+  const settings: SettingsStub = { toggle: jest.fn() };
+
+  const store = createMaidrStore();
+  store.dispatch(chatActions.addUserMessage({
+    text: 'What is the highest bar?',
+    timestamp: '2025-01-01T00:00:00.000Z',
+  }));
+  store.dispatch(chatActions.addSystemMessage({
+    text: 'The highest bar is Q3.',
+    timestamp: '2025-01-01T00:00:01.000Z',
+  }));
+
+  const registry = new ViewModelRegistry();
+  registry.register('chat', chat as ChatViewModel);
+  registry.register('settings', settings as SettingsViewModel);
+
+  render(
+    <Provider store={store}>
+      <MaidrContext.Provider
+        value={{
+          viewModelRegistry: registry,
+          commandExecutor: {} as unknown as CommandExecutor,
+        }}
+      >
+        <Chat />
+      </MaidrContext.Provider>
+    </Provider>,
+  );
+}
+
+describe('chat transcript structure', () => {
+  it('should own every message item with a list', () => {
+    renderChat();
+
+    const list = screen.getByRole('list');
+    const items = screen.getAllByRole('listitem');
+
+    expect(items).toHaveLength(MESSAGE_COUNT);
+    items.forEach(item => expect(list).toContainElement(item));
+  });
+});

--- a/test/ui/goToExtrema.test.tsx
+++ b/test/ui/goToExtrema.test.tsx
@@ -231,3 +231,29 @@ describe('go to dialog: what the listbox announces', () => {
     expect(viewModel.moveToIndex).toHaveBeenCalledWith(0);
   });
 });
+
+describe('go to dialog: keyboard reach', () => {
+  it('should make only the selected extrema option a tab stop', () => {
+    // Roving tabindex, as the two sibling listboxes implement it. With every
+    // option a tab stop, reaching the search field or the close button from
+    // an intersection-heavy layer meant Tabbing through hundreds of them, and
+    // Shift+Tab never left the list at all.
+    const { store } = renderDialog();
+
+    act(() => {
+      store.dispatch({ type: 'goToExtrema/updateSelectedIndex', payload: 1 });
+    });
+
+    expect(screen.getByLabelText('Max Bar Value: 8.00 at Q1')).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByLabelText('Min Bar Value: 2.00 at Q3')).toHaveAttribute('tabindex', '0');
+  });
+
+  it('should make only the highlighted search result a tab stop', () => {
+    renderDialog({ xValues: [{ value: 3, label: 'Q3' }, { value: 4, label: 'Q4' }] });
+
+    fireEvent.click(screen.getByLabelText('Search and select X value'));
+
+    expect(screen.getByRole('option', { name: 'Q3' })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('option', { name: 'Q4' })).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/test/ui/goToExtrema.test.tsx
+++ b/test/ui/goToExtrema.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Component tests for the Go To dialog.
+ *
+ * The dialog is the only place a reader can jump to a named point of interest
+ * without walking the whole trace, so what is asserted here is the contract a
+ * screen reader depends on: that a selection goes out through the view model's
+ * guarded path rather than the component driving the model itself.
+ */
+
+import type { CommandExecutor } from '@service/commandExecutor';
+import type { GoToExtremaViewModel } from '@state/viewModel/goToExtremaViewModel';
+import type { ExtremaTarget } from '@type/extrema';
+import { describe, expect, it, jest } from '@jest/globals';
+import { MaidrContext } from '@state/context';
+import { createMaidrStore } from '@state/store';
+import { ViewModelRegistry } from '@state/viewModel/registry';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GoToExtrema } from '@ui/components/GoToExtrema';
+import { Provider } from 'react-redux';
+// The `/jest-globals` entry point augments the imported `expect`; the bare
+// one only augments the ambient global.
+import '@testing-library/jest-dom/jest-globals';
+
+/** The `GoToExtremaViewModel` surface `GoToExtrema` actually calls. */
+type GoToExtremaStub = Pick<
+  GoToExtremaViewModel,
+  | 'getAvailableXValueOptions'
+  | 'hide'
+  | 'moveUp'
+  | 'moveDown'
+  | 'moveToIndex'
+  | 'moveToXValue'
+  | 'selectTarget'
+>;
+
+/** Builds a min/max target the dialog can render. */
+function createTarget(label: string, value: number): ExtremaTarget {
+  return {
+    label,
+    value,
+    pointIndex: 0,
+    segment: 'bar',
+    type: 'max',
+    navigationType: 'point',
+  };
+}
+
+const TARGETS = [
+  createTarget('Max Bar at Q1', 8),
+  createTarget('Min Bar at Q3', 2),
+];
+
+interface Rendered {
+  viewModel: { [K in keyof GoToExtremaStub]: jest.Mock };
+}
+
+/**
+ * Renders the dialog over a real store with a stub view model.
+ *
+ * The store is the production one so the component reads its state through
+ * `useViewModelState` exactly as it does at runtime; only the view model's
+ * own methods are stubbed.
+ * @param options - Test options.
+ * @param options.xValues - The X-value search options the trace offers.
+ * @param options.targets - The extrema targets to list.
+ * @returns The stub view model, for asserting what the component called.
+ */
+function renderDialog(options: {
+  xValues?: { value: number; label: string }[];
+  targets?: ExtremaTarget[];
+} = {}): Rendered {
+  const viewModel = {
+    getAvailableXValueOptions: jest.fn(() => options.xValues ?? []),
+    hide: jest.fn(),
+    moveUp: jest.fn(),
+    moveDown: jest.fn(),
+    moveToIndex: jest.fn(),
+    moveToXValue: jest.fn(() => true),
+    selectTarget: jest.fn(),
+  };
+
+  const store = createMaidrStore();
+  store.dispatch({
+    type: 'goToExtrema/show',
+    payload: { targets: options.targets ?? TARGETS, description: 'Go somewhere' },
+  });
+
+  const registry = new ViewModelRegistry();
+  registry.register('goToExtrema', viewModel as unknown as GoToExtremaViewModel);
+
+  render(
+    <Provider store={store}>
+      <MaidrContext.Provider
+        value={{
+          viewModelRegistry: registry,
+          commandExecutor: {} as unknown as CommandExecutor,
+        }}
+      >
+        <GoToExtrema />
+      </MaidrContext.Provider>
+    </Provider>,
+  );
+
+  return { viewModel: viewModel as unknown as Rendered['viewModel'] };
+}
+
+describe('go to dialog: selecting a target', () => {
+  it('should send a clicked target to the view model rather than navigating itself', () => {
+    const { viewModel } = renderDialog();
+
+    fireEvent.click(screen.getByLabelText('Max Bar Value: 8.00 at Q1'));
+
+    expect(viewModel.selectTarget).toHaveBeenCalledWith(TARGETS[0]);
+  });
+
+  it('should send an Enter on the selected target to the view model', () => {
+    const { viewModel } = renderDialog();
+
+    fireEvent.keyDown(screen.getByRole('listbox', { name: 'Navigation targets' }), {
+      key: 'Enter',
+    });
+
+    expect(viewModel.selectTarget).toHaveBeenCalledWith(TARGETS[0]);
+  });
+
+  it('should leave the dialog to close itself, so the close cue sounds once', () => {
+    // The view model hides before it navigates, which is what keeps the scope
+    // change and its close cue ahead of the move. A component that hides on
+    // its own account would sound it a second time.
+    const { viewModel } = renderDialog();
+
+    fireEvent.click(screen.getByLabelText('Max Bar Value: 8.00 at Q1'));
+
+    expect(viewModel.hide).not.toHaveBeenCalled();
+  });
+});
+
+describe('go to dialog: selecting an X value', () => {
+  it('should send a chosen X value to the view model rather than moving the trace', () => {
+    const { viewModel } = renderDialog({
+      xValues: [{ value: 3, label: 'Q3' }],
+    });
+
+    fireEvent.click(screen.getByLabelText('Search and select X value'));
+    fireEvent.click(screen.getByRole('option', { name: 'Q3' }));
+
+    expect(viewModel.moveToXValue).toHaveBeenCalledWith(3);
+    expect(viewModel.hide).not.toHaveBeenCalled();
+  });
+});

--- a/test/ui/goToExtrema.test.tsx
+++ b/test/ui/goToExtrema.test.tsx
@@ -18,7 +18,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { MaidrContext } from '@state/context';
 import { createMaidrStore } from '@state/store';
 import { ViewModelRegistry } from '@state/viewModel/registry';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { GoToExtrema } from '@ui/components/GoToExtrema';
 import { Provider } from 'react-redux';
 // The `/jest-globals` entry point augments the imported `expect`; the bare
@@ -56,6 +56,7 @@ const TARGETS = [
 
 interface Rendered {
   viewModel: { [K in keyof GoToExtremaStub]: jest.Mock };
+  store: ReturnType<typeof createMaidrStore>;
 }
 
 /**
@@ -105,7 +106,25 @@ function renderDialog(options: {
     </Provider>,
   );
 
-  return { viewModel: viewModel as unknown as Rendered['viewModel'] };
+  return { viewModel: viewModel as unknown as Rendered['viewModel'], store };
+}
+
+/** The dialog's extrema listbox. */
+function targetListbox(): HTMLElement {
+  return screen.getByRole('listbox', { name: 'Navigation targets' });
+}
+
+/**
+ * The dialog's assertive live region.
+ * @returns The region element.
+ * @throws When the dialog rendered without one.
+ */
+function liveRegion(): HTMLElement {
+  const region = document.getElementById('sr-active-option-announcer');
+  if (region === null) {
+    throw new Error('the dialog rendered no live region');
+  }
+  return region;
 }
 
 describe('go to dialog: selecting a target', () => {
@@ -120,9 +139,7 @@ describe('go to dialog: selecting a target', () => {
   it('should send an Enter on the selected target to the view model', () => {
     const { viewModel } = renderDialog();
 
-    fireEvent.keyDown(screen.getByRole('listbox', { name: 'Navigation targets' }), {
-      key: 'Enter',
-    });
+    fireEvent.keyDown(targetListbox(), { key: 'Enter' });
 
     expect(viewModel.selectTarget).toHaveBeenCalledWith(TARGETS[0]);
   });
@@ -150,5 +167,67 @@ describe('go to dialog: selecting an X value', () => {
 
     expect(viewModel.moveToXValue).toHaveBeenCalledWith(3);
     expect(viewModel.hide).not.toHaveBeenCalled();
+  });
+});
+
+describe('go to dialog: what the listbox announces', () => {
+  it('should keep a live region mounted for a trace with no X-value search', () => {
+    // The region used to live inside the search option, which only exists for
+    // the three traces that offer getAvailableXValues. For a bar or a heatmap
+    // there was no region at all, so every message written to it was dropped.
+    renderDialog({ xValues: [] });
+
+    expect(liveRegion()).toBeInTheDocument();
+  });
+
+  it('should announce the first-option boundary on a trace with no X-value search', () => {
+    renderDialog({ xValues: [] });
+
+    fireEvent.keyDown(targetListbox(), { key: 'ArrowUp' });
+
+    expect(liveRegion()).toHaveTextContent('At first extrema option');
+  });
+
+  it('should move focus onto the selected option, which is what announces it', () => {
+    const { store } = renderDialog();
+
+    act(() => {
+      store.dispatch({ type: 'goToExtrema/updateSelectedIndex', payload: 1 });
+    });
+
+    expect(document.activeElement).toBe(screen.getByLabelText('Min Bar Value: 2.00 at Q3'));
+  });
+
+  it('should not also write the moved-to label into the live region', () => {
+    // Focus lands on the option and the screen reader reads its label and
+    // position; writing the same label to an assertive region says it twice.
+    // Observed as a mutation, because the region carrying no new text and the
+    // region never being written are the same assertion otherwise.
+    // A trace that offers the X-value search, so the region existed even
+    // before it was hoisted out of that block: the failure this pins is the
+    // duplicate write, not a missing region.
+    const { viewModel } = renderDialog({ xValues: [{ value: 3, label: 'Q3' }] });
+    const observer = new MutationObserver(() => {});
+    observer.observe(liveRegion(), { childList: true, characterData: true, subtree: true });
+
+    fireEvent.keyDown(targetListbox(), { key: 'ArrowDown' });
+    const records = observer.takeRecords();
+    observer.disconnect();
+
+    expect(records).toHaveLength(0);
+    expect(viewModel.moveDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not repeat the label on a Home jump either', () => {
+    const { viewModel } = renderDialog({ xValues: [{ value: 3, label: 'Q3' }] });
+    const observer = new MutationObserver(() => {});
+    observer.observe(liveRegion(), { childList: true, characterData: true, subtree: true });
+
+    fireEvent.keyDown(targetListbox(), { key: 'Home' });
+    const records = observer.takeRecords();
+    observer.disconnect();
+
+    expect(records).toHaveLength(0);
+    expect(viewModel.moveToIndex).toHaveBeenCalledWith(0);
   });
 });

--- a/test/ui/serviceImports.test.ts
+++ b/test/ui/serviceImports.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The view layer does not call services.
+ *
+ * `rules/ui.md` puts it plainly — "No `useSelector`, no service imports, no
+ * model imports" — and the reason is not tidiness: a component that starts a
+ * network request on its own account owns a side effect nothing else can see,
+ * cancel, or reuse, and the same request then grows a second call site with
+ * its own idea of what a stale response is. That is exactly what happened to
+ * the LLM credential probe, which ran from `Settings.tsx` and, separately,
+ * from `useOllamaModels`.
+ *
+ * What is checked is the *service*, not every symbol that happens to live in
+ * `src/service/`: `modelVersions` is a catalog of constants and a pure lookup,
+ * with no behaviour to route through a view model. Where that file belongs is
+ * a separate question from this one — `scripts/check-model-catalog.mjs` and
+ * `.github/workflows/model-catalog-check.yml` both name it by path.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+
+const UI_DIR = resolve(__dirname, '../../src/ui');
+const ROOT = resolve(__dirname, '../..');
+
+/** Matches an import of a `…Service` class from the service layer. */
+const SERVICE_IMPORT = /import\s+(?:type\s+)?\{[^}]*\b\w+Service\b[^}]*\}\s+from\s+'@service\//;
+
+/**
+ * Every TypeScript source file under a directory.
+ * @param dir - The directory to walk.
+ * @returns Absolute paths of the files found.
+ */
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      return sourceFiles(path);
+    }
+    return /\.tsx?$/.test(entry) ? [path] : [];
+  });
+}
+
+describe('the view layer', () => {
+  it('should reach services through a view model or a state hook, never directly', () => {
+    const offenders = sourceFiles(UI_DIR)
+      .filter(path => SERVICE_IMPORT.test(readFileSync(path, 'utf8')))
+      .map(path => relative(ROOT, path));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/ui/settings.frequencyRange.test.tsx
+++ b/test/ui/settings.frequencyRange.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Component test for what the settings dialog persists as the pitch range.
+ *
+ * The two frequency fields are free-typed numbers, and the audio service maps
+ * every data point into `[minFrequency, maxFrequency]` with no clamp of its
+ * own. A range that does not rise carries no pitch information at all: with a
+ * max of 0 the tones are sub-audible, and with a min above the max higher
+ * values sound *lower*. Either one survives a reload, because it is written to
+ * localStorage — only "Reset" clears it.
+ *
+ * The assertions are on the range's properties (audible, increasing) rather
+ * than on a particular fallback, because those are what the sonification
+ * actually depends on.
+ */
+
+import type { CommandExecutor } from '@service/commandExecutor';
+import type { ChatViewModel } from '@state/viewModel/chatViewModel';
+import type { SettingsViewModel } from '@state/viewModel/settingsViewModel';
+import type { Settings as SettingsState } from '@type/settings';
+import { describe, expect, it, jest } from '@jest/globals';
+import { MaidrContext } from '@state/context';
+import { ViewModelRegistry } from '@state/viewModel/registry';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DEFAULT_SETTINGS } from '@type/settings';
+import Settings from '@ui/component/Settings';
+// The `/jest-globals` entry point augments the imported `expect`; the bare
+// one only augments the ambient global.
+import '@testing-library/jest-dom/jest-globals';
+
+/** The `SettingsViewModel` surface `Settings` actually calls. */
+type SettingsStub = Pick<
+  SettingsViewModel,
+  | 'state'
+  | 'load'
+  | 'reset'
+  | 'toggle'
+  | 'saveAndClose'
+  | 'tactileDisplayState'
+  | 'onTactileDisplayStateChange'
+  | 'supportsTactileTransport'
+  | 'connectTactileDisplay'
+  | 'disconnectTactileDisplay'
+  | 'preloadTactileDisplay'
+>;
+
+/** The `ChatViewModel` surface `Settings` actually calls. */
+type ChatStub = Pick<ChatViewModel, 'updateWelcomeMessage'>;
+
+/** The lowest pitch a listener can be expected to hear. */
+const AUDIBLE_FLOOR_HZ = 20;
+
+/**
+ * Renders the settings dialog with stub view models.
+ *
+ * Only the leaves are stubbed: the registry is the production one, so the
+ * component reaches its view models the same way it does at runtime.
+ * @returns The `saveAndClose` stub, which carries what would be persisted.
+ */
+function renderSettings(): jest.Mock<SettingsViewModel['saveAndClose']> {
+  const saveAndClose = jest.fn<SettingsViewModel['saveAndClose']>();
+  const settings: SettingsStub = {
+    state: DEFAULT_SETTINGS,
+    load: jest.fn(),
+    reset: jest.fn(),
+    toggle: jest.fn(),
+    saveAndClose,
+    // The tactile-display picker sits in the same dialog. Nothing here
+    // exercises it, but the component reads its state on every render and
+    // subscribes on mount, so the stub has to answer both.
+    tactileDisplayState: {
+      status: 'disconnected',
+      deviceName: null,
+      transport: null,
+      geometry: null,
+      message: '',
+    },
+    onTactileDisplayStateChange: jest.fn(() => ({ dispose: jest.fn() })),
+    supportsTactileTransport: jest.fn(() => false),
+    connectTactileDisplay: jest.fn(async () => ({
+      status: 'disconnected' as const,
+      deviceName: null,
+      transport: null,
+      geometry: null,
+      message: '',
+    })),
+    disconnectTactileDisplay: jest.fn(),
+    preloadTactileDisplay: jest.fn(),
+  };
+  const chat: ChatStub = { updateWelcomeMessage: jest.fn() };
+
+  const registry = new ViewModelRegistry();
+  registry.register('settings', settings as SettingsViewModel);
+  registry.register('chat', chat as ChatViewModel);
+
+  render(
+    <MaidrContext.Provider
+      value={{
+        viewModelRegistry: registry,
+        commandExecutor: {} as unknown as CommandExecutor,
+      }}
+    >
+      <Settings />
+    </MaidrContext.Provider>,
+  );
+
+  return saveAndClose;
+}
+
+/**
+ * Types the two frequency fields, saves, and reports what was persisted.
+ * @param minFrequency - What to type into the Min Frequency field.
+ * @param maxFrequency - What to type into the Max Frequency field.
+ * @returns The general settings handed to `saveAndClose`.
+ */
+function savedGeneral(minFrequency: string, maxFrequency: string): SettingsState['general'] {
+  const saveAndClose = renderSettings();
+
+  fireEvent.change(screen.getByLabelText('Minimum Frequency'), {
+    target: { value: minFrequency },
+  });
+  fireEvent.change(screen.getByLabelText('Maximum Frequency'), {
+    target: { value: maxFrequency },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Save & Close Settings' }));
+
+  const [saved] = saveAndClose.mock.calls[0];
+  return saved.general;
+}
+
+describe('settings pitch range', () => {
+  it('should not persist a cleared max frequency as silence', () => {
+    const general = savedGeneral('200', '');
+
+    expect(general.maxFrequency).toBeGreaterThanOrEqual(AUDIBLE_FLOOR_HZ);
+    expect(general.maxFrequency).toBeGreaterThan(general.minFrequency);
+  });
+
+  it('should not persist a cleared min frequency as silence', () => {
+    const general = savedGeneral('', '1000');
+
+    expect(general.minFrequency).toBeGreaterThanOrEqual(AUDIBLE_FLOOR_HZ);
+    expect(general.maxFrequency).toBeGreaterThan(general.minFrequency);
+  });
+
+  it('should not persist a range that runs backwards', () => {
+    const general = savedGeneral('900', '300');
+
+    expect(general.maxFrequency).toBeGreaterThan(general.minFrequency);
+  });
+
+  it('should keep a range the user typed correctly', () => {
+    const general = savedGeneral('300', '900');
+
+    expect(general.minFrequency).toBe(300);
+    expect(general.maxFrequency).toBe(900);
+  });
+});

--- a/test/ui/typingEffectAnimation.esm-test.tsx
+++ b/test/ui/typingEffectAnimation.esm-test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * What the typing animation costs, and what it shows while it runs.
+ *
+ * Every 10 ms tick used to hand a one-character-longer prefix straight to
+ * `<ReactMarkdown>`, which re-parses and re-transforms its children on every
+ * render — remark-gfm, remark-math, rehype-sanitize, rehype-scope-ids and,
+ * for a message with maths, rehype-katex. An N-character reply therefore cost
+ * N full parses of a growing prefix, and each one replaced the whole rendered
+ * subtree. Past a couple of thousand characters a tick no longer fits in the
+ * interval, the callbacks queue, and the main thread — including the live
+ * region updates a screen reader depends on — stalls for the length of the
+ * reply.
+ *
+ * The cases below pin the shape rather than a timing: one DOM mutation per
+ * tick instead of a whole re-rendered tree, and no half-parsed markdown on
+ * screen on the way there.
+ *
+ * This is an `esm-test` because the component imports `react-markdown`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createMaidrStore } from '@state/store';
+import { act, render } from '@testing-library/react';
+import { TypingEffect } from '@ui/components/TypingEffect';
+import { Provider } from 'react-redux';
+import '@testing-library/jest-dom/jest-globals';
+
+/** The animation reveals one character per this many milliseconds. */
+const TICK_MS = 10;
+
+/** Distinguishes every message this file renders, so none replays a cached run. */
+let rendered = 0;
+
+/**
+ * Renders one assistant message, mid-animation.
+ * @param text - The message body.
+ * @returns The rendered container and the element holding the message content.
+ */
+function renderMessage(text: string): { container: HTMLElement; content: HTMLElement } {
+  const { container } = render(
+    <Provider store={createMaidrStore()}>
+      <TypingEffect text={text} isUser={false} messageId={`anim-${rendered++}`} />
+    </Provider>,
+  );
+
+  const content = container.querySelector('.chat-message-content');
+  if (content === null) {
+    throw new Error('no message content rendered');
+  }
+  return { container, content: content as HTMLElement };
+}
+
+/**
+ * Advances the animation by a number of ticks.
+ * @param ticks - How many characters to reveal.
+ */
+function type(ticks: number): void {
+  act(() => {
+    jest.advanceTimersByTime(ticks * TICK_MS);
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('the typing animation', () => {
+  it('should build no markdown tree while it types', () => {
+    // The property that makes a tick cheap: the prefix is text, so nothing is
+    // parsed or transformed on the way to the next character. Two hundred
+    // characters into this message the old path had already rendered a
+    // heading, a paragraph, a link and most of a list, and rebuilt all of it
+    // on every one of those two hundred ticks.
+    const body = `# Heading\n\nSome **bold** text, a [link](https://example.com) and a list:\n\n- one\n- two\n- three\n\nAnd a closing paragraph that runs on for a while so the tree is not tiny.`;
+    const { content } = renderMessage(body);
+
+    // Well past the heading, the link and most of the list, and well short of
+    // the end, so the animation is still running when the assertions read it.
+    const revealed = 120;
+    type(revealed + 1);
+
+    expect(content.querySelectorAll('*').length).toBeLessThanOrEqual(1);
+    expect(content.textContent).toBe(body.slice(0, revealed));
+  });
+
+  it('should not show half-parsed markdown while it types', () => {
+    // A prefix is not a document: `**bold` renders as literal asterisks until
+    // the closing delimiter arrives, so the structure flickered as it typed.
+    const { container, content } = renderMessage('**bold** and then some more text');
+
+    type(9);
+
+    expect(content.textContent).toBe('**bold**');
+    expect(container.querySelector('strong')).toBeNull();
+  });
+
+  it('should render the finished message as markdown', () => {
+    const body = '**bold** and then some more text';
+    const { container, content } = renderMessage(body);
+
+    type(body.length + 2);
+
+    expect(container.querySelector('strong')).toHaveTextContent('bold');
+    expect(content.textContent).toBe('bold and then some more text');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Ten defects in the UI layer, found in a codebase audit. Each was reproduced with a test that failed first. This is the layer where accessibility is either delivered or lost, so the weighting reflects that.

Extrema labels were rewritten with `replaceAll`, so formatting the x value **corrupted every other number in the label that happened to match it**. They were also always formatted with the x-axis formatter regardless of orientation, so a horizontal trace applied the value-axis format to a category.

The extrema listbox announced each option twice, once from focus and once from a live region that duplicated it, and that region was only mounted for traces with x-value search, so other trace types got no boundary or search messages at all. Every option was its own tab stop rather than a roving tabindex, so a reader tabbed through the whole list instead of arrowing within it.

Chat messages were `role="listitem"` inside a section rather than a list, which leaves the items without the container that gives them meaning.

## Related Issues

None.

## Changes Made

- **extrema**: only the x value is rewritten, after the label's final ` at `, and it is formatted with the trace's main axis.
- **extrema**: the live region moved to dialog level so every trace type has one, and it no longer repeats what focus already announced. Boundary and search-result messages are kept.
- **extrema**: roving tabindex on both the list and the x-value dropdown.
- **extrema**: the dialog no longer reaches through the ViewModel into the model to navigate the trace itself.
- **settings**: a pitch range that is not audible or not rising falls back to the defaults at save time, and the inputs declare their bounds.
- **settings**: the dialog no longer imports a service directly; the probe moved to a hook.
- **chat**: messages are a list.
- **chat**: the typing animation no longer re-runs the whole markdown pipeline every 10ms tick.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**The change I would most like a second opinion on** is the `visibilitychange` handler, which is deleted outright rather than repaired. It rebuilt the controller when a tab regained focus, silently discarding the reader's position, their text and braille output, and the chat history. Nothing in the tree needed that rebuild, and the audio service already defers its cues behind `resume()`, which is what the rebuild appears to have been working around. But this changes tab-return behaviour for every chart, so it is worth someone confirming there is no case it was quietly serving.

**Two boundary crossings are fixed and one is documented rather than fixed.** `GoToExtremaViewModel.activeContext` was removed, since it was the view's only route into the model and nothing else used it. The settings dialog's probe moved into a hook. But `@service/modelVersions` stays where it is: `scripts/check-model-catalog.mjs`, the model-catalog workflow and its own test all name it by path, so moving it is a repo-wide rename rather than a minimal fix. `test/ui/serviceImports.test.ts` now bans service-class imports from `src/ui` and documents that one carve-out, so the rule is enforced rather than remembered.

Mid-animation the chat bubble now shows the raw prefix as pre-wrapped text and renders markdown once when typing finishes, so half-parsed markdown no longer flickers. The live region was already silent while typing, so nothing announced changes.

One existing fixture was extended, not weakened: the extrema view-model test's trace state now carries `text.mainAxis`, which the production code reads. No existing assertion changed.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (503 suites, 6740 tests) and the esm project under `--experimental-vm-modules` (15 suites, 177 tests), both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_