### PR TITLE
fix(tableau): leave a cell the view never drew as null, not zero

### DIFF
--- a/src/adapters/recharts/MaidrRecharts.tsx
+++ b/src/adapters/recharts/MaidrRecharts.tsx
@@ -142,32 +142,49 @@ export function MaidrRecharts({
   selectorOverride,
   children,
 }: MaidrRechartsProps): JSX.Element {
+  // Read out of the chart subtree on every render, and cheaply: each walk is
+  // depth-first and stops at the first element it wants. What must NOT be a
+  // dependency of the conversion below is `children` itself — the parent
+  // builds a fresh element tree every time it renders, so its identity is
+  // never stable and the memo would never hold. These three scalars are the
+  // whole of what the schema takes from it, so they are what it depends on;
+  // the per-panel answers travel as their serialised form for the same reason.
+  //
+  // Simple and composed mode read the one chart's axes; subplot mode reads
+  // each panel's own, since a panel is its own chart with its own axes and
+  // the walk would otherwise stop at whichever axis it met first. Each panel
+  // is asked with its own orientation, since a panel may override the grid's
+  // and that is what decides which axis its categories are on.
+  const categoryAxisReversed = subplots
+    ? undefined
+    : categoryAxisReversedFor(children, orientation === Orientation.HORIZONTAL);
+  const perPanel = subplots
+    ? categoryAxisReversedPerPanelFor(
+        children,
+        normalizeRechartsSubplotGrid(subplots, columns).flat(),
+        orientation,
+      )
+    : undefined;
+  // Serialised rather than joined so an empty grid stays empty: `''.split(',')`
+  // is `['']`, which would claim a panel that is not there.
+  const perPanelKey = perPanel === undefined ? undefined : JSON.stringify(perPanel);
+  // The convention is on the `<Line type>` the chart already declares, so a
+  // step chart need not say it twice. An explicit one still wins, which is how
+  // the reading is corrected when the walk finds a curve that is not the one
+  // meant. Subplot mode abstains for the same reason the axis walk does above
+  // -- one verdict would read the first panel's curve onto every other -- so a
+  // grid of step charts declares the convention, on the panel or on the grid.
+  const resolvedStepDirection = subplots
+    ? stepDirection
+    : (stepDirection ?? stepDirectionFor(children));
+
   const maidrData = useMemo(
     () => convertRechartsToMaidr({
-      // Simple and composed mode read the one chart's axes; subplot mode reads
-      // each panel's own, since a panel is its own chart with its own axes and
-      // the walk would otherwise stop at whichever axis it met first.
-      categoryAxisReversed: subplots
+      categoryAxisReversed,
+      categoryAxisReversedPerPanel: perPanelKey === undefined
         ? undefined
-        : categoryAxisReversedFor(children, orientation === Orientation.HORIZONTAL),
-      // Each panel is asked with its own orientation, since a panel may
-      // override the grid's and that is what decides which axis its categories
-      // are on.
-      categoryAxisReversedPerPanel: subplots
-        ? categoryAxisReversedPerPanelFor(
-            children,
-            normalizeRechartsSubplotGrid(subplots, columns).flat(),
-            orientation,
-          )
-        : undefined,
-      // The convention is on the `<Line type>` the chart already declares, so
-      // a step chart need not say it twice. An explicit one still wins, which
-      // is how the reading is corrected when the walk finds a curve that is
-      // not the one meant. Subplot mode abstains for the same reason the axis
-      // walk does above -- one verdict would read the first panel's curve onto
-      // every other -- so a grid of step charts declares the convention, on the
-      // panel or on the grid.
-      stepDirection: subplots ? stepDirection : (stepDirection ?? stepDirectionFor(children)),
+        : (JSON.parse(perPanelKey) as boolean[]),
+      stepDirection: resolvedStepDirection,
       id,
       title,
       subtitle,
@@ -198,9 +215,10 @@ export function MaidrRecharts({
       boxenConfig,
       selectorOverride,
     }),
-    // `children` joins the list because the schema now reads the axes out of
-    // it; without that a chart that flips `reversed` would keep the old order.
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, stepDirection, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, parallelConfig, ridgelineConfig, hexbinConfig, boxenConfig, selectorOverride, children],
+    // The three facts read out of `children` stand in for it, so a chart that
+    // flips `reversed` is still picked up while a parent re-render that only
+    // rebuilds the same subtree is not.
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, categoryAxisReversed, perPanelKey, resolvedStepDirection, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, parallelConfig, ridgelineConfig, hexbinConfig, boxenConfig, selectorOverride],
   );
 
   return (

--- a/src/adapters/recharts/MaidrRecharts.tsx
+++ b/src/adapters/recharts/MaidrRecharts.tsx
@@ -43,7 +43,7 @@ import type { MaidrRechartsProps, RechartsSubplotConfig } from './types';
 import { Children, useMemo } from 'react';
 import { Maidr } from '../../maidr-component';
 import { Orientation } from '../../type/grammar';
-import { categoryAxisReversedFor, stepDirectionFor } from './childProps';
+import { categoryAxisReversedFor, categoryAxisReversedPerPanelFor, stepDirectionFor } from './childProps';
 import { convertRechartsToMaidr, normalizeRechartsSubplotGrid } from './converters';
 import { getPanelClassName } from './selectors';
 
@@ -150,9 +150,15 @@ export function MaidrRecharts({
       categoryAxisReversed: subplots
         ? undefined
         : categoryAxisReversedFor(children, orientation === Orientation.HORIZONTAL),
+      // Each panel is asked with its own orientation, since a panel may
+      // override the grid's and that is what decides which axis its categories
+      // are on.
       categoryAxisReversedPerPanel: subplots
-        ? Children.toArray(children).map(panel =>
-            categoryAxisReversedFor(panel, orientation === Orientation.HORIZONTAL))
+        ? categoryAxisReversedPerPanelFor(
+            children,
+            normalizeRechartsSubplotGrid(subplots, columns).flat(),
+            orientation,
+          )
         : undefined,
       // The convention is on the `<Line type>` the chart already declares, so
       // a step chart need not say it twice. An explicit one still wins, which

--- a/src/adapters/recharts/childProps.ts
+++ b/src/adapters/recharts/childProps.ts
@@ -13,6 +13,8 @@
  */
 import type { StepDirection } from '@type/grammar';
 import type { ReactNode } from 'react';
+import type { RechartsSubplotConfig } from './types';
+import { Orientation } from '@type/grammar';
 import { Children, isValidElement } from 'react';
 
 /**
@@ -98,6 +100,39 @@ export function categoryAxisReversedFor(children: ReactNode, horizontal: boolean
 
   walk(children);
   return found;
+}
+
+/**
+ * The same answer for each panel of a grid, in its row-major order.
+ *
+ * Which axis carries the categories follows the orientation, and in subplot
+ * mode that is the *panel's* — `buildPanelSubplot` resolves it as
+ * `panel.orientation ?? config.orientation`. Asking every panel with the
+ * grid's own answer reads `reversed` off the wrong axis component for any
+ * panel that overrides it: the un-reversed one answers `false`, the payload
+ * and the selectors are left as written, and the reader is walked through the
+ * categories the opposite way to the way the panel draws them (#1017). The
+ * mirror case is worse still — a reversed value axis turning a payload round
+ * that should have been left alone.
+ *
+ * A child with no panel of its own falls back to the grid's orientation, which
+ * is also what `buildPanelSubplot` does with a panel that declares none.
+ *
+ * @param children - One chart per panel, in the grid's row-major order
+ * @param panels - The panel configs, flattened into the same order
+ * @param gridOrientation - The orientation the grid declares, if any
+ * @returns One answer per child, in the same order
+ */
+export function categoryAxisReversedPerPanelFor(
+  children: ReactNode,
+  panels: readonly RechartsSubplotConfig[],
+  gridOrientation: Orientation | undefined,
+): boolean[] {
+  return Children.toArray(children).map((child, index) =>
+    categoryAxisReversedFor(
+      child,
+      (panels[index]?.orientation ?? gridOrientation) === Orientation.HORIZONTAL,
+    ));
 }
 
 /**

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -255,6 +255,24 @@ function buildLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrL
 }
 
 /**
+ * Whether a chart type's builder raises when it finds none of its fields.
+ *
+ * The four that do are the ones whose whole payload is named by their own
+ * sub-config rather than by `xKey`/`yKeys`, so a mismatch there leaves them
+ * with nothing at all rather than with a column of `NaN`.
+ *
+ * @param chartType - The declared chart type
+ * @returns Whether an empty row set has to be turned away before the builder
+ * mistakes it for a config that does not match the data
+ */
+function refusesUnreadableRows(chartType: RechartsChartType): boolean {
+  return chartType === 'gauge'
+    || chartType === 'ridgeline'
+    || chartType === 'hexbin'
+    || chartType === 'boxen';
+}
+
+/**
  * Builds layers for simple mode (single chart type, one or more yKeys).
  */
 function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
@@ -267,6 +285,25 @@ function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): 
   }
   if (!data) {
     throw new Error('RechartsAdapter: data is required (top-level or per subplot panel)');
+  }
+
+  // Four builders refuse rows they can find none of their fields in — a gauge
+  // with no measure, a ridgeline with no density, a hexbin with no centres, a
+  // boxen with no median. That diagnostic is about a config that does not
+  // match the data, and it stays. Empty data is a different thing: the
+  // ordinary React fetch pattern renders once with `[]` before the rows
+  // arrive, and a filter that matches nothing goes back to it.
+  //
+  // `MaidrRecharts` converts inside `useMemo`, i.e. during render, so throwing
+  // there unwinds the consumer's tree to its nearest error boundary — the
+  // accessibility wrapper destroying the chart it was added to make readable.
+  // Emitting no layer is the core's own spelling for not ready:
+  // `useMaidrController.createController` returns null for a subplot with none
+  // and builds the figure when the rows land. `chartType: 'bar'` has always
+  // taken empty data without complaint, which is why the crash was confined to
+  // these four and easy to ship without noticing.
+  if (data.length === 0 && refusesUnreadableRows(chartType)) {
+    return [];
   }
 
   // Four types whose payload is a grid grouped by something that is not a

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -442,6 +442,33 @@ function buildSegmentedBarLayer(
 }
 
 /**
+ * Converts data to `HistogramPoint[]`, reading the bin edges the config names.
+ *
+ * @param data - The rows as the chart was given them
+ * @param xKey - The field holding the bin's label
+ * @param yKey - The field holding the bin's count
+ * @param binConfig - The fields holding the bin's own edges
+ * @returns One point per bin
+ */
+function convertToHistogramPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  binConfig?: RechartsAdapterConfig['binConfig'],
+): HistogramPoint[] {
+  return data.map((item) => {
+    const x = item[xKey] as string | number;
+    const y = toNumber(item[yKey]);
+    const xMin = binConfig ? toNumber(item[binConfig.xMinKey]) : 0;
+    const xMax = binConfig ? toNumber(item[binConfig.xMaxKey]) : 0;
+    const yMin = binConfig?.yMinKey ? toNumber(item[binConfig.yMinKey]) : 0;
+    const yMax = binConfig?.yMaxKey ? toNumber(item[binConfig.yMaxKey]) : y;
+
+    return { x, y, xMin, xMax, yMin, yMax };
+  });
+}
+
+/**
  * Builds a histogram layer with HistogramPoint[] data.
  */
 function buildHistogramLayer(
@@ -457,16 +484,7 @@ function buildHistogramLayer(
   chartId?: string,
   panelScope?: string,
 ): MaidrLayer {
-  const histData: HistogramPoint[] = data.map((item) => {
-    const x = item[xKey] as string | number;
-    const y = toNumber(item[yKey]);
-    const xMin = binConfig ? toNumber(item[binConfig.xMinKey]) : 0;
-    const xMax = binConfig ? toNumber(item[binConfig.xMaxKey]) : 0;
-    const yMin = binConfig?.yMinKey ? toNumber(item[binConfig.yMinKey]) : 0;
-    const yMax = binConfig?.yMaxKey ? toNumber(item[binConfig.yMaxKey]) : y;
-
-    return { x, y, xMin, xMax, yMin, yMax };
-  });
+  const histData = convertToHistogramPoints(data, xKey, yKey, binConfig);
 
   const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope);
   const resolved = orientation ?? Orientation.VERTICAL;
@@ -1323,7 +1341,12 @@ function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string)
     // Only use seriesIndex when there are multiple layers of the same chart type
     const seriesIndex = (typeTotals.get(chartType) ?? 0) > 1 ? currentIndex : undefined;
 
-    const maidrType = toTraceType(chartType);
+    // A composed layer is one series, so the single-series rule applies to it
+    // exactly as it does to a simple-mode layer: a stacked/dodged/normalized/
+    // diverging bar has nothing to stack against and falls back to BAR, and a
+    // stacked area to AREA. Left as declared, `SegmentedTrace` is handed a flat
+    // `BarPoint[]` and throws on `row.map` while the figure is activating.
+    const maidrType = toLayerTraceType(chartType, false);
     const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id, panelScope);
     const layerData = convertData(chartType, data, xKey, yKey, config);
 
@@ -1372,7 +1395,7 @@ function convertData(
   xKey: string,
   yKey: string,
   config: RechartsAdapterConfig,
-): BarPoint[] | ErrorBarPoint[] | FlowPoint[] | ForestPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] | SurvivalPoint[][] | TreemapPoint[] | VolcanoPoint[] | WaterfallPoint[] {
+): BarPoint[] | ErrorBarPoint[] | FlowPoint[] | ForestPoint[] | HistogramPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] | SurvivalPoint[][] | TreemapPoint[] | VolcanoPoint[] | WaterfallPoint[] {
   switch (chartType) {
     // A dot plot and a lollipop carry a bar's data — one category, one
     // magnitude — and differ only in the mark drawn for it. So does a funnel:
@@ -1443,12 +1466,18 @@ function convertData(
     case 'hexbin':
     case 'boxen':
       throw new Error(`RechartsAdapter: chartType "${chartType}" describes a whole chart and cannot be a layer of a composed one`);
-    // Stacked/dodged/normalized/diverging/histogram handled by dedicated builders
+    // A histogram layer is a bar layer whose bins carry their own edges, and
+    // `HistogramPoint` is what `Histogram` reads them out of. Emitted as plain
+    // bar points its every bin announces an undefined range.
+    case 'histogram':
+      return convertToHistogramPoints(data, xKey, yKey, config.binConfig);
+    // One layer of a composed chart is one series, so a bar family that reads
+    // a grid has only a flat payload to read. It keeps it, and
+    // `toLayerTraceType` announces it as the plain bar it is.
     case 'stacked_bar':
     case 'dodged_bar':
     case 'normalized_bar':
     case 'diverging_bar':
-    case 'histogram':
       return convertToBarPoints(data, xKey, yKey);
   }
 }

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -442,6 +442,35 @@ function buildSegmentedBarLayer(
 }
 
 /**
+ * Where a bin sits when no `binConfig` names its edges.
+ *
+ * A numeric label places the bin, so it is read as a zero-width bin there —
+ * which is what the D3 binder does with the same pre-aggregated
+ * `[{ x, count }]` shape. A label such as `'0-10'` places nothing, and the
+ * alternative to refusing it is announcing a bin range the chart never drew:
+ * defaulting the edges to `0` made `MathUtil.spanned(0, 0)` report the whole
+ * histogram's bin range as "constant 0", and every row of the data table as
+ * Bin Min 0 / Bin Max 0.
+ *
+ * @param x - The bin's label, as the `xKey` field held it
+ * @returns The edge to use for both ends of the bin
+ * @throws When the label is not a number the bin can be placed at
+ */
+function binEdgeFor(x: string | number): number {
+  const at = Number(x);
+  if (Number.isFinite(at)) {
+    return at;
+  }
+  throw new Error(
+    `RechartsAdapter: the histogram bin labelled "${String(x)}" states no bin `
+    + `range — its label is not a number the bin could be placed at, and no `
+    + `\`binConfig\` names the fields holding its edges. Pass \`binConfig: `
+    + `{ xMinKey, xMaxKey }\`; without it every bin range the reader hears `
+    + `would be invented.`,
+  );
+}
+
+/**
  * Converts data to `HistogramPoint[]`, reading the bin edges the config names.
  *
  * @param data - The rows as the chart was given them
@@ -449,6 +478,7 @@ function buildSegmentedBarLayer(
  * @param yKey - The field holding the bin's count
  * @param binConfig - The fields holding the bin's own edges
  * @returns One point per bin
+ * @throws When no `binConfig` is given and a bin's label does not place it
  */
 function convertToHistogramPoints(
   data: Record<string, unknown>[],
@@ -459,8 +489,8 @@ function convertToHistogramPoints(
   return data.map((item) => {
     const x = item[xKey] as string | number;
     const y = toNumber(item[yKey]);
-    const xMin = binConfig ? toNumber(item[binConfig.xMinKey]) : 0;
-    const xMax = binConfig ? toNumber(item[binConfig.xMaxKey]) : 0;
+    const xMin = binConfig ? toNumber(item[binConfig.xMinKey]) : binEdgeFor(x);
+    const xMax = binConfig ? toNumber(item[binConfig.xMaxKey]) : binEdgeFor(x);
     const yMin = binConfig?.yMinKey ? toNumber(item[binConfig.yMinKey]) : 0;
     const yMax = binConfig?.yMaxKey ? toNumber(item[binConfig.yMaxKey]) : y;
 

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -1215,7 +1215,12 @@ export interface RechartsAdapterConfig {
 
   /**
    * Histogram bin range configuration.
-   * Required when `chartType` is `'histogram'`.
+   *
+   * Required when `chartType` is `'histogram'`, unless every bin's `xKey`
+   * label is itself a number — then each bin is read as a zero-width bin at
+   * its label. A label such as `'0-10'` places nothing, and a histogram
+   * carrying those without this config is refused rather than announced with
+   * a bin range nothing stated.
    */
   binConfig?: HistogramBinConfig;
 

--- a/src/adapters/recharts/useRechartsAdapter.ts
+++ b/src/adapters/recharts/useRechartsAdapter.ts
@@ -58,6 +58,13 @@ import { convertRechartsToMaidr } from './converters';
  * (`<div className="maidr-panel-<row>-<col>">`, row-major grid positions)
  * or set `panelSelector` on each panel config to your own unique selector.
  *
+ * It reads nothing out of your chart's own elements either, which
+ * `<MaidrRecharts>` does: `stepDirection`, `categoryAxisReversed` and
+ * `categoryAxisReversedPerPanel` are derived there from the `<Line>` and the
+ * `<XAxis reversed>` inside its children. Through this hook they are yours to
+ * state, and every field of the config is forwarded — a field left out of the
+ * rebuilt object below is one silently discarded from a caller's config.
+ *
  * @param config - Recharts adapter configuration
  * @returns MaidrData ready to pass to `<Maidr data={...}>`
  */
@@ -69,6 +76,9 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
     caption,
     data,
     chartType,
+    categoryAxisReversed,
+    categoryAxisReversedPerPanel,
+    stepDirection,
     xKey,
     yKeys,
     layers,
@@ -102,6 +112,9 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       caption,
       data,
       chartType,
+      categoryAxisReversed,
+      categoryAxisReversedPerPanel,
+      stepDirection,
       xKey,
       yKeys,
       layers,
@@ -126,6 +139,6 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       boxenConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, parallelConfig, ridgelineConfig, hexbinConfig, boxenConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, categoryAxisReversed, categoryAxisReversedPerPanel, stepDirection, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, parallelConfig, ridgelineConfig, hexbinConfig, boxenConfig, selectorOverride],
   );
 }

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -789,9 +789,11 @@ function ladderTraceType(
  * Decide what one worksheet is, in the fixed order of authority.
  *
  * A → an explicit `overrides.traceType`; B → the visual specification's mark
- * type; C → the heuristic ladder. An override that cannot be honoured — `heat`
+ * type; C → the heuristic ladder. A reading that cannot be honoured — `heat`
  * on a view with holes in its grid, say — degrades to the ladder's answer with
  * a warning, because a truthful smaller reading beats a confident wrong one.
+ * That applies to A and to B alike: both are claims about what the author drew,
+ * and neither is evidence that the summary data can carry it.
  *
  * @param snapshot - The worksheet snapshot.
  * @param plan - The worksheet's column plan.
@@ -824,7 +826,22 @@ function decideTraceType(
   if (markType !== undefined) {
     const decision = markTypeToTrace(markType, plan, rows, snapshot.name, warned);
     if (decision.kind === 'trace') {
-      return decision.type;
+      // Checked exactly as an override is: the mark type says what was drawn,
+      // not that the summary data can describe it. `bar`, `line`, `area` and
+      // `pie` all need a category, and a worksheet with a continuous field on
+      // an axis has none — `classifyColumn` reads that field as a second
+      // measure — so honouring the mark unchecked hands `buildData` a plan it
+      // returns `null` for and the whole worksheet is dropped from the figure.
+      // The ladder can still read it, as C1 explains.
+      if (canBuild(decision.type, plan, rows)) {
+        return decision.type;
+      }
+      warnOnce(
+        warned,
+        `worksheet "${snapshot.name}" is drawn with ${markType} marks, but a `
+        + `"${decision.type}" layer cannot be built from these columns; `
+        + `falling back to the inferred type.`,
+      );
     }
     if (decision.kind === 'skip') {
       warnOnce(

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -502,20 +502,34 @@ function traceFamily(type: TraceType): TraceFamily | null {
  * grid.
  *
  * `HeatmapData` is a rectangle: `points[r].length` must equal `x.length` for
- * every row. A view whose row count does not match the product has holes, and a
- * hole filled with a zero is a value the viz never drew.
+ * every row. A view that does not fill the product has holes, and a hole is a
+ * cell the viz never drew.
+ *
+ * The *distinct pairs* are counted rather than the rows. A row count matching
+ * the product is necessary but not sufficient: a view carrying a duplicated
+ * `(category, group)` pair and missing a different one has exactly the same row
+ * count as a complete grid, and duplicates are not exotic here — `planColumns`
+ * reads only D[0] and D[1] and warns that further dimensions are ignored, and
+ * every ignored dimension is a source of them. Counting rows let such a view
+ * through, `buildHeatData` found no source row for the missing pair and padded
+ * it, and the duplicate's own value was silently dropped.
  *
  * @param plan - The worksheet's column plan.
  * @param rows - The worksheet's rows.
  * @returns Whether a complete grid can be built.
  */
 function isCompleteGrid(plan: ColumnPlan, rows: readonly TableauRow[]): boolean {
-  if (plan.category === null || plan.group === null || rows.length === 0) {
+  const { category, group } = plan;
+  if (category === null || group === null || rows.length === 0) {
     return false;
   }
-  const columns = distinctKeys(rows, plan.category.viewIndex).length;
-  const bands = distinctKeys(rows, plan.group.viewIndex).length;
-  return rows.length === columns * bands;
+  const columns = distinctKeys(rows, category.viewIndex).length;
+  const bands = distinctKeys(rows, group.viewIndex).length;
+  const pairs = new Set(rows.map(row => cellKey(
+    toCategoryKey(row[group.viewIndex]),
+    toCategoryKey(row[category.viewIndex]),
+  )));
+  return pairs.size === columns * bands;
 }
 
 /**

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -713,6 +713,22 @@ function activeMarkType(
 }
 
 /**
+ * Whether every dimension names one value per row, i.e. is on Detail rather
+ * than describing a category.
+ *
+ * One full pass per dimension, so it is called only where its answer is used.
+ *
+ * @param plan - The worksheet's column plan.
+ * @param rows - The worksheet's rows.
+ * @returns Whether the rows are observations rather than categories.
+ */
+function everyDimensionIsDetail(plan: ColumnPlan, rows: readonly TableauRow[]): boolean {
+  return plan.dimensions.every(
+    dimension => distinctKeys(rows, dimension.viewIndex).length === rows.length,
+  );
+}
+
+/**
  * The heuristic ladder: what the columns alone say the worksheet is.
  *
  * Runs only when neither an override nor a visual specification settled it.
@@ -751,10 +767,13 @@ function ladderTraceType(
   //     reading it as numeric x against numeric y is exactly what it is. Tested
   //     the other way round it would be skipped for having no category, and a
   //     perfectly readable view would vanish from the figure.
-  const everyDimensionIsDetail = plan.dimensions.every(
-    dimension => distinctKeys(rows, dimension.viewIndex).length === rows.length,
-  );
-  if (plan.measures.length >= 2 && everyDimensionIsDetail) {
+  //
+  //     The scan is behind the measure count rather than beside it:
+  //     `distinctKeys` is a full pass per dimension, and the ordinary Tableau
+  //     shape — one measure, one or two dimensions — throws every one of those
+  //     passes away. The binder re-extracts from scratch on every filter,
+  //     parameter, data and tab change, so it is paid again each time.
+  if (plan.measures.length >= 2 && everyDimensionIsDetail(plan, rows)) {
     return TraceType.SCATTER;
   }
 

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -1079,11 +1079,13 @@ function buildScatterData(
  * Build a complete grid, for `heat`.
  *
  * `HeatmapData` is an object rather than an array and demands a rectangle:
- * `points.length === y.length` and `points[r].length === x.length`. Callers
- * check {@link isCompleteGrid} first, so a hole here is a duplicated pair
- * rather than a missing one; it is filled with `0` and given `null` criteria,
- * so the pad names no mark — the same criteria contract the segmented builder
- * uses for its own padding.
+ * `points.length === y.length` and `points[r].length === x.length`. A cell the
+ * view drew nothing at — an unmatched pair, or a NULL measure, which Tableau
+ * reports as a `null` `nativeValue` — is padded with `null` and given `null`
+ * criteria, so the pad names no mark and announces no reading. Never `0`: a
+ * zero sonifies at the bottom of the range, is reachable as an extremum, and
+ * pulls the scale every other cell is measured against (#1191) — the same
+ * reason the segmented builder pads with `NaN`.
  *
  * @param category - The category dimension, laid along x.
  * @param group - The series dimension, laid along y.
@@ -1117,18 +1119,18 @@ function buildHeatData(
     }
   }
 
-  const points: number[][] = [];
+  const points: (number | null)[][] = [];
   const cells: (readonly TableauSelectionCriteria[] | null)[][] = [];
 
   for (const bandKey of y) {
-    const magnitudes: number[] = [];
+    const magnitudes: (number | null)[] = [];
     const bandCells: (readonly TableauSelectionCriteria[] | null)[] = [];
     for (const columnKey of x) {
       const source = sourceRows.get(cellKey(bandKey, columnKey));
       const magnitude = source === undefined
         ? null
         : toFiniteNumber(source[value.viewIndex]);
-      magnitudes.push(magnitude ?? 0);
+      magnitudes.push(magnitude);
       bandCells.push(
         source === undefined || magnitude === null
           ? null

--- a/test/adapters/recharts/composedLayerTypes.test.ts
+++ b/test/adapters/recharts/composedLayerTypes.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { RechartsAdapterConfig, RechartsChartType } from '@adapters/recharts/types';
+import type { BarPoint, HistogramPoint, MaidrLayer } from '@type/grammar';
+import { convertRechartsToMaidr } from '@adapters/recharts/converters';
+import { describe, expect, it } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A composed layer is one series of the chart around it, so its payload is a
+ * flat `BarPoint[]` whatever bar family the author named. Declaring a trace
+ * type that reads a grid over that payload does not fail in conversion — it
+ * fails in `TraceFactory.create`, inside the focus-in callback, where nothing
+ * catches it and the figure never activates for a keyboard user.
+ */
+
+const quarters = [
+  { quarter: 'Q1', north: 10, south: 4 },
+  { quarter: 'Q2', north: 20, south: 6 },
+];
+
+/** The composed chart's first layer, for one declared chart type. */
+function firstLayer(chartType: RechartsChartType): MaidrLayer {
+  const config: RechartsAdapterConfig = {
+    id: 'composed',
+    data: quarters,
+    xKey: 'quarter',
+    layers: [
+      { yKey: 'north', chartType, name: 'North' },
+      { yKey: 'south', chartType: 'line', name: 'South' },
+    ],
+  };
+
+  return convertRechartsToMaidr(config).subplots[0][0].layers[0];
+}
+
+describe('a composed layer naming a bar family that reads a grid', () => {
+  const SEGMENTED: RechartsChartType[] = [
+    'stacked_bar',
+    'dodged_bar',
+    'normalized_bar',
+    'diverging_bar',
+  ];
+
+  it.each(SEGMENTED)('reads a single %s series as a plain bar', (chartType) => {
+    const layer = firstLayer(chartType);
+
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'Q1', y: 10 },
+      { x: 'Q2', y: 20 },
+    ]);
+  });
+
+  it.each(SEGMENTED)('builds a trace the core can activate from a %s layer', (chartType) => {
+    const layer = firstLayer(chartType);
+
+    const state = TraceFactory.create(layer).getStateAt(0, 1);
+
+    expect(state.empty).toBe(false);
+    if (state.empty) {
+      return;
+    }
+    expect(state.text.cross).toEqual({ label: 'Y', value: 20 });
+  });
+});
+
+describe('a composed histogram layer', () => {
+  it('carries the bin edges its trace type promises', () => {
+    const config: RechartsAdapterConfig = {
+      id: 'composed-hist',
+      data: [
+        { bin: '0-10', count: 5, from: 0, to: 10 },
+        { bin: '10-20', count: 9, from: 10, to: 20 },
+      ],
+      xKey: 'bin',
+      layers: [
+        { yKey: 'count', chartType: 'histogram', name: 'Counts' },
+        { yKey: 'count', chartType: 'line', name: 'Trend' },
+      ],
+      binConfig: { xMinKey: 'from', xMaxKey: 'to' },
+    };
+
+    const layer = convertRechartsToMaidr(config).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.HISTOGRAM);
+    expect(layer.data as HistogramPoint[]).toEqual([
+      { x: '0-10', y: 5, xMin: 0, xMax: 10, yMin: 0, yMax: 5 },
+      { x: '10-20', y: 9, xMin: 10, xMax: 20, yMin: 0, yMax: 9 },
+    ]);
+  });
+
+  it('announces the bin it is on rather than an undefined range', () => {
+    const config: RechartsAdapterConfig = {
+      id: 'composed-hist',
+      data: [
+        { bin: '0-10', count: 5, from: 0, to: 10 },
+        { bin: '10-20', count: 9, from: 10, to: 20 },
+      ],
+      xKey: 'bin',
+      layers: [{ yKey: 'count', chartType: 'histogram', name: 'Counts' }],
+      binConfig: { xMinKey: 'from', xMaxKey: 'to' },
+    };
+    const layer = convertRechartsToMaidr(config).subplots[0][0].layers[0];
+
+    const state = TraceFactory.create(layer).getStateAt(0, 1);
+
+    expect(state.empty).toBe(false);
+    if (state.empty) {
+      return;
+    }
+    expect(state.text.range).toEqual({ min: 10, max: 20 });
+  });
+});

--- a/test/adapters/recharts/conversionMemo.test.tsx
+++ b/test/adapters/recharts/conversionMemo.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ *
+ * `children` is a JSX element freshly created by the parent on every render, so
+ * its identity is never stable. With it in the `useMemo` dependency list the
+ * conversion never hits: `convertRechartsToMaidr` walks every row once per
+ * `yKey` — plus one selector string per bar on a reversed axis — on every
+ * render of the parent, including renders caused by state that has nothing to
+ * do with the chart.
+ *
+ * It also hands `<Maidr>` a new `maidrData` identity each time, which fires
+ * `useMaidrController`'s `useEffect([data])` and calls
+ * `liveDataManager.updateStoredData` on every one of them.
+ *
+ * Only two scalar facts are read out of `children`, and those are what the
+ * dependency should be.
+ */
+
+import type { Maidr as MaidrData } from '@type/grammar';
+import type { JSX, ReactNode } from 'react';
+import { MaidrRecharts } from '@adapters/recharts/MaidrRecharts';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, render } from '@testing-library/react';
+import { createElement, useState } from 'react';
+
+const seen: MaidrData[] = [];
+
+jest.mock('../../../src/maidr-component', () => ({
+  Maidr: ({ data, children }: { data: MaidrData; children: ReactNode }): ReactNode => {
+    seen.push(data);
+    return children;
+  },
+}));
+
+/** A stand-in for a Recharts component: only `displayName` is read. */
+function stub(displayName: string): { (): null; displayName: string } {
+  const component = (): null => null;
+  component.displayName = displayName;
+  return component;
+}
+
+const XAxis = stub('XAxis');
+const BarChart = stub('BarChart');
+
+const DATA = [
+  { quarter: 'Q1', revenue: 100 },
+  { quarter: 'Q2', revenue: 200 },
+];
+// Hoisted because array props are compared by reference, which the hook's own
+// documentation says: a fresh `['revenue']` per render would defeat the memo
+// on its own and prove nothing about `children`.
+const Y_KEYS = ['revenue'];
+
+/** Fires its own state update, exactly as a hover or a resize would. */
+let bump: () => void = () => {};
+
+/**
+ * A parent whose unrelated state change rebuilds the chart subtree.
+ *
+ * @param props - What the chart declares
+ * @param props.reversed - Whether the category axis is drawn from its far end
+ * @returns The wrapped chart
+ */
+function Host({ reversed }: { reversed: boolean }): JSX.Element {
+  const [, setTick] = useState(0);
+  bump = () => setTick(tick => tick + 1);
+
+  return createElement(
+    MaidrRecharts,
+    {
+      id: 'chart',
+      data: DATA,
+      chartType: 'bar' as const,
+      xKey: 'quarter',
+      yKeys: Y_KEYS,
+      // A fresh element every render, which is what JSX in a parent produces.
+      children: createElement(BarChart, null, createElement(XAxis, { reversed })),
+    },
+  );
+}
+
+describe('the recharts conversion memo', () => {
+  beforeEach(() => {
+    seen.length = 0;
+  });
+
+  it('holds when only the chart subtree is rebuilt', () => {
+    const { rerender } = render(createElement(Host, { reversed: false }));
+
+    rerender(createElement(Host, { reversed: false }));
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
+  });
+
+  it('holds across a parent state change the chart has nothing to do with', () => {
+    render(createElement(Host, { reversed: false }));
+
+    act(() => bump());
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen[seen.length - 1]).toBe(seen[0]);
+  });
+
+  it('still picks up a chart that flips its axis round', () => {
+    const { rerender } = render(createElement(Host, { reversed: false }));
+
+    rerender(createElement(Host, { reversed: true }));
+
+    const before = seen[0].subplots[0][0].layers[0].data;
+    const after = seen[seen.length - 1].subplots[0][0].layers[0].data;
+    expect(before).toEqual([{ x: 'Q1', y: 100 }, { x: 'Q2', y: 200 }]);
+    expect(after).toEqual([{ x: 'Q2', y: 200 }, { x: 'Q1', y: 100 }]);
+  });
+});

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -798,19 +798,39 @@ describe('convertRechartsToMaidr', () => {
       expect(data[1]).toEqual({ x: '10-20', y: 8, xMin: 10, xMax: 20, yMin: 0, yMax: 8 });
     });
 
-    it('defaults bin ranges to 0 when binConfig omitted', () => {
+    it('reads a numeric bin label as a zero-width bin when binConfig is omitted', () => {
+      // No edges were declared and none can be derived, but the bin does sit
+      // at its own label, so that is what is announced. Defaulting to 0 made
+      // `MathUtil.spanned` report the whole histogram's bin range as
+      // "constant 0" — a specific, confident and wrong reading.
       const config: RechartsAdapterConfig = {
         id: 'hist',
-        data: [{ bin: 'A', count: 5 }],
+        data: [{ bin: 5, count: 5 }, { bin: 15, count: 9 }],
         chartType: 'histogram',
         xKey: 'bin',
         yKeys: ['count'],
       };
 
       const result = convertRechartsToMaidr(config);
+
       const data = result.subplots[0][0].layers[0].data as HistogramPoint[];
-      expect(data[0].xMin).toBe(0);
-      expect(data[0].xMax).toBe(0);
+      expect(data[0]).toEqual({ x: 5, y: 5, xMin: 5, xMax: 5, yMin: 0, yMax: 5 });
+      expect(data[1]).toEqual({ x: 15, y: 9, xMin: 15, xMax: 15, yMin: 0, yMax: 9 });
+    });
+
+    it('refuses a labelled histogram whose bin edges nothing states', () => {
+      // `binConfig` is documented as required for a histogram, and every other
+      // required sub-config throws. A bin labelled "0-10" places nothing, so
+      // the alternative is announcing a bin range the chart never drew.
+      const config: RechartsAdapterConfig = {
+        id: 'hist',
+        data: [{ bin: '0-10', count: 5 }],
+        chartType: 'histogram',
+        xKey: 'bin',
+        yKeys: ['count'],
+      };
+
+      expect(() => convertRechartsToMaidr(config)).toThrow('binConfig');
     });
   });
 
@@ -2318,10 +2338,11 @@ describe('convertRechartsToMaidr', () => {
     it('uses selectorOverride for histogram', () => {
       const config: RechartsAdapterConfig = {
         id: 'override-hist',
-        data: [{ bin: 'A', count: 5 }],
+        data: [{ bin: 'A', count: 5, from: 0, to: 10 }],
         chartType: 'histogram',
         xKey: 'bin',
         yKeys: ['count'],
+        binConfig: { xMinKey: 'from', xMaxKey: 'to' },
         selectorOverride: '.custom-hist',
       };
 

--- a/test/adapters/recharts/emptyData.test.ts
+++ b/test/adapters/recharts/emptyData.test.ts
@@ -1,0 +1,99 @@
+import type { RechartsAdapterConfig, RechartsChartType } from '@adapters/recharts/types';
+import { convertRechartsToMaidr } from '@adapters/recharts/converters';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * `MaidrRecharts` converts inside `useMemo`, i.e. during render, so a builder
+ * that throws on data which is merely empty unwinds the consumer's tree to its
+ * nearest error boundary — a blank page for an app without one. The ordinary
+ * React fetch pattern renders once with `[]` before the rows arrive, and a
+ * filter that matches nothing goes back to it, so the accessibility wrapper
+ * would destroy the chart it was added to make readable.
+ *
+ * `chartType: 'bar'` with no rows already survives this. These four did not.
+ */
+
+/** One config per chart type whose builder refuses data it finds no fields in. */
+const CONFIGS: Record<string, RechartsAdapterConfig> = {
+  gauge: {
+    id: 'g',
+    data: [],
+    chartType: 'gauge',
+    xKey: 'k',
+    yKeys: ['v'],
+    gaugeConfig: { min: 0, max: 100 },
+  },
+  ridgeline: {
+    id: 'r',
+    data: [],
+    chartType: 'ridgeline',
+    xKey: 'temp',
+    ridgelineConfig: { groupKey: 'month', valueKey: 'temp', densityKey: 'density' },
+  },
+  hexbin: {
+    id: 'h',
+    data: [],
+    chartType: 'hexbin',
+    xKey: 'cx',
+    yKeys: ['cy'],
+    hexbinConfig: { countKey: 'count' },
+  },
+  boxen: {
+    id: 'b',
+    data: [],
+    chartType: 'boxen',
+    xKey: 'group',
+    boxenConfig: { medianKey: 'median', levelsKey: 'levels' },
+  },
+};
+
+describe('a recharts chart whose rows have not arrived yet', () => {
+  it.each(Object.keys(CONFIGS))('does not throw out of a %s conversion', (chartType) => {
+    expect(() => convertRechartsToMaidr(CONFIGS[chartType])).not.toThrow();
+  });
+
+  it.each(Object.keys(CONFIGS))('emits no %s layer, which is the core\'s "not ready"', (chartType) => {
+    const maidr = convertRechartsToMaidr(CONFIGS[chartType]);
+
+    expect(maidr.subplots[0][0].layers).toEqual([]);
+  });
+
+  it('still refuses rows whose declared fields it cannot find', () => {
+    // The diagnostic is about a config that does not match the data, and it
+    // stays: rows arrived, and none of them carried a centre and a count.
+    const config: RechartsAdapterConfig = {
+      ...CONFIGS.hexbin,
+      data: [{ somethingElse: 1 }],
+    };
+
+    expect(() => convertRechartsToMaidr(config)).toThrow('RechartsAdapter');
+  });
+
+  it('builds the layer once the rows land', () => {
+    const config: RechartsAdapterConfig = {
+      ...CONFIGS.gauge,
+      data: [{ k: 'Load', v: 42 }],
+    };
+
+    const layers = convertRechartsToMaidr(config).subplots[0][0].layers;
+
+    expect(layers).toHaveLength(1);
+  });
+});
+
+describe('a chart type that never refused empty rows', () => {
+  it('keeps emitting its layer, so nothing else changes shape', () => {
+    const config: RechartsAdapterConfig = {
+      id: 'bars',
+      data: [],
+      chartType: 'bar' as RechartsChartType,
+      xKey: 'name',
+      yKeys: ['value'],
+    };
+
+    const layers = convertRechartsToMaidr(config).subplots[0][0].layers;
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].data).toEqual([]);
+  });
+});

--- a/test/adapters/recharts/panelOrientation.test.tsx
+++ b/test/adapters/recharts/panelOrientation.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Which axis carries the categories follows the *panel's* orientation, and a
+ * panel may declare its own: `buildPanelSubplot` resolves it as
+ * `panel.orientation ?? config.orientation`. `MaidrRecharts` was passing the
+ * grid-wide orientation for every panel, so a panel that overrode it had
+ * `reversed` read off the wrong axis component — the un-reversed one answers
+ * `false`, and the reader is walked through the categories the opposite way to
+ * the way the chart draws them. That is the #1017 regression the per-panel
+ * plumbing was added to fix, still present for any panel that overrides
+ * orientation.
+ *
+ * `<Maidr>` is mocked away so the schema the component builds can be read
+ * without mounting the whole UI tree (and its ESM-only markdown stack).
+ */
+
+import type { Maidr as MaidrData } from '@type/grammar';
+import type { JSX, ReactNode } from 'react';
+import { MaidrRecharts } from '@adapters/recharts/MaidrRecharts';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render } from '@testing-library/react';
+import { Orientation } from '@type/grammar';
+import { createElement } from 'react';
+
+let captured: MaidrData | null = null;
+
+jest.mock('../../../src/maidr-component', () => ({
+  Maidr: ({ data, children }: { data: MaidrData; children: ReactNode }): ReactNode => {
+    captured = data;
+    return children;
+  },
+}));
+
+/** A stand-in for a Recharts component: only `displayName` is read. */
+function stub(displayName: string): { (): null; displayName: string } {
+  const component = (): null => null;
+  component.displayName = displayName;
+  return component;
+}
+
+const XAxis = stub('XAxis');
+const YAxis = stub('YAxis');
+const BarChart = stub('BarChart');
+
+const LISTED = ['Q1', 'Q2', 'Q3', 'Q4'];
+const DRAWN = [...LISTED].reverse();
+const DATA = LISTED.map((quarter, i) => ({ quarter, revenue: (i + 1) * 100 }));
+
+/**
+ * A panel chart with one axis reversed and the other not.
+ *
+ * @param reversedAxis - Which axis carries `reversed`
+ * @returns The chart subtree for that panel
+ */
+function panelChart(reversedAxis: 'XAxis' | 'YAxis'): JSX.Element {
+  return createElement(
+    BarChart,
+    null,
+    createElement(XAxis, { reversed: reversedAxis === 'XAxis' }),
+    createElement(YAxis, { reversed: reversedAxis === 'YAxis' }),
+  );
+}
+
+/**
+ * The categories of the grid's only panel, in the order it announces them.
+ *
+ * @param panelOrientation - The orientation the panel declares, if any
+ * @param gridOrientation - The orientation the grid declares, if any
+ * @param reversedAxis - Which axis the panel's chart reverses
+ * @returns The categories, in announced order
+ */
+function categoriesOf(
+  panelOrientation: Orientation | undefined,
+  gridOrientation: Orientation | undefined,
+  reversedAxis: 'XAxis' | 'YAxis',
+): (string | number)[] {
+  captured = null;
+  render(
+    createElement(
+      MaidrRecharts,
+      {
+        id: 'grid',
+        xKey: 'quarter',
+        orientation: gridOrientation,
+        subplots: [[{
+          chartType: 'bar' as const,
+          yKeys: ['revenue'],
+          data: DATA,
+          ...(panelOrientation === undefined ? {} : { orientation: panelOrientation }),
+        }]],
+        children: panelChart(reversedAxis),
+      },
+    ),
+  );
+
+  const layer = (captured as unknown as MaidrData).subplots[0][0].layers[0];
+  const horizontal = layer.orientation === Orientation.HORIZONTAL;
+  return (layer.data as { x: string | number; y: string | number }[])
+    .map(point => (horizontal ? point.y : point.x));
+}
+
+describe('a subplot panel that declares its own orientation', () => {
+  beforeEach(() => {
+    captured = null;
+  });
+
+  it('reads the reversed axis the panel puts its categories on', () => {
+    // The grid says nothing, the panel says horizontal, so the categories are
+    // on the `<YAxis>` — and that is the one carrying `reversed`.
+    expect(categoriesOf(Orientation.HORIZONTAL, undefined, 'YAxis')).toEqual(DRAWN);
+  });
+
+  it('leaves the value axis alone, whichever way the panel is drawn', () => {
+    // The mirror case: the grid is horizontal, the panel overrides to
+    // vertical, so a reversed `<YAxis>` is the value axis and moves no
+    // category.
+    expect(categoriesOf(Orientation.VERTICAL, Orientation.HORIZONTAL, 'YAxis'))
+      .toEqual(LISTED);
+  });
+
+  it('still reads the grid orientation for a panel that declares none', () => {
+    expect(categoriesOf(undefined, Orientation.HORIZONTAL, 'YAxis')).toEqual(DRAWN);
+    expect(categoriesOf(undefined, undefined, 'XAxis')).toEqual(DRAWN);
+  });
+});

--- a/test/adapters/recharts/useRechartsAdapter.test.tsx
+++ b/test/adapters/recharts/useRechartsAdapter.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ *
+ * `useRechartsAdapter` destructures its config field by field and rebuilds a
+ * fresh object for the converter, so a field missing from that list is
+ * discarded without a warning — the same defect `buildPanelSubplot` was fixed
+ * for once already (#1017). The two documented entry points then disagree:
+ * `<MaidrRecharts stepDirection="hv">` announces the riser convention and the
+ * hook does not.
+ */
+
+import type { RechartsAdapterConfig } from '@adapters/recharts/types';
+import type { MaidrLayer } from '@type/grammar';
+import { useRechartsAdapter } from '@adapters/recharts/useRechartsAdapter';
+import { describe, expect, it } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { Orientation, TraceType } from '@type/grammar';
+
+const SAMPLES = [
+  { t: 1, v: 10 },
+  { t: 2, v: 20 },
+];
+
+/** The hook's first layer, for one config. */
+function layerFor(config: RechartsAdapterConfig): MaidrLayer {
+  const { result } = renderHook(() => useRechartsAdapter(config));
+  return result.current.subplots[0][0].layers[0];
+}
+
+describe('useRechartsAdapter', () => {
+  it('forwards the riser convention a step chart declared', () => {
+    // Without it `StepTrace` announces no convention, so the reader is never
+    // told whether the value they hear covers the interval before or after
+    // the time — the regression #1059 was filed for.
+    const layer = layerFor({
+      id: 's',
+      data: SAMPLES,
+      chartType: 'step',
+      xKey: 't',
+      yKeys: ['v'],
+      stepDirection: 'hv',
+    });
+
+    expect(layer.type).toBe(TraceType.STEP);
+    expect(layer.stepDirection).toBe('hv');
+  });
+
+  it('forwards a reversed category axis, so the walk runs the way the chart draws', () => {
+    const layer = layerFor({
+      id: 'r',
+      data: [{ q: 'Q1', v: 10 }, { q: 'Q2', v: 20 }],
+      chartType: 'bar',
+      xKey: 'q',
+      yKeys: ['v'],
+      categoryAxisReversed: true,
+    });
+
+    expect(layer.data).toEqual([{ x: 'Q2', y: 20 }, { x: 'Q1', y: 10 }]);
+  });
+
+  it('forwards a per-panel reversed axis in subplot mode', () => {
+    const { result } = renderHook(() => useRechartsAdapter({
+      id: 'g',
+      xKey: 'q',
+      subplots: [[
+        { chartType: 'bar', xKey: 'q', yKeys: ['v'], data: [{ q: 'Q1', v: 10 }, { q: 'Q2', v: 20 }] },
+      ]],
+      categoryAxisReversedPerPanel: [true],
+    } as RechartsAdapterConfig));
+
+    const layer = result.current.subplots[0][0].layers[0];
+
+    expect(layer.data).toEqual([{ x: 'Q2', y: 20 }, { x: 'Q1', y: 10 }]);
+  });
+
+  it('keeps forwarding the fields it already did', () => {
+    const layer = layerFor({
+      id: 'b',
+      data: [{ band: '0-9', people: 5 }],
+      chartType: 'bar',
+      xKey: 'band',
+      yKeys: ['people'],
+      xLabel: 'Band',
+      yLabel: 'People',
+      orientation: Orientation.HORIZONTAL,
+    });
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.axes).toEqual({ x: { label: 'People' }, y: { label: 'Band' } });
+  });
+});

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -541,6 +541,30 @@ describe('tableau extractor', () => {
       expect(data.points.every(row => row.length === data.x.length)).toBe(true);
     });
 
+    it('leaves a cell Tableau drew no value at as a gap rather than a zero', () => {
+      // A NULL measure arrives as a `null` nativeValue over a grid that is
+      // otherwise complete, so `isCompleteGrid` does not stand in the way. A
+      // `0` there sonifies at the bottom of the range, is reachable as the
+      // row minimum, and pulls the scale every other cell is announced
+      // against; `null` is the gap spelling `HeatmapData` demands (#1191).
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', null],
+            ['Chairs', 'West', 3],
+            ['Tables', 'West', 4],
+          ],
+          spec: fakeVisualSpec(['heatmap']),
+        }),
+      ]);
+
+      const data = layerOf(extraction).data as HeatmapData;
+
+      expect(data.points).toEqual([[1, null], [3, 4]]);
+    });
+
     it('falls back to grouped bars, with a warning, when the grid has holes', () => {
       const extraction = extractTableau([
         fakeSnapshot({

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -214,6 +214,28 @@ describe('tableau extractor', () => {
       );
     });
 
+    it('keeps a continuous-axis worksheet the mark type cannot describe', () => {
+      // Same worksheet as above, now on a host that reports a visual
+      // specification — the normal case on any current Embedding library. The
+      // mark type is authority B, but `line` needs a category and this
+      // worksheet has none, so trusting it drops the whole panel from the
+      // figure. The ladder's own reading is still available and still right.
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Profit by Discount',
+          columns: [fakeColumn('Discount', 'float', 0), fakeColumn('SUM(Profit)', 'float', 1)],
+          rows: [[0.1, 5], [0.2, 9], [0.3, 2]],
+          spec: fakeVisualSpec(['line']),
+        }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(1);
+      expect(layerOf(extraction).type).toBe(TraceType.SCATTER);
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('produced no sonifiable data'),
+      );
+    });
+
     it('gives every point of a grouped line a z, and does not pad the shorter series', () => {
       const january = fakeValue(new Date('2021-01-01T00:00:00Z'), 'January 2021');
       const february = fakeValue(new Date('2021-02-01T00:00:00Z'), 'February 2021');

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -605,6 +605,29 @@ describe('tableau extractor', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('complete grid'));
     });
 
+    it('falls back to grouped bars when a duplicated pair hides a missing one', () => {
+      // Four rows over two categories and two regions, so the row count alone
+      // matches the product of the two — but `(Chairs, East)` appears twice and
+      // `(Tables, West)` not at all. Reading it as a grid draws a cell the view
+      // never did and discards the duplicate's value.
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Highlight Table',
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Chairs', 'East', 9],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+          ],
+          spec: fakeVisualSpec(['heatmap']),
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.DODGED);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('complete grid'));
+    });
+
     it('reads circle marks as a point cloud only when there are two measures', () => {
       const asPoints = extractTableau([
         fakeSnapshot({

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -1,6 +1,7 @@
 import type { TableauExtraction } from '@adapters/tableau/extractor';
 import type {
   TableauColumn,
+  TableauDataValue,
   TableauMarkType,
   WorksheetSnapshot,
 } from '@adapters/tableau/types';
@@ -186,6 +187,33 @@ describe('tableau extractor', () => {
       ]);
 
       expect(layerOf(extraction).type).toBe(TraceType.LINE);
+    });
+
+    it('does not scan the dimensions for a rung that cannot fire', () => {
+      // `everyDimensionIsDetail` is a full pass per dimension and feeds only
+      // the point-cloud rung, which needs two measures. One measure and one
+      // dimension is the ordinary Tableau shape, and the binder re-extracts
+      // from scratch on every filter, parameter, data and tab change.
+      let reads = 0;
+      const counted = (text: string): TableauDataValue => ({
+        value: text,
+        nativeValue: text,
+        get formattedValue(): string {
+          reads++;
+          return text;
+        },
+      });
+
+      extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [[counted('Chairs'), 3], [counted('Tables'), 1]],
+        }),
+      ]);
+
+      // Twice per row, which is what building the layer costs: once for the
+      // bar's announced label, once for the criteria that address its mark.
+      expect(reads).toBe(4);
     });
 
     it('reads a continuous axis as a point cloud rather than dropping the worksheet', () => {


### PR DESCRIPTION
# Pull Request

## Description

Ten defects across the Recharts and Tableau adapters, found in a codebase audit. Each was reproduced with a test that failed first.

The theme running through most of them is a reading the chart never drew. A Tableau heat map emitted `0` for a cell the view left empty, which is the exact spelling `HeatmapData` forbids. A Recharts histogram with no bin configuration announced a fabricated bin range of "constant 0". A composed chart emitted segmented and histogram trace types carrying flat bar data, so a single-series stacked area announced a running total equal to its own value and a 100% share at every point.

Two others lose whole worksheets or crash: Tableau trusted its own mark type without checking the layer could be built, and the Recharts adapter threw inside React render for empty data.

## Related Issues

None.

## Changes Made

**Tableau**

- A cell the view drew nothing at carries `null`. `buildHeatData` widens to `(number | null)[][]`, which is what `HeatmapData` already declared.
- A mark type whose reading cannot be built degrades to the ladder with a warning instead of being honoured, so worksheets that were dropped entirely now appear.
- `isCompleteGrid` counts pairs, not just rows, so a view with duplicates no longer passes as a rectangle.
- `ladderTraceType` stops scanning every dimension once the point-cloud rung cannot fire.

**Recharts**

- Composed mode resolves its layer type through the existing helper.
- A histogram with no bin configuration refuses rather than inventing a range.
- Empty data emits zero layers instead of throwing inside render.
- `stepDirection` and the reversed-axis flags are no longer dropped.
- Subplot mode reads each panel's reversed axis rather than the grid-wide orientation.
- The conversion no longer re-runs on every parent render.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Two existing tests were updated**, both in the Recharts converter suite and both explained in the commit that changes them. One pinned the fabricated bin range this branch removes; it is replaced by a zero-width-bin case and a refusal case. The other is about a selector and its fixture now states its bins.

**A behaviour change to weigh:** a Recharts histogram with no bin configuration and non-numeric labels now throws, following the D3 binder's precedent for the identical data shape. Numeric labels become zero-width bins. That turns a silent bad reading into a hard failure, which is right for a reader but is the change most likely to surface elsewhere.

**Four findings were investigated and deliberately not fixed.** Two would need a threshold chosen on the maintainers' behalf, and I would rather name that than pick one: rectangularising a segmented Tableau view really can build 90,000 points, but every principled guard I could design either refuses a legitimate grouped bar or contradicts the existing fallback that `DODGED` exists to serve, leaving only a fill-ratio or cell cap. The summary-data read queue likewise needs two design decisions, a read deadline and whether the queue stays module-scoped, and the second is the half that stops one frozen visualisation taking an independent one down with it.

**One finding is the cause of this session's build-machine trouble and is worth surfacing on its own.** `jest.config.ts` sets `collectCoverage: true` unconditionally, and nothing consumes the result. Collecting coverage over the whole tree needs roughly 10 GB across the three workers, which does not fit on a 16 GB machine running anything else, so `npm test` stalls partway and never finishes. Every branch in this sweep was validated with `--coverage=false` for that reason. Turning it off would change what `npm test` means for every contributor and CI, and `.claude/rules/testing.md` documents the current behaviour at some length, so it is a maintainer decision rather than a contained fix. Flagging it here rather than doing it.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (505 suites, 6754 tests) and the esm project under `--experimental-vm-modules` (12 suites, 172 tests), both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_