### PR TITLE
perf(model): read a chart's derived geometry before drawing any of it

### DIFF
--- a/.claude/rules/model.md
+++ b/.claude/rules/model.md
@@ -101,7 +101,7 @@ every one of them at once.
 
 **Every code path that creates a highlight element must mark it.** The `Svg`
 helpers (`selectAllElements` / `selectElement` with clone,
-`createEmptyElement`, `createCircleElement`, `createLineElement`,
-`createHighlightElement`) already do. If you clone or synthesize an element by
+`createEmptyElement`, `createCircleElements`, `buildLineElements`,
+`buildWhiskerElements`, `createHighlightElement`) already do. If you clone or synthesize an element by
 hand, wrap it in `Svg.markOwned(...)`. Elements selected with
 `shouldClone = false` are live chart geometry — never mark or remove them.

--- a/.github/instructions/model.instructions.md
+++ b/.github/instructions/model.instructions.md
@@ -103,7 +103,7 @@ every one of them at once.
 
 **Every code path that creates a highlight element must mark it.** The `Svg`
 helpers (`selectAllElements` / `selectElement` with clone,
-`createEmptyElement`, `createCircleElement`, `createLineElement`,
-`createHighlightElement`) already do. If you clone or synthesize an element by
+`createEmptyElement`, `createCircleElements`, `buildLineElements`,
+`buildWhiskerElements`, `createHighlightElement`) already do. If you clone or synthesize an element by
 hand, wrap it in `Svg.markOwned(...)`. Elements selected with
 `shouldClone = false` are live chart geometry — never mark or remove them.

--- a/docs/VIOLIN_PLOT_SPEC.md
+++ b/docs/VIOLIN_PLOT_SPEC.md
@@ -393,7 +393,7 @@ The IQ box (`iq`) is a `<rect>` SVG element spanning Q1 to Q3. The frontend extr
 - **Vertical orientation**: Q1 = bottom edge, Q3 = top edge
 - **Horizontal orientation**: Q1 = left edge, Q3 = right edge
 
-The frontend asks `Svg.createLineElements` for the `'bottom'` and `'top'` edges of every box's `iq` element in one batch, and creates the line elements from that.
+The frontend asks `Svg.buildLineElements` for the `'bottom'` and `'top'` edges of every box's `iq` element in one batch, and creates the line elements from that.
 
 **Selector Array Requirements:**
 - `lowerOutliers` and `upperOutliers` can be empty arrays `[]` when no outliers exist.

--- a/docs/VIOLIN_PLOT_SPEC.md
+++ b/docs/VIOLIN_PLOT_SPEC.md
@@ -393,7 +393,7 @@ The IQ box (`iq`) is a `<rect>` SVG element spanning Q1 to Q3. The frontend extr
 - **Vertical orientation**: Q1 = bottom edge, Q3 = top edge
 - **Horizontal orientation**: Q1 = left edge, Q3 = right edge
 
-The frontend calls `Svg.createLineElement(iqElement, 'bottom')` and `Svg.createLineElement(iqElement, 'top')` to create line elements at the edges.
+The frontend asks `Svg.createLineElements` for the `'bottom'` and `'top'` edges of every box's `iq` element in one batch, and creates the line elements from that.
 
 **Selector Array Requirements:**
 - `lowerOutliers` and `upperOutliers` can be empty arrays `[]` when no outliers exist.

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -736,7 +736,7 @@ const BOX_ATTR = 'data-maidr-anychart-box';
  * visual part of a box a given element represents. Values match the
  * {@link BoxSelector} field names that MAIDR's `BoxTrace` consumes:
  *   - `'iq'`  — filled IQR body (Q1-Q3 range); Q1 and Q3 are derived from
- *               its top/bottom edges via `Svg.createLineElements`.
+ *               its top/bottom edges via `Svg.buildLineElements`.
  *   - `'q2'`  — median stroke (horizontal line inside the IQR).
  *   - `'min'` — lower whisker (vertical stroke below the IQR).
  *   - `'max'` — upper whisker (vertical stroke above the IQR).
@@ -1969,7 +1969,7 @@ function findWhiskerElements(
  *   2. For each box `b` (`0…points.length-1`):
  *      a. Stamp the IQR element with `BOX_ATTR="s-b"` + `BOX_PART_ATTR="iq"`.
  *         Q1 and Q3 are NOT stamped — MAIDR derives them from the IQ
- *         element's top/bottom edges via `Svg.createLineElements`.
+ *         element's top/bottom edges via `Svg.buildLineElements`.
  *      b. Find the median stroke (horizontal stroke-only shape whose
  *         center sits inside the IQ bbox) and stamp `"q2"`.
  *      c. Find the whisker pair. If AnyChart renders them as one path
@@ -4792,7 +4792,7 @@ function buildBoxLayer(
   // `selectors.length === points.length`, so we always emit exactly one
   // entry per box. `q1` and `q3` are intentionally omitted — MAIDR derives
   // them from the `iq` element's top/bottom edges via
-  // `Svg.createLineElements`. Outlier arrays are empty
+  // `Svg.buildLineElements`. Outlier arrays are empty
   // because AnyChart's iterator API does not expose outliers.
   const scope = panelScope(panel);
   const stamp = panelStampPrefix(panel);

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -736,7 +736,7 @@ const BOX_ATTR = 'data-maidr-anychart-box';
  * visual part of a box a given element represents. Values match the
  * {@link BoxSelector} field names that MAIDR's `BoxTrace` consumes:
  *   - `'iq'`  — filled IQR body (Q1-Q3 range); Q1 and Q3 are derived from
- *               its top/bottom edges via `Svg.createLineElement`.
+ *               its top/bottom edges via `Svg.createLineElements`.
  *   - `'q2'`  — median stroke (horizontal line inside the IQR).
  *   - `'min'` — lower whisker (vertical stroke below the IQR).
  *   - `'max'` — upper whisker (vertical stroke above the IQR).
@@ -1969,7 +1969,7 @@ function findWhiskerElements(
  *   2. For each box `b` (`0…points.length-1`):
  *      a. Stamp the IQR element with `BOX_ATTR="s-b"` + `BOX_PART_ATTR="iq"`.
  *         Q1 and Q3 are NOT stamped — MAIDR derives them from the IQ
- *         element's top/bottom edges via `Svg.createLineElement`.
+ *         element's top/bottom edges via `Svg.createLineElements`.
  *      b. Find the median stroke (horizontal stroke-only shape whose
  *         center sits inside the IQ bbox) and stamp `"q2"`.
  *      c. Find the whisker pair. If AnyChart renders them as one path
@@ -4792,7 +4792,7 @@ function buildBoxLayer(
   // `selectors.length === points.length`, so we always emit exactly one
   // entry per box. `q1` and `q3` are intentionally omitted — MAIDR derives
   // them from the `iq` element's top/bottom edges via
-  // `Svg.createLineElement(iq, 'top'|'bottom')`. Outlier arrays are empty
+  // `Svg.createLineElements`. Outlier arrays are empty
   // because AnyChart's iterator API does not expose outliers.
   const scope = panelScope(panel);
   const stamp = panelStampPrefix(panel);

--- a/src/adapters/highcharts/selectors.ts
+++ b/src/adapters/highcharts/selectors.ts
@@ -532,7 +532,7 @@ export function histogramSelector(containerId: string, seriesIndex: number): str
  *
  * Trade-off: open/close are not provided as separate selectors. MAIDR's
  * `CandlestickTrace` derives open/close line segments from the body's edges
- * via `Svg.createLineElements` when omitted, which is sufficient for
+ * via `Svg.buildLineElements` when omitted, which is sufficient for
  * highlighting the open/close marks.
  */
 export function candlestickSelectors(

--- a/src/adapters/highcharts/selectors.ts
+++ b/src/adapters/highcharts/selectors.ts
@@ -532,7 +532,7 @@ export function histogramSelector(containerId: string, seriesIndex: number): str
  *
  * Trade-off: open/close are not provided as separate selectors. MAIDR's
  * `CandlestickTrace` derives open/close line segments from the body's edges
- * via `Svg.createLineElement` when omitted, which is sufficient for
+ * via `Svg.createLineElements` when omitted, which is sufficient for
  * highlighting the open/close marks.
  */
 export function candlestickSelectors(

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -384,15 +384,23 @@ export class BoxTrace extends AbstractTrace {
       });
     });
 
-    // Phase 1.5: draw everything that has to be measured, for every box at
-    // once. Each derived quartile edge costs a `getBBox` and a
+    // Phase 1.5: measure and build everything that has to be measured, for
+    // every box at once. Each derived quartile edge costs a `getBBox` and a
     // `getComputedStyle` on the box, and each whisker costs a `getBBox` on
     // the box and on the cap; drawing them a box at a time put those reads
     // straight after the previous box's inserts, so the chart was laid out
     // again before each -- measured at 4 forced layouts per box, 120 over 30
     // boxes, paid again on every live-data rebuild. The same box was measured
-    // four times over. Both batches read before they write, and the edges are
-    // requested before the whiskers so each box keeps the child order it had.
+    // four times over.
+    //
+    // Nothing is inserted here. The lines come back detached and Phase 2 puts
+    // them in exactly where the one-at-a-time code did, because a box whose
+    // body element is also one of its own parts -- Victory names one `<path>`
+    // as both `iq` and `q1`, Plotly's violin box names one as `min`, `iq`,
+    // `q2` and `max` -- would otherwise have its hidden clone land directly
+    // after that element instead of behind the derived lines, and
+    // `getAllOriginalElements` pairs clone to original by
+    // `previousElementSibling`.
     const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
     const edgeRequests: LineRequest[] = [];
     const edgeOwners: number[] = [];
@@ -410,7 +418,7 @@ export class BoxTrace extends AbstractTrace {
       );
       edgeOwners.push(boxIdx);
     });
-    const edges = Svg.createLineElements(edgeRequests);
+    const edges = Svg.buildLineElements(edgeRequests);
     const derivedEdges = new Map<number, [SVGElement, SVGElement]>();
     edgeOwners.forEach((boxIdx, request) => {
       derivedEdges.set(boxIdx, [edges[request * 2], edges[request * 2 + 1]]);
@@ -418,7 +426,8 @@ export class BoxTrace extends AbstractTrace {
 
     // The lower cap's whisker then the upper cap's, box by box, which is the
     // order `getGeometryElements` reports them in and `test/model/
-    // boxGeometry.test.ts` pins.
+    // boxGeometry.test.ts` pins, and the order `offerGeometry` inserts them
+    // in.
     const whiskerRequests: WhiskerRequest[] = [];
     const whiskerOwners: number[] = [];
     originals.forEach((original, boxIdx) => {
@@ -434,7 +443,7 @@ export class BoxTrace extends AbstractTrace {
         whiskerOwners.push(boxIdx);
       }
     });
-    const whiskers = Svg.createWhiskerElements(whiskerRequests);
+    const whiskers = Svg.buildWhiskerElements(whiskerRequests);
     const whiskersByBox: SVGElement[][] = originals.map(() => []);
     whiskerOwners.forEach((boxIdx, request) => {
       const whisker = whiskers[request];
@@ -464,17 +473,20 @@ export class BoxTrace extends AbstractTrace {
 
       // Use direct Q1/Q3 selectors if provided (Plotly: highlight entire box).
       // Otherwise, take the Q1/Q3 edges derived from iq in Phase 1.5
-      // (matplotlib/seaborn).
+      // (matplotlib/seaborn) and insert them here, after this box's clones,
+      // where deriving them one at a time used to insert them.
+      const derived = derivedEdges.get(boxIdx);
       let q1: SVGElement;
       let q3: SVGElement;
       if (original.q1Direct && original.q3Direct) {
         q1 = this.cloneElementOrEmpty(original.q1Direct);
         q3 = this.cloneElementOrEmpty(original.q3Direct);
+      } else if (derived && original.iq) {
+        [q1, q3] = derived;
+        Svg.insertDerived(original.iq, q1, q3);
       } else {
-        [q1, q3] = derivedEdges.get(boxIdx) ?? [
-          Svg.createEmptyElement('line'),
-          Svg.createEmptyElement('line'),
-        ];
+        q1 = Svg.createEmptyElement('line');
+        q3 = Svg.createEmptyElement('line');
       }
 
       this.offerGeometry(original, whiskersByBox[boxIdx]);
@@ -512,8 +524,9 @@ export class BoxTrace extends AbstractTrace {
    * @param original.q2 - The median
    * @param original.q1Direct - The lower quartile, where the chart drew it
    * @param original.q3Direct - The upper quartile, where the chart drew it
-   * @param whiskers - The box's whiskers, drawn in Phase 1.5, lower cap
-   *   first; the ones that could not be drawn are already left out
+   * @param whiskers - The box's whiskers, built in Phase 1.5 and inserted
+   *   here, lower cap first; the ones that could not be drawn are already
+   *   left out
    */
   private offerGeometry(
     original: {
@@ -544,7 +557,14 @@ export class BoxTrace extends AbstractTrace {
         parts.add(part);
       }
     }
+    // The whiskers go in beside the box here rather than when they were
+    // built, so that on a box whose body element is also one of its own
+    // parts the hidden clones stand between the body and its whiskers, as
+    // they did when each whisker was drawn at this point.
     for (const whisker of whiskers) {
+      if (body !== null) {
+        Svg.insertDerived(body, whisker);
+      }
       parts.add(whisker);
     }
     this.geometry.push(...parts);

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -2,6 +2,7 @@ import type { BoxplotSectionType } from '@type/boxplotSection';
 import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Edge, LineRequest, WhiskerRequest } from '@util/svg';
 import type { Dimension, NearestPoint } from './abstract';
 import { BoxplotSection } from '@type/boxplotSection';
 import { Orientation } from '@type/grammar';
@@ -383,6 +384,65 @@ export class BoxTrace extends AbstractTrace {
       });
     });
 
+    // Phase 1.5: draw everything that has to be measured, for every box at
+    // once. Each derived quartile edge costs a `getBBox` and a
+    // `getComputedStyle` on the box, and each whisker costs a `getBBox` on
+    // the box and on the cap; drawing them a box at a time put those reads
+    // straight after the previous box's inserts, so the chart was laid out
+    // again before each -- measured at 4 forced layouts per box, 120 over 30
+    // boxes, paid again on every live-data rebuild. The same box was measured
+    // four times over. Both batches read before they write, and the edges are
+    // requested before the whiskers so each box keeps the child order it had.
+    const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
+    const edgeRequests: LineRequest[] = [];
+    const edgeOwners: number[] = [];
+    originals.forEach((original, boxIdx) => {
+      // Direct Q1/Q3 selectors bypass iq edge derivation (used by Plotly).
+      if ((original.q1Direct && original.q3Direct) || !original.iq) {
+        return;
+      }
+      const [q1Edge, q3Edge]: [Edge, Edge] = isVertical
+        ? (isIqrReversed ? ['top', 'bottom'] : ['bottom', 'top'])
+        : ['left', 'right'];
+      edgeRequests.push(
+        { box: original.iq, edge: q1Edge },
+        { box: original.iq, edge: q3Edge },
+      );
+      edgeOwners.push(boxIdx);
+    });
+    const edges = Svg.createLineElements(edgeRequests);
+    const derivedEdges = new Map<number, [SVGElement, SVGElement]>();
+    edgeOwners.forEach((boxIdx, request) => {
+      derivedEdges.set(boxIdx, [edges[request * 2], edges[request * 2 + 1]]);
+    });
+
+    // The lower cap's whisker then the upper cap's, box by box, which is the
+    // order `getGeometryElements` reports them in and `test/model/
+    // boxGeometry.test.ts` pins.
+    const whiskerRequests: WhiskerRequest[] = [];
+    const whiskerOwners: number[] = [];
+    originals.forEach((original, boxIdx) => {
+      const body = original.iq ?? original.q1Direct;
+      if (body === null) {
+        return;
+      }
+      for (const cap of [original.min, original.max]) {
+        if (cap === null) {
+          continue;
+        }
+        whiskerRequests.push({ cap, body, vertical: isVertical });
+        whiskerOwners.push(boxIdx);
+      }
+    });
+    const whiskers = Svg.createWhiskerElements(whiskerRequests);
+    const whiskersByBox: SVGElement[][] = originals.map(() => []);
+    whiskerOwners.forEach((boxIdx, request) => {
+      const whisker = whiskers[request];
+      if (whisker !== null) {
+        whiskersByBox[boxIdx].push(whisker);
+      }
+    });
+
     // Phase 2: Clone and create elements from originals (DOM queries complete)
     originals.forEach((original, boxIdx) => {
       const lowerOutliers = original.lowerOutliers.map((el) => {
@@ -403,36 +463,21 @@ export class BoxTrace extends AbstractTrace {
       const q2 = this.cloneElementOrEmpty(original.q2);
 
       // Use direct Q1/Q3 selectors if provided (Plotly: highlight entire box).
-      // Otherwise, derive Q1/Q3 line elements from iq edges (matplotlib/seaborn).
+      // Otherwise, take the Q1/Q3 edges derived from iq in Phase 1.5
+      // (matplotlib/seaborn).
       let q1: SVGElement;
       let q3: SVGElement;
       if (original.q1Direct && original.q3Direct) {
         q1 = this.cloneElementOrEmpty(original.q1Direct);
         q3 = this.cloneElementOrEmpty(original.q3Direct);
       } else {
-        const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
-        [q1, q3] = original.iq
-          ? (isVertical
-              ? isIqrReversed
-                ? [
-                    Svg.createLineElement(original.iq, 'top'),
-                    Svg.createLineElement(original.iq, 'bottom'),
-                  ]
-                : [
-                    Svg.createLineElement(original.iq, 'bottom'),
-                    Svg.createLineElement(original.iq, 'top'),
-                  ]
-              : [
-                  Svg.createLineElement(original.iq, 'left'),
-                  Svg.createLineElement(original.iq, 'right'),
-                ])
-          : [
-              Svg.createEmptyElement('line'),
-              Svg.createEmptyElement('line'),
-            ];
+        [q1, q3] = derivedEdges.get(boxIdx) ?? [
+          Svg.createEmptyElement('line'),
+          Svg.createEmptyElement('line'),
+        ];
       }
 
-      this.offerGeometry(original, isVertical);
+      this.offerGeometry(original, whiskersByBox[boxIdx]);
 
       const sections = [lowerOutliers, min, q1, q2, q3, max, upperOutliers];
 
@@ -467,7 +512,8 @@ export class BoxTrace extends AbstractTrace {
    * @param original.q2 - The median
    * @param original.q1Direct - The lower quartile, where the chart drew it
    * @param original.q3Direct - The upper quartile, where the chart drew it
-   * @param isVertical - Whether the box stands upright
+   * @param whiskers - The box's whiskers, drawn in Phase 1.5, lower cap
+   *   first; the ones that could not be drawn are already left out
    */
   private offerGeometry(
     original: {
@@ -480,7 +526,7 @@ export class BoxTrace extends AbstractTrace {
       q1Direct: SVGElement | null;
       q3Direct: SVGElement | null;
     },
-    isVertical: boolean,
+    whiskers: readonly SVGElement[],
   ): void {
     const body = original.iq ?? original.q1Direct;
     const parts = new Set<SVGElement>();
@@ -498,13 +544,8 @@ export class BoxTrace extends AbstractTrace {
         parts.add(part);
       }
     }
-    if (body !== null) {
-      for (const cap of [original.min, original.max]) {
-        const whisker = cap === null ? null : Svg.createWhiskerElement(cap, body, isVertical);
-        if (whisker !== null) {
-          parts.add(whisker);
-        }
-      }
+    for (const whisker of whiskers) {
+      parts.add(whisker);
     }
     this.geometry.push(...parts);
   }

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -10,6 +10,7 @@ import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState, TraceState } from '@type/state';
 import type { Ohlc } from '@util/candlePattern';
+import type { LineRequest } from '@util/svg';
 import { AbstractTrace } from '@model/abstract';
 import { Orientation } from '@type/grammar';
 import {
@@ -842,51 +843,69 @@ export class Candlestick extends AbstractTrace {
     const derivedOpen = Array.from({ length: N }) as SVGElement[];
     const derivedClose = Array.from({ length: N }) as SVGElement[];
 
+    // The edges are drawn along the body, and every line costs a `getBBox`
+    // and a `getComputedStyle` on it. Drawing them one at a time put those
+    // reads immediately after the insert of the previous line, so the chart
+    // had to be laid out again before each -- measured at exactly 2N forced
+    // layouts, 400 at 200 candles, paid again on every live-data rebuild.
+    // Decide what to draw for every candle first, then draw the batch.
+    const lineRequests: LineRequest[] = [];
+    // Where each request's line belongs: the candle, and which edge of it.
+    const lineSlots: { readonly index: number; readonly isOpen: boolean }[] = [];
+
     for (let i = 0; i < N; i++) {
+      const body = this.getElementAt(bodies, i);
+      const { open, close } = this.candles[i];
+
       // Open (explicit otherwise derive from body using data)
-      let openEl = this.getElementAt(opens, i);
-      if (!openEl) {
-        const body = this.getElementAt(bodies, i);
-        const { open, close } = this.candles[i];
+      const openEl = this.getElementAt(opens, i);
+      if (openEl) {
+        derivedOpen[i] = openEl;
+      } else if (body && this.hasOpen && open !== undefined) {
         // Which edge of the body is the open depends on which way the body
         // ran, so a candle with none has no edge to derive -- and no `open`
         // section for the element to be reached through either. The section
         // is a property of the chart, not of the candle: on a chart without
         // one, a candle that does state an open still has nowhere to place
-        // the line, and `createLineElement` inserts it the moment it is made,
-        // so deriving it left a `<line>` in the chart `dispose()` never saw.
-        if (body && this.hasOpen && open !== undefined) {
-          const edge: 'top' | 'bottom'
-            = close > open ? 'bottom' : close < open ? 'top' : 'bottom';
-          openEl = Svg.createLineElement(body, edge);
-        } else {
-          openEl = Svg.createEmptyElement();
-        }
+        // the line, and the line is inserted into the chart, so deriving it
+        // left a `<line>` behind that `dispose()` never saw.
+        lineRequests.push({
+          box: body,
+          edge: close > open ? 'bottom' : close < open ? 'top' : 'bottom',
+        });
+        lineSlots.push({ index: i, isOpen: true });
+      } else {
+        derivedOpen[i] = Svg.createEmptyElement();
       }
-      derivedOpen[i] = openEl;
 
       // Close (explicit otherwise derive from body using data)
-      let closeEl = this.getElementAt(closes, i);
-      if (!closeEl) {
-        const body = this.getElementAt(bodies, i);
-        const { open, close } = this.candles[i];
+      const closeEl = this.getElementAt(closes, i);
+      if (closeEl) {
+        derivedClose[i] = closeEl;
+      } else if (body && open !== undefined) {
         // The close is the body's other edge, so it is derivable on exactly
         // the charts the open is. A high-low-close chart draws no body at
         // all; its close comes from the explicit selector or from nothing.
-        if (body && open !== undefined) {
-          const edge: 'top' | 'bottom'
-            = close > open ? 'top' : close < open ? 'bottom' : 'top';
-          closeEl = Svg.createLineElement(body, edge);
-        } else {
-          closeEl = Svg.createEmptyElement();
-        }
+        lineRequests.push({
+          box: body,
+          edge: close > open ? 'top' : close < open ? 'bottom' : 'top',
+        });
+        lineSlots.push({ index: i, isOpen: false });
+      } else {
+        derivedClose[i] = Svg.createEmptyElement();
       }
-      derivedClose[i] = closeEl;
-
-      // Volatility is composed below as [high, body, low]; there is no single
-      // element for it, and nothing ever read the one that used to be made
-      // here.
     }
+
+    // Requested open-then-close per candle, as the one-at-a-time code drew
+    // them, so each body keeps the child order it had.
+    const lines = Svg.createLineElements(lineRequests);
+    lineSlots.forEach((slot, request) => {
+      if (slot.isOpen) {
+        derivedOpen[slot.index] = lines[request];
+      } else {
+        derivedClose[slot.index] = lines[request];
+      }
+    });
 
     // Build 2D array in value-sorted navigation order per point.
     //

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -897,8 +897,15 @@ export class Candlestick extends AbstractTrace {
     }
 
     // Requested open-then-close per candle, as the one-at-a-time code drew
-    // them, so each body keeps the child order it had.
-    const lines = Svg.createLineElements(lineRequests);
+    // them, and inserted in that same order, one call per line, so each body
+    // keeps the child order it had. The anchors are the hidden body clones
+    // `collectElements` inserted before any of this ran, and nothing is
+    // inserted beside them afterwards, so where these lines land is the same
+    // as it was.
+    const lines = Svg.buildLineElements(lineRequests);
+    lineRequests.forEach(({ box }, request) => {
+      Svg.insertDerived(box, lines[request]);
+    });
     lineSlots.forEach((slot, request) => {
       if (slot.isOpen) {
         derivedOpen[slot.index] = lines[request];

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -834,12 +834,13 @@ export class Candlestick extends AbstractTrace {
     const closes = this.collectElements(cs.close);
     // Volatility will be composed from [wickHigh, body, wickLow]; no direct selectors used
 
-    const derivedOpen: SVGElement[] = Array.from({ length: N }, () =>
-      Svg.createEmptyElement());
-    const derivedClose: SVGElement[] = Array.from({ length: N }, () =>
-      Svg.createEmptyElement());
-    const derivedVolatility: SVGElement[] = Array.from({ length: N }, () =>
-      Svg.createEmptyElement());
+    // Every index of both is written unconditionally by the loop below, so
+    // there is nothing to pre-fill: an element made here would be discarded
+    // a few lines later, and at 200 candles that was 400 hidden `<rect>`s
+    // built and thrown away per construction -- paid again on every
+    // live-data rebuild.
+    const derivedOpen = Array.from({ length: N }) as SVGElement[];
+    const derivedClose = Array.from({ length: N }) as SVGElement[];
 
     for (let i = 0; i < N; i++) {
       // Open (explicit otherwise derive from body using data)
@@ -882,14 +883,25 @@ export class Candlestick extends AbstractTrace {
       }
       derivedClose[i] = closeEl;
 
-      // Volatility: composed later as [high, body, low]; no single element here
-      derivedVolatility[i] = Svg.createEmptyElement();
+      // Volatility is composed below as [high, body, low]; there is no single
+      // element for it, and nothing ever read the one that used to be made
+      // here.
     }
 
-    // Build 2D array in value-sorted navigation order per point
+    // Build 2D array in value-sorted navigation order per point.
+    //
+    // The rows start empty rather than pre-filled: the loop below writes
+    // `segmentElements[pos][pointIndex]` for every `pos` in
+    // `0..navOrder.length - 1`, and `navOrder` is
+    // `sortedSegmentsByPoint[pointIndex]`, which `precomputeSortedSegments`
+    // builds as `['volatility', ...ohlc]` with `ohlc` four long when
+    // {@link hasOpen} and three otherwise -- exactly `sections.length`, which
+    // `candlestickSectionsOf` derives from the same flag. Every cell is
+    // therefore written, and pre-filling one only built an element to
+    // overwrite it.
     const segmentElements: HighlightValue[][] = Array.from(
       { length: this.sections.length },
-      () => Array.from({ length: N }, () => Svg.createEmptyElement()),
+      () => Array.from({ length: N }) as HighlightValue[],
     );
 
     for (let pointIndex = 0; pointIndex < N; pointIndex++) {

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -608,7 +608,14 @@ export class ViolinBoxTrace extends AbstractTrace {
         parts.add(part);
       }
     }
+    // The whiskers go in beside the box here rather than when they were
+    // built, so that where the inner box is drawn as one element the hidden
+    // clones stand between it and its whiskers, as they did when each whisker
+    // was drawn at this point.
     for (const whisker of whiskers) {
+      if (original.iq !== null) {
+        Svg.insertDerived(original.iq, whisker);
+      }
       parts.add(whisker);
     }
     this.geometry.push(...parts);
@@ -655,13 +662,20 @@ export class ViolinBoxTrace extends AbstractTrace {
       });
     });
 
-    // Phase 1.5: draw everything that has to be measured, for every box at
-    // once, for the reason given on `Svg.createLineElements` -- drawing a box
-    // at a time put each box's measurements straight after the previous box's
-    // inserts, so the chart was laid out again before each: measured at 4
-    // forced layouts per box, 120 over 30 boxes, and paid again on every
-    // live-data rebuild. Edges before whiskers, so each box keeps the child
-    // order it had.
+    // Phase 1.5: measure and build everything that has to be measured, for
+    // every box at once, for the reason given on `Svg.buildLineElements` --
+    // drawing a box at a time put each box's measurements straight after the
+    // previous box's inserts, so the chart was laid out again before each:
+    // measured at 4 forced layouts per box, 120 over 30 boxes, and paid again
+    // on every live-data rebuild.
+    //
+    // Nothing is inserted here. The lines come back detached and Phase 2 puts
+    // them in where the one-at-a-time code did, because a violin whose inner
+    // box is one element -- Plotly names one `<path>` as `min`, `iq`, `q2`
+    // and `max` -- would otherwise have its hidden clones land directly after
+    // that element instead of behind the derived lines, and
+    // `getAllOriginalElements` pairs clone to original by
+    // `previousElementSibling`.
     //
     // Check if IQR direction should be reversed (for gridSVG vertical plots
     // where scale(1,-1) Y-flip inverts getBBox top/bottom edges).
@@ -681,14 +695,15 @@ export class ViolinBoxTrace extends AbstractTrace {
       );
       edgeOwners.push(boxIdx);
     });
-    const edges = Svg.createLineElements(edgeRequests);
+    const edges = Svg.buildLineElements(edgeRequests);
     const derivedEdges = new Map<number, [SVGElement, SVGElement]>();
     edgeOwners.forEach((boxIdx, request) => {
       derivedEdges.set(boxIdx, [edges[request * 2], edges[request * 2 + 1]]);
     });
 
     // The lower cap's whisker then the upper cap's, box by box, which is the
-    // order `getGeometryElements` reports them in.
+    // order `getGeometryElements` reports them in and the order
+    // `offerGeometry` inserts them in.
     const whiskerRequests: WhiskerRequest[] = [];
     const whiskerOwners: number[] = [];
     originals.forEach((original, boxIdx) => {
@@ -703,7 +718,7 @@ export class ViolinBoxTrace extends AbstractTrace {
         whiskerOwners.push(boxIdx);
       }
     });
-    const whiskers = Svg.createWhiskerElements(whiskerRequests);
+    const whiskers = Svg.buildWhiskerElements(whiskerRequests);
     const whiskersByBox: SVGElement[][] = originals.map(() => []);
     whiskerOwners.forEach((boxIdx, request) => {
       const whisker = whiskers[request];
@@ -719,12 +734,19 @@ export class ViolinBoxTrace extends AbstractTrace {
       const q2 = this.cloneElementOrEmpty(original.q2);
       const mean = this.cloneElementOrEmpty(original.mean);
 
-      // Q1/Q3 are the IQ box's edges, derived in Phase 1.5 (same approach as
-      // BoxTrace).
-      const [q1, q3] = derivedEdges.get(boxIdx) ?? [
-        Svg.createEmptyElement('line'),
-        Svg.createEmptyElement('line'),
-      ];
+      // Q1/Q3 are the IQ box's edges, derived in Phase 1.5 and inserted here,
+      // after this box's clones, where deriving them one at a time used to
+      // insert them (same approach as BoxTrace).
+      const derived = derivedEdges.get(boxIdx);
+      let q1: SVGElement;
+      let q3: SVGElement;
+      if (derived && original.iq) {
+        [q1, q3] = derived;
+        Svg.insertDerived(original.iq, q1, q3);
+      } else {
+        q1 = Svg.createEmptyElement('line');
+        q3 = Svg.createEmptyElement('line');
+      }
 
       this.offerGeometry(original, whiskersByBox[boxIdx]);
 

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -2,6 +2,7 @@ import type { BoxPoint, BoxSelector, MaidrLayer, ViolinOptions } from '@type/gra
 import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Edge, LineRequest, WhiskerRequest } from '@util/svg';
 import type { Dimension, NearestPoint } from './abstract';
 import { BoxplotSection } from '@type/boxplotSection';
 import { Orientation } from '@type/grammar';
@@ -588,7 +589,8 @@ export class ViolinBoxTrace extends AbstractTrace {
    * @param original.iq - The box body
    * @param original.q2 - The median
    * @param original.mean - The mean marker, where the chart drew one
-   * @param isVertical - Whether the box stands upright
+   * @param whiskers - The box's whiskers, drawn in Phase 1.5, lower cap
+   *   first; the ones that could not be drawn are already left out
    */
   private offerGeometry(
     original: {
@@ -598,7 +600,7 @@ export class ViolinBoxTrace extends AbstractTrace {
       q2: SVGElement | null;
       mean: SVGElement | null;
     },
-    isVertical: boolean,
+    whiskers: readonly SVGElement[],
   ): void {
     const parts = new Set<SVGElement>();
     for (const part of [original.iq, original.q2, original.mean, original.min, original.max]) {
@@ -606,13 +608,8 @@ export class ViolinBoxTrace extends AbstractTrace {
         parts.add(part);
       }
     }
-    if (original.iq !== null) {
-      for (const cap of [original.min, original.max]) {
-        const whisker = cap === null ? null : Svg.createWhiskerElement(cap, original.iq, isVertical);
-        if (whisker !== null) {
-          parts.add(whisker);
-        }
-      }
+    for (const whisker of whiskers) {
+      parts.add(whisker);
     }
     this.geometry.push(...parts);
   }
@@ -658,6 +655,63 @@ export class ViolinBoxTrace extends AbstractTrace {
       });
     });
 
+    // Phase 1.5: draw everything that has to be measured, for every box at
+    // once, for the reason given on `Svg.createLineElements` -- drawing a box
+    // at a time put each box's measurements straight after the previous box's
+    // inserts, so the chart was laid out again before each: measured at 4
+    // forced layouts per box, 120 over 30 boxes, and paid again on every
+    // live-data rebuild. Edges before whiskers, so each box keeps the child
+    // order it had.
+    //
+    // Check if IQR direction should be reversed (for gridSVG vertical plots
+    // where scale(1,-1) Y-flip inverts getBBox top/bottom edges).
+    const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
+    const edgeRequests: LineRequest[] = [];
+    const edgeOwners: number[] = [];
+    originals.forEach((original, boxIdx) => {
+      if (!original.iq) {
+        return;
+      }
+      const [q1Edge, q3Edge]: [Edge, Edge] = isVertical
+        ? (isIqrReversed ? ['top', 'bottom'] : ['bottom', 'top'])
+        : ['left', 'right'];
+      edgeRequests.push(
+        { box: original.iq, edge: q1Edge },
+        { box: original.iq, edge: q3Edge },
+      );
+      edgeOwners.push(boxIdx);
+    });
+    const edges = Svg.createLineElements(edgeRequests);
+    const derivedEdges = new Map<number, [SVGElement, SVGElement]>();
+    edgeOwners.forEach((boxIdx, request) => {
+      derivedEdges.set(boxIdx, [edges[request * 2], edges[request * 2 + 1]]);
+    });
+
+    // The lower cap's whisker then the upper cap's, box by box, which is the
+    // order `getGeometryElements` reports them in.
+    const whiskerRequests: WhiskerRequest[] = [];
+    const whiskerOwners: number[] = [];
+    originals.forEach((original, boxIdx) => {
+      if (original.iq === null) {
+        return;
+      }
+      for (const cap of [original.min, original.max]) {
+        if (cap === null) {
+          continue;
+        }
+        whiskerRequests.push({ cap, body: original.iq, vertical: isVertical });
+        whiskerOwners.push(boxIdx);
+      }
+    });
+    const whiskers = Svg.createWhiskerElements(whiskerRequests);
+    const whiskersByBox: SVGElement[][] = originals.map(() => []);
+    whiskerOwners.forEach((boxIdx, request) => {
+      const whisker = whiskers[request];
+      if (whisker !== null) {
+        whiskersByBox[boxIdx].push(whisker);
+      }
+    });
+
     // Phase 2: Clone elements
     originals.forEach((original, boxIdx) => {
       const min = this.cloneElementOrEmpty(original.min);
@@ -665,31 +719,14 @@ export class ViolinBoxTrace extends AbstractTrace {
       const q2 = this.cloneElementOrEmpty(original.q2);
       const mean = this.cloneElementOrEmpty(original.mean);
 
-      // Create Q1/Q3 line elements from IQ box (same approach as BoxTrace).
-      // Check if IQR direction should be reversed (for gridSVG vertical plots
-      // where scale(1,-1) Y-flip inverts getBBox top/bottom edges).
-      const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
-      const [q1, q3] = original.iq
-        ? (isVertical
-            ? isIqrReversed
-              ? [
-                  Svg.createLineElement(original.iq, 'top'),
-                  Svg.createLineElement(original.iq, 'bottom'),
-                ]
-              : [
-                  Svg.createLineElement(original.iq, 'bottom'),
-                  Svg.createLineElement(original.iq, 'top'),
-                ]
-            : [
-                Svg.createLineElement(original.iq, 'left'),
-                Svg.createLineElement(original.iq, 'right'),
-              ])
-        : [
-            Svg.createEmptyElement('line'),
-            Svg.createEmptyElement('line'),
-          ];
+      // Q1/Q3 are the IQ box's edges, derived in Phase 1.5 (same approach as
+      // BoxTrace).
+      const [q1, q3] = derivedEdges.get(boxIdx) ?? [
+        Svg.createEmptyElement('line'),
+        Svg.createEmptyElement('line'),
+      ];
 
-      this.offerGeometry(original, isVertical);
+      this.offerGeometry(original, whiskersByBox[boxIdx]);
 
       // Build sections array matching this.sections (no outlier sections)
       const sectionElements: (SVGElement[] | SVGElement)[] = [];

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -310,17 +310,26 @@ export abstract class Svg {
   private static readonly MIN_LINE_SPAN = 10;
 
   /**
-   * Creates one line per request, each along one edge of one element's
-   * bounding box.
+   * Builds one line per request, each along one edge of one element's
+   * bounding box, and returns them **detached**.
    *
    * A whole batch at once rather than a line at a time, for the reason given
    * on {@link createCircleElements}: measuring an element after inserting a
    * node beside it is what forces the browser to lay the chart out again, and
    * a loop that alternated the two paid a layout per line. Reading every
-   * anchor first, building from the numbers, and inserting once per anchor
-   * costs one layout for the batch however many lines it holds -- and a
-   * candlestick or a box plot builds two per candle or per box, at
-   * construction and again on every live-data rebuild.
+   * anchor first and building from the numbers costs one layout for the batch
+   * however many lines it holds -- and a candlestick or a box plot builds two
+   * per candle or per box, at construction and again on every live-data
+   * rebuild.
+   *
+   * Building is split from inserting because *where* a line lands among its
+   * siblings is behaviour, not bookkeeping: an anchor that is also the
+   * original of a hidden clone pairs with that clone by
+   * `previousElementSibling`, so a line inserted between them changes which
+   * elements a trace reports as its originals and therefore what a
+   * high-contrast reader is shown. The caller inserts with
+   * {@link insertDerived}, at the point in its own writes where the line
+   * belongs.
    *
    * Each anchor is measured and styled once even when several lines are drawn
    * along it: inserting a hidden sibling does not move the anchor, so the
@@ -331,9 +340,9 @@ export abstract class Svg {
    * visible.
    *
    * @param requests - The lines to draw, in the order they should be made
-   * @returns The lines, index-aligned with the requests
+   * @returns The lines, index-aligned with the requests, not yet in the document
    */
-  public static createLineElements(requests: readonly LineRequest[]): SVGElement[] {
+  public static buildLineElements(requests: readonly LineRequest[]): SVGElement[] {
     if (requests.length === 0) {
       return [];
     }
@@ -369,9 +378,6 @@ export abstract class Svg {
       return this.markOwned(line);
     });
 
-    // WRITE. One insertion per anchor, reproducing the order that repeated
-    // `insertAdjacentElement(AFTER_END, ...)` left behind.
-    this.insertAfterAnchors(requests.map(({ box }) => box), lines);
     return lines;
   }
 
@@ -414,42 +420,37 @@ export abstract class Svg {
   }
 
   /**
-   * Inserts each node directly after its anchor, one DOM call per anchor.
+   * Puts derived nodes into the document directly after the element they were
+   * derived from, one at a time and in the order they were built.
    *
-   * `anchor.after(a, b)` leaves `[anchor, a, b]`, where inserting `a` and then
-   * `b` with `insertAdjacentElement(AFTER_END, ...)` leaves `[anchor, b, a]`.
-   * The batch therefore hands each anchor its nodes reversed, so the child
-   * order is the one the one-at-a-time code produced -- which is the order the
-   * chart is painted in, and so the order a reader sees a highlight in:
-   * {@link createHighlightElement} inserts its visible clone directly after
-   * the element it highlights.
+   * `insertAdjacentElement(AFTER_END, ...)` puts each node straight after the
+   * anchor, so building `a` then `b` and inserting both leaves `[anchor, b,
+   * a]`. That reversal is the child order every renderer, highlight and
+   * high-contrast pass has always seen, so it is reproduced exactly rather
+   * than tidied: the caller passes the nodes in the order it built them.
+   *
+   * Where the caller makes this call matters as much as the order within it.
+   * A node inserted after an anchor that is itself the original of a hidden
+   * clone lands between the two, and `AbstractTrace.getAllOriginalElements`
+   * pairs a clone to its original by `previousElementSibling`; inserting
+   * earlier or later than the chart's own clones therefore changes which
+   * elements `HighContrastService` recolours. Callers insert at the point
+   * their one-at-a-time predecessor did.
    *
    * An anchor with no parent inserts nothing, exactly as
-   * `insertAdjacentElement` did.
+   * `insertAdjacentElement` does.
    *
-   * @param anchors - The anchor for each node, index-aligned with `nodes`
-   * @param nodes - The nodes to insert, in the order they were made
+   * @param anchor - The element the nodes were derived from and sit beside
+   * @param nodes - The nodes, in the order they were built; nulls are skipped
    */
-  private static insertAfterAnchors(
-    anchors: readonly SVGElement[],
-    nodes: readonly (SVGElement | null)[],
+  public static insertDerived(
+    anchor: SVGElement,
+    ...nodes: readonly (SVGElement | null)[]
   ): void {
-    const byAnchor = new Map<SVGElement, SVGElement[]>();
-    anchors.forEach((anchor, index) => {
-      const node = nodes[index];
-      if (node === null) {
-        return;
+    for (const node of nodes) {
+      if (node !== null) {
+        anchor.insertAdjacentElement(Constant.AFTER_END, node);
       }
-      const existing = byAnchor.get(anchor);
-      if (existing) {
-        existing.push(node);
-      } else {
-        byAnchor.set(anchor, [node]);
-      }
-    });
-
-    for (const [anchor, group] of byAnchor) {
-      anchor.after(...[...group].reverse());
     }
   }
 
@@ -464,17 +465,19 @@ export abstract class Svg {
    * to read, not a mark for the chart to show.
    *
    * A whole batch at once for the reason given on
-   * {@link createLineElements}: one box plot's whiskers used to be measured
+   * {@link buildLineElements}: one box plot's whiskers used to be measured
    * after the previous one's had been inserted, so every box cost the browser
    * two more layouts. The same element is measured once however many whiskers
-   * touch it -- a box and both its caps were read four times per box.
+   * touch it -- a box and both its caps were read four times per box. The
+   * whiskers come back detached, for the caller to insert with
+   * {@link insertDerived} where its one-at-a-time predecessor did.
    *
    * @param requests - The whiskers to draw, in the order they should be made
-   * @returns One entry per request, index-aligned: the hidden line, or null
-   *   when the cap and the box do not sit apart along the box's axis, or when
-   *   the document cannot measure them
+   * @returns One entry per request, index-aligned and not yet in the document:
+   *   the hidden line, or null when the cap and the box do not sit apart along
+   *   the box's axis, or when the document cannot measure them
    */
-  public static createWhiskerElements(
+  public static buildWhiskerElements(
     requests: readonly WhiskerRequest[],
   ): (SVGElement | null)[] {
     if (requests.length === 0) {
@@ -538,8 +541,6 @@ export abstract class Svg {
       return this.markOwned(line);
     });
 
-    // WRITE. Each whisker sits beside the box it joins, as before.
-    this.insertAfterAnchors(requests.map(({ body }) => body), whiskers);
     return whiskers;
   }
 

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -4,7 +4,36 @@ import { Constant } from './constant';
 /**
  * Edge positions for SVG bounding box calculations.
  */
-type Edge = 'top' | 'bottom' | 'left' | 'right';
+export type Edge = 'top' | 'bottom' | 'left' | 'right';
+
+/**
+ * One line to draw along one edge of one element's bounding box.
+ */
+export interface LineRequest {
+  /** The element to measure and draw along. */
+  readonly box: SVGElement;
+  /** Which of its edges the line runs along. */
+  readonly edge: Edge;
+}
+
+/**
+ * One whisker to draw between a cap and the box it belongs to.
+ */
+export interface WhiskerRequest {
+  /** The whisker's end. */
+  readonly cap: SVGElement;
+  /** The box the whisker joins, and the element it is inserted beside. */
+  readonly body: SVGElement;
+  /** Whether the box stands upright, so the whisker does too. */
+  readonly vertical: boolean;
+}
+
+/** What one anchor was measured to be, read once and reused. */
+interface Measured {
+  readonly bBox: DOMRect;
+  readonly stroke: string;
+  readonly strokeWidth: string;
+}
 
 /**
  * Abstract utility class for SVG element manipulation, conversion, and highlighting operations.
@@ -281,76 +310,151 @@ export abstract class Svg {
   private static readonly MIN_LINE_SPAN = 10;
 
   /**
-   * Creates a line element along a specified edge of an SVG element's bounding box.
+   * Creates one line per request, each along one edge of one element's
+   * bounding box.
    *
-   * When the bounding box has zero width (vertical path) or zero height
-   * (horizontal path), a minimum span is used so the resulting line is visible.
+   * A whole batch at once rather than a line at a time, for the reason given
+   * on {@link createCircleElements}: measuring an element after inserting a
+   * node beside it is what forces the browser to lay the chart out again, and
+   * a loop that alternated the two paid a layout per line. Reading every
+   * anchor first, building from the numbers, and inserting once per anchor
+   * costs one layout for the batch however many lines it holds -- and a
+   * candlestick or a box plot builds two per candle or per box, at
+   * construction and again on every live-data rebuild.
    *
-   * @param box - The SVG element to create a line along
-   * @param edge - The edge position ('top', 'bottom', 'left', or 'right')
-   * @returns The newly created line element
+   * Each anchor is measured and styled once even when several lines are drawn
+   * along it: inserting a hidden sibling does not move the anchor, so the
+   * second read only ever returned what the first did.
+   *
+   * When a bounding box has zero width (vertical path) or zero height
+   * (horizontal path), a minimum span is used so the resulting line is
+   * visible.
+   *
+   * @param requests - The lines to draw, in the order they should be made
+   * @returns The lines, index-aligned with the requests
    */
-  public static createLineElement(box: SVGElement, edge: Edge): SVGElement {
-    const svg = box as SVGGraphicsElement;
-    const bBox = svg.getBBox();
+  public static createLineElements(requests: readonly LineRequest[]): SVGElement[] {
+    if (requests.length === 0) {
+      return [];
+    }
 
-    // Ensure non-zero dimensions so edge lines are always visible.
-    // A vertical <path> (width=0) needs a minimum width for top/bottom edges;
-    // a horizontal <path> (height=0) needs a minimum height for left/right edges.
+    // READ. Every measurement the batch needs, before anything is inserted.
+    const measured = new Map<SVGElement, Measured>();
+    for (const { box } of requests) {
+      if (measured.has(box)) {
+        continue;
+      }
+      const bBox = (box as SVGGraphicsElement).getBBox();
+      const style = window.getComputedStyle(box);
+      measured.set(box, {
+        bBox,
+        stroke: style.stroke,
+        strokeWidth: style.strokeWidth || '2',
+      });
+    }
+
+    // BUILD. Arithmetic only; nothing enters the document yet.
+    const lines = requests.map(({ box, edge }) => {
+      const { bBox, stroke, strokeWidth } = measured.get(box)!;
+      const [x1, y1, x2, y2] = this.edgeOf(bBox, edge);
+
+      const line = document.createElementNS(this.SVG_NAMESPACE, Constant.LINE) as SVGElement;
+      line.setAttribute(Constant.X1, String(x1));
+      line.setAttribute(Constant.Y1, String(y1));
+      line.setAttribute(Constant.X2, String(x2));
+      line.setAttribute(Constant.Y2, String(y2));
+      line.setAttribute(Constant.STROKE, stroke);
+      line.setAttribute(Constant.STROKE_WIDTH, strokeWidth);
+      line.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
+      return this.markOwned(line);
+    });
+
+    // WRITE. One insertion per anchor, reproducing the order that repeated
+    // `insertAdjacentElement(AFTER_END, ...)` left behind.
+    this.insertAfterAnchors(requests.map(({ box }) => box), lines);
+    return lines;
+  }
+
+  /**
+   * Where one edge of a measured box runs.
+   *
+   * A zero-width or zero-height box -- a vertical or horizontal `<path>`, as
+   * a violin plot draws its IQ range -- is given {@link MIN_LINE_SPAN} along
+   * the degenerate axis so the edge is still a visible line rather than a
+   * point.
+   *
+   * @param bBox - The measured box
+   * @param edge - Which edge
+   * @returns The line's `[x1, y1, x2, y2]`
+   */
+  private static edgeOf(bBox: DOMRect, edge: Edge): [number, number, number, number] {
     const effectiveWidth = bBox.width || this.MIN_LINE_SPAN;
     const effectiveHeight = bBox.height || this.MIN_LINE_SPAN;
     const cx = bBox.x + bBox.width / 2;
     const cy = bBox.y + bBox.height / 2;
 
-    let x1: number, y1: number, x2: number, y2: number;
     switch (edge) {
       case 'top':
-        if (bBox.width === 0) {
-          [x1, y1, x2, y2] = [cx - effectiveWidth / 2, bBox.y, cx + effectiveWidth / 2, bBox.y];
-        } else {
-          [x1, y1, x2, y2] = [bBox.x, bBox.y, bBox.x + bBox.width, bBox.y];
-        }
-        break;
+        return bBox.width === 0
+          ? [cx - effectiveWidth / 2, bBox.y, cx + effectiveWidth / 2, bBox.y]
+          : [bBox.x, bBox.y, bBox.x + bBox.width, bBox.y];
       case 'bottom':
-        if (bBox.width === 0) {
-          [x1, y1, x2, y2] = [cx - effectiveWidth / 2, bBox.y + bBox.height, cx + effectiveWidth / 2, bBox.y + bBox.height];
-        } else {
-          [x1, y1, x2, y2] = [bBox.x, bBox.y + bBox.height, bBox.x + bBox.width, bBox.y + bBox.height];
-        }
-        break;
+        return bBox.width === 0
+          ? [cx - effectiveWidth / 2, bBox.y + bBox.height, cx + effectiveWidth / 2, bBox.y + bBox.height]
+          : [bBox.x, bBox.y + bBox.height, bBox.x + bBox.width, bBox.y + bBox.height];
       case 'left':
-        if (bBox.height === 0) {
-          [x1, y1, x2, y2] = [bBox.x, cy - effectiveHeight / 2, bBox.x, cy + effectiveHeight / 2];
-        } else {
-          [x1, y1, x2, y2] = [bBox.x, bBox.y, bBox.x, bBox.y + bBox.height];
-        }
-        break;
+        return bBox.height === 0
+          ? [bBox.x, cy - effectiveHeight / 2, bBox.x, cy + effectiveHeight / 2]
+          : [bBox.x, bBox.y, bBox.x, bBox.y + bBox.height];
       case 'right':
-        if (bBox.height === 0) {
-          [x1, y1, x2, y2] = [bBox.x + bBox.width, cy - effectiveHeight / 2, bBox.x + bBox.width, cy + effectiveHeight / 2];
-        } else {
-          [x1, y1, x2, y2] = [bBox.x + bBox.width, bBox.y, bBox.x + bBox.width, bBox.y + bBox.height];
-        }
-        break;
+        return bBox.height === 0
+          ? [bBox.x + bBox.width, cy - effectiveHeight / 2, bBox.x + bBox.width, cy + effectiveHeight / 2]
+          : [bBox.x + bBox.width, bBox.y, bBox.x + bBox.width, bBox.y + bBox.height];
     }
-
-    const style = window.getComputedStyle(box);
-    const line = document.createElementNS(this.SVG_NAMESPACE, Constant.LINE) as SVGElement;
-    line.setAttribute(Constant.X1, String(x1));
-    line.setAttribute(Constant.Y1, String(y1));
-    line.setAttribute(Constant.X2, String(x2));
-    line.setAttribute(Constant.Y2, String(y2));
-    line.setAttribute(Constant.STROKE, style.stroke);
-    line.setAttribute(Constant.STROKE_WIDTH, style.strokeWidth || '2');
-    line.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
-    this.markOwned(line);
-
-    box.insertAdjacentElement(Constant.AFTER_END, line);
-    return line;
   }
 
   /**
-   * Draws the whisker between a box plot's cap and its box.
+   * Inserts each node directly after its anchor, one DOM call per anchor.
+   *
+   * `anchor.after(a, b)` leaves `[anchor, a, b]`, where inserting `a` and then
+   * `b` with `insertAdjacentElement(AFTER_END, ...)` leaves `[anchor, b, a]`.
+   * The batch therefore hands each anchor its nodes reversed, so the child
+   * order is the one the one-at-a-time code produced -- which is the order the
+   * chart is painted in, and so the order a reader sees a highlight in:
+   * {@link createHighlightElement} inserts its visible clone directly after
+   * the element it highlights.
+   *
+   * An anchor with no parent inserts nothing, exactly as
+   * `insertAdjacentElement` did.
+   *
+   * @param anchors - The anchor for each node, index-aligned with `nodes`
+   * @param nodes - The nodes to insert, in the order they were made
+   */
+  private static insertAfterAnchors(
+    anchors: readonly SVGElement[],
+    nodes: readonly (SVGElement | null)[],
+  ): void {
+    const byAnchor = new Map<SVGElement, SVGElement[]>();
+    anchors.forEach((anchor, index) => {
+      const node = nodes[index];
+      if (node === null) {
+        return;
+      }
+      const existing = byAnchor.get(anchor);
+      if (existing) {
+        existing.push(node);
+      } else {
+        byAnchor.set(anchor, [node]);
+      }
+    });
+
+    for (const [anchor, group] of byAnchor) {
+      anchor.after(...[...group].reverse());
+    }
+  }
+
+  /**
+   * Draws the whiskers between box plots' caps and their boxes.
    *
    * A box plot's selectors name the caps and the box, and a highlight only
    * ever needs those. A renderer showing the chart's shape needs the whisker
@@ -359,49 +463,84 @@ export abstract class Svg {
    * nearer edge of the box, and it is hidden: it is geometry for a renderer
    * to read, not a mark for the chart to show.
    *
-   * @param cap - The whisker's end
-   * @param body - The box the whisker joins
-   * @param vertical - Whether the box stands upright, so the whisker does too
-   * @returns The hidden line, or null when the two do not sit apart along the
-   *   box's axis, or when the document cannot measure them
+   * A whole batch at once for the reason given on
+   * {@link createLineElements}: one box plot's whiskers used to be measured
+   * after the previous one's had been inserted, so every box cost the browser
+   * two more layouts. The same element is measured once however many whiskers
+   * touch it -- a box and both its caps were read four times per box.
+   *
+   * @param requests - The whiskers to draw, in the order they should be made
+   * @returns One entry per request, index-aligned: the hidden line, or null
+   *   when the cap and the box do not sit apart along the box's axis, or when
+   *   the document cannot measure them
    */
-  public static createWhiskerElement(cap: SVGElement, body: SVGElement, vertical: boolean): SVGElement | null {
-    let capBox: DOMRect;
-    let bodyBox: DOMRect;
-    try {
-      capBox = (cap as SVGGraphicsElement).getBBox();
-      bodyBox = (body as SVGGraphicsElement).getBBox();
-    } catch {
-      return null;
+  public static createWhiskerElements(
+    requests: readonly WhiskerRequest[],
+  ): (SVGElement | null)[] {
+    if (requests.length === 0) {
+      return [];
     }
 
-    const cx = capBox.x + capBox.width / 2;
-    const cy = capBox.y + capBox.height / 2;
-    let x2: number;
-    let y2: number;
-    if (vertical) {
-      if (cy >= bodyBox.y && cy <= bodyBox.y + bodyBox.height) {
-        return null;
+    // READ. `getBBox` throws on an element the document cannot measure, and
+    // that stays a per-request failure: null for the whisker that asked, and
+    // nothing built or inserted for it.
+    const measured = new Map<SVGElement, DOMRect | null>();
+    const measure = (element: SVGElement): DOMRect | null => {
+      if (measured.has(element)) {
+        return measured.get(element)!;
       }
-      x2 = cx;
-      y2 = cy < bodyBox.y ? bodyBox.y : bodyBox.y + bodyBox.height;
-    } else {
-      if (cx >= bodyBox.x && cx <= bodyBox.x + bodyBox.width) {
-        return null;
+      let bBox: DOMRect | null;
+      try {
+        bBox = (element as SVGGraphicsElement).getBBox();
+      } catch {
+        bBox = null;
       }
-      x2 = cx < bodyBox.x ? bodyBox.x : bodyBox.x + bodyBox.width;
-      y2 = cy;
+      measured.set(element, bBox);
+      return bBox;
+    };
+    for (const { cap, body } of requests) {
+      measure(cap);
+      measure(body);
     }
 
-    const line = document.createElementNS(this.SVG_NAMESPACE, Constant.LINE) as SVGElement;
-    line.setAttribute(Constant.X1, String(cx));
-    line.setAttribute(Constant.Y1, String(cy));
-    line.setAttribute(Constant.X2, String(x2));
-    line.setAttribute(Constant.Y2, String(y2));
-    line.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
-    this.markOwned(line);
-    body.insertAdjacentElement(Constant.AFTER_END, line);
-    return line;
+    // BUILD. Arithmetic only; nothing enters the document yet.
+    const whiskers = requests.map(({ cap, body, vertical }) => {
+      const capBox = measured.get(cap)!;
+      const bodyBox = measured.get(body)!;
+      if (capBox === null || bodyBox === null) {
+        return null;
+      }
+
+      const cx = capBox.x + capBox.width / 2;
+      const cy = capBox.y + capBox.height / 2;
+      let x2: number;
+      let y2: number;
+      if (vertical) {
+        if (cy >= bodyBox.y && cy <= bodyBox.y + bodyBox.height) {
+          return null;
+        }
+        x2 = cx;
+        y2 = cy < bodyBox.y ? bodyBox.y : bodyBox.y + bodyBox.height;
+      } else {
+        if (cx >= bodyBox.x && cx <= bodyBox.x + bodyBox.width) {
+          return null;
+        }
+        x2 = cx < bodyBox.x ? bodyBox.x : bodyBox.x + bodyBox.width;
+        y2 = cy;
+      }
+
+      const line = document.createElementNS(this.SVG_NAMESPACE, Constant.LINE) as SVGElement;
+      line.setAttribute(Constant.X1, String(cx));
+      line.setAttribute(Constant.Y1, String(cy));
+      line.setAttribute(Constant.X2, String(x2));
+      line.setAttribute(Constant.Y2, String(y2));
+      line.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
+      return this.markOwned(line);
+    });
+
+    // WRITE. Each whisker sits beside the box it joins, as before.
+    this.insertAfterAnchors(requests.map(({ body }) => body), whiskers);
+    return whiskers;
   }
 
   /**

--- a/test/model/candlestickDerivedLines.test.ts
+++ b/test/model/candlestickDerivedLines.test.ts
@@ -4,7 +4,7 @@
 
 /**
  * A candlestick derives the open and close edges it was given no selector for
- * by drawing a line along the body, and `Svg.createLineElements` inserts that
+ * by drawing a line along the body, and `Svg.buildLineElements` inserts that
  * line into the chart. On a chart whose candles do not
  * all state an open there is no `open` row (#1188), so a derived open edge has
  * no row to be placed in: it was inserted, referenced by nothing, and left

--- a/test/model/candlestickDerivedLines.test.ts
+++ b/test/model/candlestickDerivedLines.test.ts
@@ -4,8 +4,8 @@
 
 /**
  * A candlestick derives the open and close edges it was given no selector for
- * by drawing a line along the body, and `Svg.buildLineElements` inserts that
- * line into the chart. On a chart whose candles do not
+ * by drawing a line along the body: `Svg.buildLineElements` measures and
+ * builds it, and `Svg.insertDerived` puts it in the chart. On a chart whose candles do not
  * all state an open there is no `open` row (#1188), so a derived open edge has
  * no row to be placed in: it was inserted, referenced by nothing, and left
  * behind by `dispose()` -- one hidden `<line>` per opened candle per focus

--- a/test/model/candlestickDerivedLines.test.ts
+++ b/test/model/candlestickDerivedLines.test.ts
@@ -4,8 +4,8 @@
 
 /**
  * A candlestick derives the open and close edges it was given no selector for
- * by drawing a line along the body, and `Svg.createLineElement` inserts that
- * line into the chart the moment it is made. On a chart whose candles do not
+ * by drawing a line along the body, and `Svg.createLineElements` inserts that
+ * line into the chart. On a chart whose candles do not
  * all state an open there is no `open` row (#1188), so a derived open edge has
  * no row to be placed in: it was inserted, referenced by nothing, and left
  * behind by `dispose()` -- one hidden `<line>` per opened candle per focus

--- a/test/model/candlestickPlaceholders.test.ts
+++ b/test/model/candlestickPlaceholders.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * A candlestick's highlight grid is built by writing every cell.
+ *
+ * `mapToSvgElements` used to pre-fill the derived-edge arrays and every cell
+ * of the grid with a hidden `<rect>` from `Svg.createEmptyElement`, then
+ * overwrite all of them: at 200 candles that was 1800 elements built and
+ * discarded per construction, and `Context.replaceFigure` rebuilds the trace
+ * on every live-data append. The rows are only safe to leave empty while
+ * every cell is still written, which is what these tests pin -- the count
+ * alone would be satisfied by a grid with a hole in it, and a hole is a
+ * segment the reader silently loses the highlight on.
+ */
+
+import type { CandlestickSelector, MaidrLayer } from '@type/grammar';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { Candlestick, candlestickSectionsOf } from '@model/candlestick';
+import { TraceType } from '@type/grammar';
+import { Svg } from '@util/svg';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const N = 200;
+
+/**
+ * A chart of `count` candles.
+ * @param count - How many candles
+ * @param withOpen - Whether every candle states an open, which is what gives
+ *   the chart an `open` row
+ * @returns The layer, without selectors
+ */
+function candles(count: number, withOpen: boolean): Omit<MaidrLayer, 'selectors'> {
+  return {
+    id: 'candlestick',
+    type: TraceType.CANDLESTICK,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: Array.from({ length: count }, (_, i) => ({
+      value: `d${i}`,
+      ...(withOpen ? { open: 10 + (i % 3) } : {}),
+      high: 15,
+      low: 9,
+      close: 14,
+      volume: 1,
+      volatility: 6,
+    })),
+  } as Omit<MaidrLayer, 'selectors'>;
+}
+
+/**
+ * Reads the grid a trace built.
+ * @param trace - The candlestick
+ * @returns Its highlight grid
+ */
+function gridOf(trace: Candlestick): unknown[][] {
+  return (trace as unknown as { highlightValues: unknown[][] }).highlightValues;
+}
+
+describe('a candlestick highlight grid', () => {
+  beforeEach(() => {
+    // jsdom lays nothing out, so the bodies are measured by hand.
+    Object.defineProperty(SVGElement.prototype, 'getBBox', {
+      value: () => ({ x: 0, y: 0, width: 2, height: 4 }),
+      configurable: true,
+    });
+    document.body.innerHTML = `<svg xmlns="${SVG_NS}">${
+      '<rect class="body" x="0" y="0" width="2" height="4" />'.repeat(N)}</svg>`;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    Reflect.deleteProperty(SVGElement.prototype, 'getBBox');
+    document.body.innerHTML = '';
+  });
+
+  // Every shape `mapToSvgElements` can be handed, so the "no cell is left
+  // undefined" claim is made about all of them and not only the common one.
+  const shapes: [name: string, count: number, withOpen: boolean, selectors: string | string[] | CandlestickSelector][] = [
+    ['structured selectors', N, true, { body: '.body' }],
+    ['structured selectors, no open row', N, false, { body: '.body' }],
+    ['structured selectors matching nothing', N, true, { body: '.nowhere' }],
+    ['a legacy single selector', N, true, '.body'],
+    ['a legacy selector array', N, true, ['.body']],
+    ['one candle', 1, true, { body: '.body' }],
+    ['one candle, legacy', 1, true, '.body'],
+    ['no candles', 0, true, { body: '.body' }],
+    ['no candles, legacy', 0, true, '.body'],
+  ];
+
+  test.each(shapes)('fills every cell with %s', (_name, count, withOpen, selectors) => {
+    const layer = { ...candles(count, withOpen), selectors } as MaidrLayer;
+    const rows = candlestickSectionsOf(layer.data as never).length;
+
+    const trace = new Candlestick(layer);
+    const grid = gridOf(trace);
+
+    expect(grid).toHaveLength(rows);
+    for (const row of grid) {
+      expect(row).toHaveLength(count);
+      for (const cell of row) {
+        expect(cell).toBeDefined();
+        expect(cell).not.toBeNull();
+      }
+    }
+
+    trace.dispose();
+  });
+
+  test('a fully selectored chart derives its edges and builds no placeholder', () => {
+    const empty = jest.spyOn(Svg, 'createEmptyElement');
+
+    const trace = new Candlestick({
+      ...candles(N, true),
+      selectors: { body: '.body' },
+    } as MaidrLayer);
+
+    expect(empty).toHaveBeenCalledTimes(0);
+    trace.dispose();
+  });
+
+  test('a chart whose selectors match nothing builds one placeholder per cell and no more', () => {
+    const empty = jest.spyOn(Svg, 'createEmptyElement');
+
+    const trace = new Candlestick({
+      ...candles(N, true),
+      selectors: { body: '.nowhere' },
+    } as MaidrLayer);
+    const grid = gridOf(trace);
+
+    // One per cell: five rows of 200, and nothing spare.
+    expect(empty).toHaveBeenCalledTimes(grid.length * N);
+    trace.dispose();
+  });
+});

--- a/test/model/sharedAnchorWrites.test.ts
+++ b/test/model/sharedAnchorWrites.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Where a trace inserts the lines it derives, when one element is several
+ * parts of the same box.
+ *
+ * A box plot's selectors usually name a different element per part, but two
+ * shipped adapters point more than one part at a single node: Victory names
+ * one `<path>` as both `iq` and `q1` (`src/adapters/victory/selectors.ts`),
+ * and Plotly draws a violin's whole inner box as one `<path>` and names it
+ * `min`, `iq`, `q2` and `max` (`src/adapters/plotly/extractor.ts`).
+ *
+ * That makes the write order load-bearing. `AbstractTrace.getAllOriginalElements`
+ * pairs each hidden clone back to the chart's own element by
+ * `previousElementSibling` -- same tag, not hidden -- and
+ * `HighContrastService.getAllTraceElements` feeds exactly that set to the
+ * recolouring a low-vision reader sees. A derived edge or whisker inserted
+ * before the clone stands between the two and the pairing is refused; inserted
+ * after, the clone sits directly against the shared element and the pairing is
+ * accepted, adding a member to the trace's high-contrast palette. Deriving the
+ * lines earlier is therefore only free if they are still *written* where they
+ * always were, which is what this pins.
+ */
+
+import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { BoxTrace } from '@model/box';
+import { ViolinBoxTrace } from '@model/violinBox';
+import { Orientation, TraceType } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Puts an element in the chart, carrying the box the chart would have laid out.
+ * @param tag - The SVG tag
+ * @param id - Its id, which the selectors name
+ * @param bBox - What `getBBox` reports for it
+ * @param bBox.x - Its left edge
+ * @param bBox.y - Its top edge
+ * @param bBox.width - Its width
+ * @param bBox.height - Its height
+ */
+function place(
+  tag: string,
+  id: string,
+  bBox: { x: number; y: number; width: number; height: number },
+): void {
+  const element = document.createElementNS(SVG_NS, tag);
+  element.setAttribute('id', id);
+  (element as unknown as { bBox: unknown }).bBox = bBox;
+  document.querySelector('svg')!.appendChild(element);
+}
+
+/**
+ * Names one sibling well enough to tell the derived lines, the clones and the
+ * chart's own marks apart.
+ * @param node - The sibling
+ * @returns Its tag, its id or its `y1`, and whether MAIDR made it
+ */
+function describeNode(node: Element): string {
+  const id = node.getAttribute('id') ?? `y1=${node.getAttribute('y1')}`;
+  return `${node.tagName}#${id}${node.hasAttribute('data-maidr-owned') ? ' owned' : ''}`;
+}
+
+/**
+ * Every sibling after an element, in document order.
+ * @param element - The anchor
+ * @returns One description per following sibling
+ */
+function siblingsAfter(element: Element): string[] {
+  const found: string[] = [];
+  for (let node = element.nextElementSibling; node !== null; node = node.nextElementSibling) {
+    found.push(describeNode(node));
+  }
+  return found;
+}
+
+/** The part of a trace this file reads. */
+interface Reporting {
+  getAllOriginalElements: () => SVGElement[];
+}
+
+/**
+ * The ids of the chart's own elements a trace reports as its originals.
+ * @param trace - The trace
+ * @returns One id per reported element, in the order reported
+ */
+function originalIds(trace: Reporting): string[] {
+  return trace.getAllOriginalElements().map(element => element.getAttribute('id') ?? '?');
+}
+
+const POINT: BoxPoint = {
+  z: 'a',
+  lowerOutliers: [],
+  min: 2,
+  q1: 4,
+  q2: 5,
+  q3: 6,
+  max: 8,
+  upperOutliers: [],
+};
+
+/**
+ * A one-box vertical layer with the given selectors.
+ * @param type - The trace type
+ * @param selector - The box's selectors
+ * @returns The layer
+ */
+function layer(type: TraceType, selector: BoxSelector): MaidrLayer {
+  return {
+    id: 'shared-anchor',
+    type,
+    title: 'A box',
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    selectors: [selector],
+    data: [POINT],
+  } as MaidrLayer;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = `<svg xmlns="${SVG_NS}"></svg>`;
+  Object.defineProperty(SVGElement.prototype, 'getBBox', {
+    value(this: SVGElement) {
+      return (this as unknown as { bBox?: DOMRect }).bBox
+        ?? { x: 0, y: 0, width: 2, height: 4 } as DOMRect;
+    },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(SVGElement.prototype, 'getBBox');
+  document.body.innerHTML = '';
+});
+
+describe('a victory box, whose `iq` and `q1` are one element', () => {
+  beforeEach(() => {
+    place('path', 'min0', { x: 15, y: 90, width: 10, height: 0 });
+    place('path', 'q1_0', { x: 10, y: 40, width: 20, height: 30 });
+    place('path', 'q3_0', { x: 10, y: 40, width: 20, height: 0 });
+    place('path', 'q2_0', { x: 10, y: 55, width: 20, height: 0 });
+    place('path', 'max0', { x: 15, y: 10, width: 10, height: 0 });
+  });
+
+  /**
+   * @returns A trace over the placed elements
+   */
+  function build(): BoxTrace {
+    return new BoxTrace(layer(TraceType.BOX, {
+      lowerOutliers: [],
+      upperOutliers: [],
+      min: '#min0',
+      max: '#max0',
+      // The shared element: `iq` and `q1` name the same `<path>`.
+      iq: '#q1_0',
+      q1: '#q1_0',
+      q3: '#q3_0',
+      q2: '#q2_0',
+    }));
+  }
+
+  test('leaves its whiskers between the shared element and the q1 clone', () => {
+    const trace = build();
+
+    // The upper cap's whisker, then the lower cap's, then the clone: the
+    // order repeated `insertAdjacentElement(afterend)` left behind.
+    expect(siblingsAfter(document.getElementById('q1_0')!).slice(0, 3)).toEqual([
+      'line#y1=10 owned',
+      'line#y1=90 owned',
+      'path#q1_0 owned',
+    ]);
+
+    trace.dispose();
+  });
+
+  test('does not report the shared element as an original', () => {
+    const trace = build();
+
+    // The q1 clone's previous sibling is a whisker, so it pairs with nothing
+    // and `#q1_0` is not recoloured in high contrast.
+    expect(originalIds(trace)).toEqual(['min0', 'q2_0', 'q3_0', 'max0']);
+
+    trace.dispose();
+  });
+});
+
+describe('a plotly violin box, drawn as one element', () => {
+  beforeEach(() => {
+    place('path', 'box0', { x: 10, y: 40, width: 20, height: 30 });
+  });
+
+  /**
+   * The whole box is one `<path>`: no cap sits outside it, so it has no
+   * whiskers, and with no `q1`/`q3` selectors both quartile edges are derived
+   * from it.
+   * @returns The selector
+   */
+  function selector(): BoxSelector {
+    return {
+      lowerOutliers: [],
+      upperOutliers: [],
+      min: '#box0',
+      max: '#box0',
+      iq: '#box0',
+      q2: '#box0',
+    };
+  }
+
+  test.each([
+    ['box', (): BoxTrace => new BoxTrace(layer(TraceType.BOX, selector()))],
+    ['violin box', (): ViolinBoxTrace => new ViolinBoxTrace(layer(TraceType.VIOLIN_BOX, selector()))],
+  ])('leaves a %s\'s derived edges between the element and its clones', (_name, make) => {
+    const trace = make();
+
+    // q3 (the box's top edge) and q1 (its bottom edge) first, then the
+    // clones, which were inserted before the edges were.
+    expect(siblingsAfter(document.getElementById('box0')!)).toEqual([
+      'line#y1=40 owned',
+      'line#y1=70 owned',
+      'path#box0 owned',
+      'path#box0 owned',
+      'path#box0 owned',
+    ]);
+    // Every clone's previous sibling is a derived line or another clone, so
+    // the box is reported no differently than a box drawn as five elements.
+    expect(originalIds(trace)).toEqual([]);
+
+    trace.dispose();
+  });
+});
+
+describe('a violin box whose median is drawn on the box itself', () => {
+  beforeEach(() => {
+    place('path', 'vlow0', { x: 15, y: 90, width: 10, height: 0 });
+    place('path', 'vb0', { x: 10, y: 40, width: 20, height: 30 });
+    place('path', 'vhigh0', { x: 15, y: 10, width: 10, height: 0 });
+  });
+
+  /**
+   * @returns A trace whose `iq` and `q2` are one element, with both caps clear
+   *   of it so it has real whiskers as well as derived edges
+   */
+  function build(): ViolinBoxTrace {
+    return new ViolinBoxTrace(layer(TraceType.VIOLIN_BOX, {
+      lowerOutliers: [],
+      upperOutliers: [],
+      min: '#vlow0',
+      max: '#vhigh0',
+      iq: '#vb0',
+      q2: '#vb0',
+    }));
+  }
+
+  test('writes its whiskers and edges ahead of the median clone', () => {
+    const trace = build();
+
+    // Sliced: the chart's own upper cap and its clone follow these.
+    expect(siblingsAfter(document.getElementById('vb0')!).slice(0, 5)).toEqual([
+      'line#y1=10 owned',
+      'line#y1=90 owned',
+      'line#y1=40 owned',
+      'line#y1=70 owned',
+      'path#vb0 owned',
+    ]);
+
+    trace.dispose();
+  });
+
+  test('reports only the caps as originals', () => {
+    const trace = build();
+
+    expect(originalIds(trace)).toEqual(['vlow0', 'vhigh0']);
+
+    trace.dispose();
+  });
+});

--- a/test/util/derivedLineBatching.test.ts
+++ b/test/util/derivedLineBatching.test.ts
@@ -1,0 +1,348 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Derived lines are measured before any of them is inserted.
+ *
+ * A candlestick draws its open and close edges along the body, and a box plot
+ * draws its quartile edges along the box and a whisker out to each cap. Each
+ * of those cost a `getBBox` -- and, for an edge, a `getComputedStyle` -- on an
+ * element that had just had a sibling inserted next to it, so the browser had
+ * to lay the chart out again before every single one. `Svg.createLineElements`
+ * and `Svg.createWhiskerElements` read the whole batch first, build from the
+ * numbers, and then write once per anchor.
+ *
+ * The DOM order those writes leave behind is load-bearing rather than
+ * cosmetic: `HighlightService` hands these lines to `Svg.createHighlightElement`,
+ * which inserts a *visible* clone directly after the line it highlights, so
+ * where the line sits among its siblings is the order the reader sees the
+ * highlight painted in. The batch must therefore insert with `anchor.after()`
+ * -- appending to the anchor's parent, as `Svg.createCircleElements` does,
+ * would move every highlight above the chart marks drawn after it.
+ */
+
+import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { BoxTrace } from '@model/box';
+import { Candlestick } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface Event {
+  readonly kind: 'read' | 'write';
+  /** For a write, whether it put a `<line>` into the document. */
+  readonly line: boolean;
+  readonly what: string;
+}
+
+interface Recorder {
+  readonly events: Event[];
+  readonly restore: () => void;
+}
+
+/**
+ * Records every layout read and every DOM insertion, in order.
+ *
+ * `getBBox` answers from a box hung on the element itself, because jsdom lays
+ * nothing out and the geometry has to come from somewhere.
+ * @returns The log, and the teardown that unwires it
+ */
+function record(): Recorder {
+  const events: Event[] = [];
+  const originalStyle = window.getComputedStyle;
+  const originalInsert = Element.prototype.insertAdjacentElement;
+  const originalAfter = Element.prototype.after;
+
+  Object.defineProperty(SVGElement.prototype, 'getBBox', {
+    value(this: SVGElement) {
+      events.push({ kind: 'read', line: false, what: 'getBBox' });
+      return (this as unknown as { bBox?: DOMRect }).bBox
+        ?? { x: 0, y: 0, width: 2, height: 4 } as DOMRect;
+    },
+    configurable: true,
+    writable: true,
+  });
+  window.getComputedStyle = function (element: Element, pseudo?: string | null): CSSStyleDeclaration {
+    events.push({ kind: 'read', line: false, what: 'getComputedStyle' });
+    return originalStyle.call(window, element, pseudo);
+  } as typeof window.getComputedStyle;
+  Element.prototype.insertAdjacentElement = function (this: Element, position: InsertPosition, element: Element): Element | null {
+    events.push({ kind: 'write', line: element.tagName === 'line', what: 'insertAdjacentElement' });
+    return originalInsert.call(this, position, element);
+  };
+  Element.prototype.after = function (this: Element, ...nodes: (Node | string)[]): void {
+    events.push({
+      kind: 'write',
+      line: nodes.some(node => node instanceof Element && node.tagName === 'line'),
+      what: 'after',
+    });
+    originalAfter.apply(this, nodes);
+  };
+
+  return {
+    events,
+    restore: () => {
+      Reflect.deleteProperty(SVGElement.prototype, 'getBBox');
+      window.getComputedStyle = originalStyle;
+      Element.prototype.insertAdjacentElement = originalInsert;
+      Element.prototype.after = originalAfter;
+    },
+  };
+}
+
+/**
+ * How many reads were taken with a DOM write standing between them and the
+ * previous read -- the measurement the browser has to lay the chart out again
+ * to answer.
+ *
+ * One per batch is the floor, and what the batch buys: the reads of a batch
+ * are consecutive, so only its first can follow a write.
+ * @param events - The recorded log
+ * @returns The count
+ */
+function forcedLayouts(events: readonly Event[]): number {
+  let forced = 0;
+  let wrote = false;
+  for (const event of events) {
+    if (event.kind === 'write') {
+      wrote = true;
+    } else {
+      if (wrote) {
+        forced++;
+      }
+      wrote = false;
+    }
+  }
+  return forced;
+}
+
+/**
+ * How many times a given read was taken.
+ * @param events - The recorded log
+ * @param what - The read's name
+ * @returns The count
+ */
+function reads(events: readonly Event[], what: string): number {
+  return events.filter(event => event.kind === 'read' && event.what === what).length;
+}
+
+/**
+ * The unbroken run of `<line>` siblings directly after an element.
+ *
+ * A run rather than every following line, because that is the claim: the
+ * batch puts the lines it derives from this anchor immediately after it, the
+ * way inserting them one at a time did.
+ * @param element - The anchor
+ * @returns Their `y1` then `x1`, which is enough to tell the edges apart
+ */
+function linesAfter(element: Element): string[] {
+  const found: string[] = [];
+  for (let node = element.nextElementSibling; node !== null; node = node.nextElementSibling) {
+    if (node.tagName !== 'line') {
+      break;
+    }
+    found.push(`${node.getAttribute('y1')},${node.getAttribute('x1')}`);
+  }
+  return found;
+}
+
+const CANDLES = 5;
+
+describe('a candlestick deriving its edges', () => {
+  let recorder: Recorder;
+
+  beforeEach(() => {
+    document.body.innerHTML = `<svg xmlns="${SVG_NS}">${
+      '<rect class="body" x="0" y="0" width="2" height="4" />'.repeat(CANDLES)}</svg>`;
+    recorder = record();
+  });
+
+  afterEach(() => {
+    recorder.restore();
+    document.body.innerHTML = '';
+  });
+
+  /**
+   * Rising candles, so the close is the body's top edge and the open its
+   * bottom -- two lines per body, from the one body.
+   * @returns The layer
+   */
+  function layer(): MaidrLayer {
+    return {
+      id: 'candlestick',
+      type: TraceType.CANDLESTICK,
+      axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+      selectors: { body: '.body' },
+      data: Array.from({ length: CANDLES }, (_, i) => ({
+        value: `d${i}`,
+        open: 10,
+        high: 15,
+        low: 9,
+        close: 14,
+        volume: 1,
+        volatility: 6,
+      })),
+    } as MaidrLayer;
+  }
+
+  test('measures each body once, before any edge is inserted', () => {
+    const trace = new Candlestick(layer());
+
+    // One read of each kind per body, not one per edge.
+    expect(reads(recorder.events, 'getBBox')).toBe(CANDLES);
+    expect(reads(recorder.events, 'getComputedStyle')).toBe(CANDLES);
+    // One, for the batch as a whole: the hidden body clones are already in
+    // the document when it starts reading. Drawing an edge at a time cost one
+    // per edge.
+    expect(forcedLayouts(recorder.events)).toBe(1);
+
+    trace.dispose();
+  });
+
+  test('leaves each body followed by its close edge and then its open edge', () => {
+    const trace = new Candlestick(layer());
+
+    // The chart's own bodies; `collectElements` cloned each one beside it.
+    const bodies = [...document.querySelectorAll('rect.body:not([data-maidr-owned])')];
+    expect(bodies).toHaveLength(CANDLES);
+    for (const body of bodies) {
+      // The clone `collectElements` made sits between the chart's own body
+      // and the edges, which anchor on the clone.
+      const clone = body.nextElementSibling!;
+      expect(clone.tagName).toBe('rect');
+      // Top edge (close, y1 = 0) before bottom edge (open, y1 = 4), which is
+      // the order inserting one at a time after the same anchor produced.
+      expect(linesAfter(clone)).toEqual(['0,0', '4,0']);
+      // Directly after the anchor: not appended to the parent.
+      expect(clone.nextElementSibling?.tagName).toBe('line');
+    }
+
+    trace.dispose();
+  });
+});
+
+const BOXES = 3;
+
+describe('a box plot deriving its quartile edges and whiskers', () => {
+  let recorder: Recorder;
+
+  /**
+   * Puts an element in the chart with the box the chart would have laid out.
+   * @param tag - The SVG tag
+   * @param id - Its id, which the selector names
+   * @param bBox - What `getBBox` reports
+   * @param bBox.x - Its left edge
+   * @param bBox.y - Its top edge
+   * @param bBox.width - Its width
+   * @param bBox.height - Its height
+   */
+  function place(tag: string, id: string, bBox: { x: number; y: number; width: number; height: number }): void {
+    const element = document.createElementNS(SVG_NS, tag);
+    element.setAttribute('id', id);
+    (element as unknown as { bBox: unknown }).bBox = bBox;
+    document.querySelector('svg')!.appendChild(element);
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = `<svg xmlns="${SVG_NS}"></svg>`;
+    for (let i = 0; i < BOXES; i++) {
+      place('path', `box${i}`, { x: 10, y: 40, width: 20, height: 30 });
+      place('path', `median${i}`, { x: 10, y: 55, width: 20, height: 0 });
+      place('path', `low${i}`, { x: 15, y: 90, width: 10, height: 0 });
+      place('path', `high${i}`, { x: 15, y: 10, width: 10, height: 0 });
+    }
+    recorder = record();
+  });
+
+  afterEach(() => {
+    recorder.restore();
+    document.body.innerHTML = '';
+  });
+
+  /**
+   * Vertical boxes with both caps clear of the body, so every whisker is real.
+   * @returns The layer
+   */
+  function layer(): MaidrLayer {
+    const selectors: BoxSelector[] = Array.from({ length: BOXES }, (_, i) => ({
+      lowerOutliers: [],
+      upperOutliers: [],
+      min: `#low${i}`,
+      iq: `#box${i}`,
+      q2: `#median${i}`,
+      max: `#high${i}`,
+    }));
+    const point: BoxPoint = {
+      z: 'a',
+      lowerOutliers: [],
+      min: 2,
+      q1: 4,
+      q2: 5,
+      q3: 6,
+      max: 8,
+      upperOutliers: [],
+    };
+    return {
+      id: 'box',
+      type: TraceType.BOX,
+      title: 'A box',
+      orientation: Orientation.VERTICAL,
+      axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+      selectors,
+      data: Array.from({ length: BOXES }, () => point),
+    } as MaidrLayer;
+  }
+
+  test('measures each element once per batch, before any line is inserted', () => {
+    const trace = new BoxTrace(layer());
+
+    // The edge batch reads each box; the whisker batch reads each box and
+    // both its caps. Four reads per box, where a box was read four times over
+    // by itself before.
+    expect(reads(recorder.events, 'getBBox')).toBe(BOXES * 4);
+    // One style read per box, for both its edges.
+    expect(reads(recorder.events, 'getComputedStyle')).toBe(BOXES);
+    // One, for the whisker batch, whose reads follow the edge batch's writes.
+    // The edge batch itself reads before anything has been inserted at all.
+    // Drawing a box at a time cost four per box.
+    expect(forcedLayouts(recorder.events)).toBe(1);
+
+    trace.dispose();
+  });
+
+  test('leaves each box followed by its whiskers and then its quartile edges', () => {
+    const trace = new BoxTrace(layer());
+
+    for (let i = 0; i < BOXES; i++) {
+      const box = document.getElementById(`box${i}`)!;
+      expect(linesAfter(box)).toEqual([
+        // The upper cap's whisker, then the lower cap's: the order repeated
+        // `insertAdjacentElement(afterend)` left behind.
+        '10,20',
+        '90,20',
+        // Then q3 (the box's top edge) and q1 (its bottom edge).
+        '40,10',
+        '70,10',
+      ]);
+      // Directly after the box: not appended to the parent.
+      expect(box.nextElementSibling?.tagName).toBe('line');
+    }
+
+    trace.dispose();
+  });
+
+  test('still reports the whiskers to a renderer, lower cap first', () => {
+    const trace = new BoxTrace(layer());
+
+    const whiskers = trace
+      .getGeometryElements()
+      .filter(element => element.tagName === 'line');
+
+    expect(whiskers).toHaveLength(BOXES * 2);
+    expect(whiskers.slice(0, 2).map(w => w.getAttribute('y1'))).toEqual(['90', '10']);
+
+    trace.dispose();
+  });
+});

--- a/test/util/derivedLineBatching.test.ts
+++ b/test/util/derivedLineBatching.test.ts
@@ -9,17 +9,20 @@
  * draws its quartile edges along the box and a whisker out to each cap. Each
  * of those cost a `getBBox` -- and, for an edge, a `getComputedStyle` -- on an
  * element that had just had a sibling inserted next to it, so the browser had
- * to lay the chart out again before every single one. `Svg.createLineElements`
- * and `Svg.createWhiskerElements` read the whole batch first, build from the
- * numbers, and then write once per anchor.
+ * to lay the chart out again before every single one. `Svg.buildLineElements`
+ * and `Svg.buildWhiskerElements` read the whole batch first and build from the
+ * numbers; the caller then inserts them, where it always did.
  *
  * The DOM order those writes leave behind is load-bearing rather than
  * cosmetic: `HighlightService` hands these lines to `Svg.createHighlightElement`,
  * which inserts a *visible* clone directly after the line it highlights, so
  * where the line sits among its siblings is the order the reader sees the
- * highlight painted in. The batch must therefore insert with `anchor.after()`
- * -- appending to the anchor's parent, as `Svg.createCircleElements` does,
- * would move every highlight above the chart marks drawn after it.
+ * highlight painted in. `Svg.insertDerived` therefore puts each line directly
+ * after its anchor -- appending to the anchor's parent, as
+ * `Svg.createCircleElements` does, would move every highlight above the chart
+ * marks drawn after it -- and the caller calls it at the point in its own
+ * writes where the one-at-a-time code inserted, which
+ * `test/model/sharedAnchorWrites.test.ts` pins.
  */
 
 import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
@@ -97,8 +100,9 @@ function record(): Recorder {
  * previous read -- the measurement the browser has to lay the chart out again
  * to answer.
  *
- * One per batch is the floor, and what the batch buys: the reads of a batch
- * are consecutive, so only its first can follow a write.
+ * One per batch is the ceiling, and what the batch buys: the reads of a batch
+ * are consecutive, so only its first can follow a write, and none does when
+ * nothing has been inserted before it.
  * @param events - The recorded log
  * @returns The count
  */
@@ -304,10 +308,10 @@ describe('a box plot deriving its quartile edges and whiskers', () => {
     expect(reads(recorder.events, 'getBBox')).toBe(BOXES * 4);
     // One style read per box, for both its edges.
     expect(reads(recorder.events, 'getComputedStyle')).toBe(BOXES);
-    // One, for the whisker batch, whose reads follow the edge batch's writes.
-    // The edge batch itself reads before anything has been inserted at all.
+    // None: both batches only measure and build, and Phase 2 does every
+    // insertion afterwards, so no write stands between any two reads.
     // Drawing a box at a time cost four per box.
-    expect(forcedLayouts(recorder.events)).toBe(1);
+    expect(forcedLayouts(recorder.events)).toBe(0);
 
     trace.dispose();
   });


### PR DESCRIPTION
# Pull Request

## Description

Two construction-cost fixes for candlestick, box and violin-box, plus the fix for a regression the first attempt at the second one introduced — which is the part worth reading.

`Svg.createLineElement` and `Svg.createWhiskerElement` each read geometry (`getBBox`, `getComputedStyle`) and then immediately insert the element they built. Called in a loop — twice per candle, six times per box — every read after the first sits behind a DOM write, so each one is a forced synchronous layout. Separately, `CandlestickTrace.mapToSvgElements` pre-filled arrays with placeholder SVG elements that the very next loop overwrote.

Measured per construction (jsdom, spies on `getBBox`, `getComputedStyle`, `createElementNS`, `insertAdjacentElement`; "forced layout" = a read with a write between it and the previous read):

| | before | after |
|---|---|---|
| Candlestick 200 candles — `getBBox` | 400 | 200 |
| Candlestick 200 candles — `getComputedStyle` | 400 | 200 |
| Candlestick 200 candles — forced layouts | 400 | 1 |
| Box 30 distributions — `getBBox` / `getComputedStyle` | 180 / 60 | 120 / 30 |
| Box 30 distributions — forced layouts | 120 | 1 |
| Violin-box 30 — forced layouts | 120 | 1 |
| Candlestick placeholders (`createEmptyElement`), 200 candles | 1800 | 0 |
| …with selectors matching nothing | 2800 | 1000 (one genuine fallback per cell) |

The unfixed 400 for 200 candles is exactly 2N, which confirms the original finding's "up to 2N" is exact. Construction is not a one-off: the controller rebuilds the figure on every live-data append.

## Related Issues

None.

## Changes Made

- **`src/util/svg.ts`** — `createLineElement`/`createWhiskerElement` become `buildLineElements`/`buildWhiskerElements`, which do a READ pass (memoised per anchor) and a BUILD pass and return marked-owned but **detached** nodes. A new `Svg.insertDerived(anchor, ...nodes)` performs the write, one `insertAdjacentElement('afterend', node)` per node in creation order — byte-for-byte what the old per-call code did.
- **`src/model/box.ts`, `src/model/violinBox.ts`** — measure and build up front; insert the derived edges at the exact point in the existing phase where `createLineElement` used to stand, and the whiskers inside `offerGeometry` in `[min, max]` order.
- **`src/model/candlestick.ts`** — same split; and the placeholder pre-fills are gone, since every cell is written by the loop below.
- Comment-only reference updates in two adapters and one doc so nothing names a method that no longer exists.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**A regression was found in review and fixed; this is the part to check.** The first version of the batching also moved the *writes*, grouping them into one `anchor.after(...)` per anchor. That is not equivalent when one DOM element serves as more than one box part, and two shipped adapters emit exactly that:

- `src/adapters/victory/selectors.ts:676-677` emits `iq: sel('q1')` **and** `q1: sel('q1')` — one node. Its own comment, "harmless: direct q1/q3 below bypass iq-edge derivation", is precisely the assumption that stopped holding.
- `src/adapters/plotly/extractor.ts:3108-3115` gives a violin box `min`, `iq`, `q2` and `max` all as one `<path>`.

Batching moved the derived lines to before the clones instead of between the anchor and the clones. That flips `previousElementSibling`, which `AbstractTrace.getAllOriginalElements()` uses to pair a hidden clone back to its visible original — and that set is the sole input to `HighContrastService.getAllTraceElements()`, which drives high-contrast recolouring and pattern assignment. Measured on the Victory shape: `getAllOriginalElements()` went from `[min0, q2_0, q3_0, max0]` to `[min0, q1_0, q2_0, q3_0, max0]`, so a low-vision reader's palette was re-derived over a different set. **No existing test caught it** — the full unit suite passed on both sides.

The fix keeps the batched reads, which is where the entire forced-layout win comes from, and restores the write positions. A differential across 28 trace shapes — full `svg.outerHTML`, `getAllOriginalElements()`, `getAllHighlightElements()`, `getGeometryElements()`, and the post-dispose DOM — is now **byte-identical to `main`**, while the pre-fix commit differs on 18 of them. The read counts in the table above are unchanged by the fix.

**`getGeometryElements()` order is preserved** — whiskers still reported lower-cap-first, pinned by the untouched `test/model/boxGeometry.test.ts` and by a new explicit case, because that order feeds the tactile display.

**The placeholder removal rests on an invariant**, verified structurally rather than by sampling: `precomputeSortedSegments` returns `['volatility', ...ohlc]` with four OHLC entries when `hasOpen` and three otherwise, and `candlestickSectionsOf` returns 5 or 4 off the same flag — so a candle's navigation order always has exactly as many entries as the chart has rows. The new test asserts **every cell is defined**, not merely that the allocation count dropped, across nine configurations including N=0 and N=1.

**Not done here, deliberately:** the adjacent pre-existing defect where `collectElements` clones before later selectors resolve (#1004). It is a separate bug and widening this PR to it would mix two changes.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (539 suites, 7003 tests) and the esm project under `--experimental-vm-modules` (15 suites, 177 tests), both clean. I also confirmed the six `sharedAnchorWrites` cases fail on the pre-fix commit and pass on the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_