### PR TITLE
perf(model): leave pointer-hover centres for the first hover in five more traces

### DIFF
--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -72,8 +72,13 @@ export class BoxTrace extends AbstractTrace {
    * however far the chart moved, and the guidance beep points at a section
    * that is no longer there. Rebuilding on the next hover rather than on the
    * event keeps a scroll itself free of layout reads.
+   *
+   * It starts stale, so the first hover measures rather than the constructor.
+   * Measuring there is a forced layout right after the writes that inserted
+   * the marks, once per trace, before the first announcement -- and a
+   * keyboard reader, who is the primary audience, never asks the question.
    */
-  private highlightCentersDirty = false;
+  private highlightCentersDirty = true;
 
   private readonly stopViewportWatch = watchViewport((): void => {
     this.highlightCentersDirty = true;
@@ -143,7 +148,10 @@ export class BoxTrace extends AbstractTrace {
       this.highlightValues?.reverse();
     }
 
-    this.highlightCenters = this.mapSvgElementsToCenters();
+    // Left for the first hover to measure. `highlightCentersDirty` starts
+    // true, so findNearestPoint builds them the same way it does after a
+    // scroll.
+    this.highlightCenters = null;
     this.movable = new MovableGrid<number[] | number>(this.boxValues, { row: 0 });
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -166,8 +166,13 @@ export class Candlestick extends AbstractTrace {
    * however far the chart moved, and a hover resolves to a candle that is no
    * longer there. Rebuilding on the next hover rather than on the event keeps
    * a scroll itself free of layout reads.
+   *
+   * It starts stale, so the first hover measures rather than the constructor.
+   * Measuring there is a forced layout right after the writes that inserted
+   * the marks, once per trace, before the first announcement -- and a
+   * keyboard reader, who is the primary audience, never asks the question.
    */
-  private highlightCentersDirty = false;
+  private highlightCentersDirty = true;
 
   private readonly stopViewportWatch = watchViewport((): void => {
     this.highlightCentersDirty = true;
@@ -260,7 +265,10 @@ export class Candlestick extends AbstractTrace {
     this.highlightValues = this.mapToSvgElements(
       layer.selectors as string | string[] | CandlestickSelector | undefined,
     );
-    this.highlightCenters = this.mapSvgElementsToCenters();
+    // Left for the first hover to measure. `highlightCentersDirty` starts
+    // true, so findNearestPoint builds them the same way it does after a
+    // scroll.
+    this.highlightCenters = null;
   }
 
   /**

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -68,8 +68,13 @@ export class Heatmap extends AbstractTrace {
    * however far the chart moved, and a hover resolves to a cell that is no
    * longer there. Rebuilding on the next hover rather than on the event keeps
    * a scroll itself free of layout reads.
+   *
+   * It starts stale, so the first hover measures rather than the constructor.
+   * Measuring there is a forced layout right after the writes that inserted
+   * the marks, once per trace, before the first announcement -- and a
+   * keyboard reader, who is the primary audience, never asks the question.
    */
-  private highlightCentersDirty = false;
+  private highlightCentersDirty = true;
 
   private readonly stopViewportWatch = watchViewport((): void => {
     this.highlightCentersDirty = true;
@@ -106,7 +111,10 @@ export class Heatmap extends AbstractTrace {
     this.highlightValues = this.mapToSvgElements(
       layer.selectors as string | (string | null)[][] | undefined,
     );
-    this.highlightCenters = this.mapSvgElementsToCenters();
+    // Left for the first hover to measure. `highlightCentersDirty` starts
+    // true, so findNearestPoint builds them the same way it does after a
+    // scroll.
+    this.highlightCenters = null;
     this.movable = new MovableGrid<number>(this.heatmapValues);
   }
 

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -61,8 +61,13 @@ export class ViolinKdeTrace extends AbstractTrace {
    * however far the chart moved, and a hover resolves to a point that is no
    * longer there. Rebuilding on the next hover rather than on the event keeps
    * a scroll itself free of layout reads.
+   *
+   * It starts stale, so the first hover measures rather than the constructor.
+   * Measuring there is a forced layout right after the writes that inserted
+   * the marks, once per trace, before the first announcement -- and a
+   * keyboard reader, who is the primary audience, never asks the question.
    */
-  private highlightCentersDirty = false;
+  private highlightCentersDirty = true;
 
   private readonly stopViewportWatch = watchViewport((): void => {
     this.highlightCentersDirty = true;
@@ -141,7 +146,10 @@ export class ViolinKdeTrace extends AbstractTrace {
       ? [...selectors].reverse()
       : selectors;
     this.highlightValues = this.mapToSvgElements(kdeSelectors);
-    this.highlightCenters = this.mapSvgElementsToCenters();
+    // Left for the first hover to measure. `highlightCentersDirty` starts
+    // true, so findNearestPoint builds them the same way it does after a
+    // scroll.
+    this.highlightCenters = null;
     this.movable = new MovableGrid<ViolinKdePoint>(this.points, { row: 0 });
   }
 

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -58,8 +58,13 @@ export class ViolinBoxTrace extends AbstractTrace {
    * however far the chart moved, and the guidance beep points at a section
    * that is no longer there. Rebuilding on the next hover rather than on the
    * event keeps a scroll itself free of layout reads.
+   *
+   * It starts stale, so the first hover measures rather than the constructor.
+   * Measuring there is a forced layout right after the writes that inserted
+   * the marks, once per trace, before the first announcement -- and a
+   * keyboard reader, who is the primary audience, never asks the question.
    */
-  private highlightCentersDirty = false;
+  private highlightCentersDirty = true;
 
   private readonly stopViewportWatch = watchViewport((): void => {
     this.highlightCentersDirty = true;
@@ -107,7 +112,10 @@ export class ViolinBoxTrace extends AbstractTrace {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.highlightValues?.reverse();
     }
-    this.highlightCenters = this.mapSvgElementsToCenters();
+    // Left for the first hover to measure. `highlightCentersDirty` starts
+    // true, so findNearestPoint builds them the same way it does after a
+    // scroll.
+    this.highlightCenters = null;
 
     this.movable = new MovableGrid<number[] | number>(this.boxValues, { row: 0 });
 

--- a/test/model/lazyHighlightCenters.test.ts
+++ b/test/model/lazyHighlightCenters.test.ts
@@ -13,17 +13,38 @@
  * and never needs the answer; a live-data chart pays it again on every
  * append, because the controller rebuilds the figure.
  *
- * Both traces already knew how to build the centres late: they mark the
- * cache stale on scroll and resize and rebuild it inside `findNearestPoint`.
+ * Every trace here already knew how to build the centres late: it marks the
+ * cache stale on scroll and resize and rebuilds it inside `findNearestPoint`.
  * These pin that the constructor now leaves it stale rather than filling it,
- * and that a hover still lands on the right point.
+ * and that a hover still lands on the same mark it used to.
+ *
+ * Leaving the cache empty is only safe because `findNearestPoint` is the one
+ * thing that reads it. It is, for all seven: `isPointInBounds` measures the
+ * element it is handed rather than the cache, `getGeometryElements` answers
+ * from the separate `geometry` field the tactile display consumes, and the
+ * audio, text, braille and highlight accessors never touch it. A reader who
+ * only ever presses arrow keys now pays nothing for pointer geometry.
  */
 
-import type { LinePoint, MaidrLayer, ScatterPoint } from '@type/grammar';
+import type {
+  BoxPoint,
+  BoxSelector,
+  CandlestickPoint,
+  HeatmapData,
+  LinePoint,
+  MaidrLayer,
+  ScatterPoint,
+  ViolinKdePoint,
+} from '@type/grammar';
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { BoxTrace } from '@model/box';
+import { Candlestick } from '@model/candlestick';
+import { Heatmap } from '@model/heatmap';
 import { LineTrace } from '@model/line';
 import { ScatterTrace } from '@model/scatter';
-import { TraceType } from '@type/grammar';
+import { ViolinKdeTrace } from '@model/violin';
+import { ViolinBoxTrace } from '@model/violinBox';
+import { Orientation, TraceType } from '@type/grammar';
 
 const MARK = '.mark';
 
@@ -80,7 +101,12 @@ function layOutMarks(): jest.SpiedFunction<() => DOMRect> {
   return jest
     .spyOn(Element.prototype, 'getBoundingClientRect')
     .mockImplementation(function (this: Element): DOMRect {
-      const at = Number(this.id.replace(/\D/g, '') || 0) * 10;
+      // A violin's marks are circles the trace itself creates, which carry a
+      // centre but no id, so read `cx` first and fall back to the id.
+      const cx = this.getAttribute('cx');
+      const at = cx !== null
+        ? Number(cx)
+        : Number(this.id.replace(/\D/g, '') || 0) * 10;
       return { x: at, y: at, width: 2, height: 2 } as DOMRect;
     });
 }
@@ -148,6 +174,288 @@ describe('when a trace measures its pointer-hover centres', () => {
     const nearest = trace.findNearestPoint(1, 1);
 
     expect(nearest?.col).toBe(0);
+    expect(layout).toHaveBeenCalled();
+  });
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Draw `count` paths, each addressable through {@link MARK}.
+ *
+ * Paths rather than the circles {@link draw} makes, because a violin picks
+ * its geometry by element kind. Each one is also given the `getBBox` jsdom
+ * does not implement, which is what a box derives its whiskers from.
+ * @param count - How many marks the chart drew
+ */
+function drawPaths(count: number): void {
+  const marks = Array.from(
+    { length: count },
+    (_, i) => `<path class="mark" id="m${i}" />`,
+  );
+  document.body.innerHTML = `<svg xmlns="${SVG_NS}">${marks.join('')}</svg>`;
+  document.querySelectorAll(MARK).forEach((mark) => {
+    Object.defineProperty(mark, 'getBBox', {
+      value: () => ({ x: 0, y: 0, width: 2, height: 2 }),
+      configurable: true,
+    });
+  });
+}
+
+/**
+ * Wire the SVG element kinds a violin branches on. jsdom exposes none of
+ * them, so `SVGPathElement` is aliased to `SVGElement` for the marks
+ * {@link drawPaths} makes to match, and the two the violin prefers ahead of
+ * it are stubs nothing can be an instance of.
+ */
+function installSvgKinds(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.SVGUseElement = class SVGUseElementStub {};
+  g.SVGPolygonElement = class SVGPolygonElementStub {};
+  g.SVGPathElement = (globalThis as unknown as { SVGElement: unknown }).SVGElement;
+}
+
+/**
+ * Undo {@link installSvgKinds}.
+ */
+function uninstallSvgKinds(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.SVGUseElement;
+  delete g.SVGPolygonElement;
+  delete g.SVGPathElement;
+}
+
+/**
+ * A heatmap layer addressing its cells one by one, the shape an adapter that
+ * stamps coordinates onto cells emits — and the shape a calendar needs, since
+ * only a per-cell grid can carry a hole.
+ * @param rows - How many rows the grid has
+ * @param cols - How many columns the grid has
+ * @returns The layer
+ */
+function heatmapLayer(rows: number, cols: number): MaidrLayer {
+  const data: HeatmapData = {
+    x: Array.from({ length: cols }, (_, c) => `x${c}`),
+    y: Array.from({ length: rows }, (_, r) => `y${r}`),
+    points: Array.from({ length: rows }, (_, r) =>
+      Array.from({ length: cols }, (_, c) => r * cols + c)),
+  };
+  return {
+    id: 'cells',
+    type: TraceType.HEATMAP,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    selectors: Array.from({ length: rows }, (_, r) =>
+      Array.from({ length: cols }, (_, c) => `#m${r * cols + c}`)),
+    data,
+  };
+}
+
+/** One box's summary statistics, drawn by the first four marks. */
+const BOX_POINT: BoxPoint = {
+  z: 'a',
+  lowerOutliers: [],
+  min: 2,
+  q1: 4,
+  q2: 5,
+  q3: 6,
+  max: 8,
+  upperOutliers: [],
+};
+
+/** The sections of {@link BOX_POINT}, each on its own mark. */
+const BOX_SELECTOR: BoxSelector[] = [{
+  lowerOutliers: [],
+  min: '#m0',
+  iq: '#m1',
+  q2: '#m2',
+  max: '#m3',
+  upperOutliers: [],
+}];
+
+/**
+ * A box or violin-box layer over {@link BOX_POINT}.
+ * @param type - Which of the two traces the layer is for
+ * @returns The layer
+ */
+function boxLayer(type: TraceType.BOX | TraceType.VIOLIN_BOX): MaidrLayer {
+  return {
+    id: 'boxes',
+    type,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    selectors: BOX_SELECTOR,
+    data: [BOX_POINT],
+  } as MaidrLayer;
+}
+
+/**
+ * A two-violin KDE layer whose points carry the SVG coordinates the trace
+ * draws its own marks at.
+ * @returns The layer
+ */
+function violinLayer(): MaidrLayer {
+  const curves = [
+    [
+      { x: 'a', y: 1, density: 0.2, svg_x: 0, svg_y: 0 },
+      { x: 'a', y: 2, density: 0.8, svg_x: 10, svg_y: 10 },
+    ],
+    [
+      { x: 'b', y: 3, density: 0.5, svg_x: 20, svg_y: 20 },
+      { x: 'b', y: 4, density: 0.3, svg_x: 30, svg_y: 30 },
+    ],
+  ] as ViolinKdePoint[][];
+  return {
+    id: 'curves',
+    type: TraceType.VIOLIN_KDE,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    selectors: ['#m0', '#m1'],
+    data: curves,
+  };
+}
+
+/**
+ * A four-candle layer, every segment of every candle on the marks the
+ * selector resolves to.
+ * @returns The layer
+ */
+function candlestickLayer(): MaidrLayer {
+  const candles = Array.from({ length: 4 }, (_, i) => ({
+    value: `d${i}`,
+    open: 100 + i,
+    high: 106 + i,
+    low: 95 + i,
+    close: 102 + i,
+    trend: 'Neutral',
+    volatility: 0,
+  })) as CandlestickPoint[];
+  return {
+    id: 'candles',
+    type: TraceType.CANDLESTICK,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    selectors: MARK,
+    data: candles,
+  };
+}
+
+describe('when a grid, box, violin or candle trace measures its centres', () => {
+  beforeEach(() => {
+    drawPaths(4);
+    installSvgKinds();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    uninstallSvgKinds();
+    document.body.innerHTML = '';
+  });
+
+  test('a heatmap reads no layout while it is being built', () => {
+    const layout = layOutMarks();
+
+    void new Heatmap(heatmapLayer(2, 2));
+
+    expect(layout).not.toHaveBeenCalled();
+  });
+
+  test('a heatmap still answers a hover with the cell under the pointer', () => {
+    const layout = layOutMarks();
+    const trace = new Heatmap(heatmapLayer(2, 2));
+
+    const nearest = trace.findNearestPoint(31, 31);
+
+    expect(nearest?.element.id).toBe('m3');
+    expect(layout).toHaveBeenCalled();
+  });
+
+  test('a calendar heatmap defers a cell measurement per day, not one', () => {
+    // 53 weeks by 7 weekdays: the shape that made this worth doing, and the
+    // count is the whole of it — every cell was measured before the reader
+    // heard anything, and again on every live-data rebuild.
+    const layout = layOutMarks();
+    drawPaths(53 * 7);
+
+    const trace = new Heatmap(heatmapLayer(7, 53));
+
+    expect(layout).not.toHaveBeenCalled();
+
+    trace.findNearestPoint(0, 0);
+
+    expect(layout).toHaveBeenCalledTimes(371);
+  });
+
+  test('a box reads no layout while it is being built', () => {
+    const layout = layOutMarks();
+
+    void new BoxTrace(boxLayer(TraceType.BOX));
+
+    expect(layout).not.toHaveBeenCalled();
+  });
+
+  test('a box still answers a hover with the section under the pointer', () => {
+    const layout = layOutMarks();
+    const trace = new BoxTrace(boxLayer(TraceType.BOX));
+
+    const nearest = trace.findNearestPoint(31, 31);
+
+    expect(nearest?.element.id).toBe('m3');
+    expect(layout).toHaveBeenCalled();
+  });
+
+  test('a violin box reads no layout while it is being built', () => {
+    const layout = layOutMarks();
+
+    void new ViolinBoxTrace(boxLayer(TraceType.VIOLIN_BOX));
+
+    expect(layout).not.toHaveBeenCalled();
+  });
+
+  test('a violin box still answers a hover with the section under the pointer', () => {
+    const layout = layOutMarks();
+    const trace = new ViolinBoxTrace(boxLayer(TraceType.VIOLIN_BOX));
+
+    const nearest = trace.findNearestPoint(31, 31);
+
+    expect(nearest?.element.id).toBe('m3');
+    expect(layout).toHaveBeenCalled();
+  });
+
+  test('a violin reads no layout while it is being built', () => {
+    const layout = layOutMarks();
+
+    void new ViolinKdeTrace(violinLayer());
+
+    expect(layout).not.toHaveBeenCalled();
+  });
+
+  test('a violin still answers a hover with the point under the pointer', () => {
+    const layout = layOutMarks();
+    const trace = new ViolinKdeTrace(violinLayer());
+
+    const nearest = trace.findNearestPoint(31, 31);
+
+    expect(nearest?.element.getAttribute('cx')).toBe('30');
+    expect(nearest?.row).toBe(1);
+    expect(nearest?.col).toBe(1);
+    expect(layout).toHaveBeenCalled();
+  });
+
+  test('a candlestick reads no layout while it is being built', () => {
+    const layout = layOutMarks();
+
+    void new Candlestick(candlestickLayer());
+
+    expect(layout).not.toHaveBeenCalled();
+  });
+
+  test('a candlestick still answers a hover with the candle under the pointer', () => {
+    const layout = layOutMarks();
+    const trace = new Candlestick(candlestickLayer());
+
+    const nearest = trace.findNearestPoint(31, 31);
+
+    expect(nearest?.element.id).toBe('m3');
     expect(layout).toHaveBeenCalled();
   });
 });

--- a/test/model/pointerCentersAfterScroll.test.ts
+++ b/test/model/pointerCentersAfterScroll.test.ts
@@ -7,9 +7,9 @@
  *
  * Heatmap, box, violin-box, violin-KDE and candlestick all measure their
  * marks once, on the first hover, and keep the result to answer later
- * `findNearestPoint` calls without measuring again. What they keep are
- * viewport* coordinates, and the pointer coordinates they are compared
- * against (`event.clientX` / `clientY`) are
+ * `findNearestPoint` calls without measuring again. What they keep are the
+ * coordinates *as the viewport saw them*, and the pointer coordinates they
+ * are compared against (`event.clientX` / `clientY`) are
  * always current -- so the moment the page, or a container the chart sits in,
  * scrolls under them, every centre is off by however far the chart moved. A
  * heatmap built below the fold and then scrolled into view resolved a hover

--- a/test/model/pointerCentersAfterScroll.test.ts
+++ b/test/model/pointerCentersAfterScroll.test.ts
@@ -8,8 +8,8 @@
  * Heatmap, box, violin-box, violin-KDE and candlestick all measure their
  * marks once, on the first hover, and keep the result to answer later
  * `findNearestPoint` calls without measuring again. What they keep are
- * viewport* coordinates, and the pointer
- * coordinates they are compared against (`event.clientX` / `clientY`) are
+ * viewport* coordinates, and the pointer coordinates they are compared
+ * against (`event.clientX` / `clientY`) are
  * always current -- so the moment the page, or a container the chart sits in,
  * scrolls under them, every centre is off by however far the chart moved. A
  * heatmap built below the fold and then scrolled into view resolved a hover

--- a/test/model/pointerCentersAfterScroll.test.ts
+++ b/test/model/pointerCentersAfterScroll.test.ts
@@ -6,8 +6,9 @@
  * Cached mark centres survive a scroll, and they must not.
  *
  * Heatmap, box, violin-box, violin-KDE and candlestick all measure their
- * marks once, in the constructor, and keep the result to answer
- * `findNearestPoint` without measuring again. What they keep are *viewport* coordinates, and the pointer
+ * marks once, on the first hover, and keep the result to answer later
+ * `findNearestPoint` calls without measuring again. What they keep are
+ * viewport* coordinates, and the pointer
  * coordinates they are compared against (`event.clientX` / `clientY`) are
  * always current -- so the moment the page, or a container the chart sits in,
  * scrolls under them, every centre is off by however far the chart moved. A
@@ -21,7 +22,9 @@
  *
  * The cost side is pinned by counting measurements rather than timing them:
  * a hover with nothing moved measures once, for the bounds check, whatever
- * the chart's size.
+ * the chart's size -- and building the trace measures nothing at all, since
+ * the cache starts stale and the first hover fills it by the same path a
+ * scroll uses. `lazyHighlightCenters.test.ts` covers that side.
  */
 
 import type {
@@ -317,22 +320,32 @@ describe.each(TRACES)('the pointer centres $name caches', ({ build }) => {
   });
 
   /**
-   * Builds the trace and reports how many marks it measured doing so, which
-   * is the size of the cache and therefore what a rebuild costs.
-   * @returns The trace and the number of marks behind it
+   * Builds the trace and pays the first hover, which is what fills the cache
+   * now that the constructor leaves it stale. Reports how many marks that
+   * measured, which is the size of the cache and therefore what a rebuild
+   * costs.
+   * @returns The trace, warmed, and the number of marks behind it
    */
   function built(): { trace: HoverTrace; marks: number } {
-    measure.mockClear();
     const trace = build();
-    const marks = measure.mock.calls.length;
+    measure.mockClear();
+    trace.moveToPointAndGetPointerGuidance(20, 20);
+    // Every mark, to fill the cache, and one more for the bounds check on
+    // the mark the hover resolved to.
+    const marks = measure.mock.calls.length - 1;
     measure.mockClear();
     return { trace, marks };
   }
 
-  test('are measured once while the trace is built', () => {
-    const { marks } = built();
+  test('are measured on the first hover, not while the trace is built', () => {
+    const built = measure.mock.calls.length;
+    const trace = build();
 
-    expect(marks).toBeGreaterThan(0);
+    const whileBuilding = measure.mock.calls.length - built;
+    trace.moveToPointAndGetPointerGuidance(20, 20);
+
+    expect(whileBuilding).toBe(0);
+    expect(measure.mock.calls.length).toBeGreaterThan(1);
   });
 
   test('answer a hover without measuring again while nothing has moved', () => {


### PR DESCRIPTION
# Pull Request

## Description

#1237 gave several traces a viewport-invalidation mechanism — a `highlightCentersDirty` flag, a `watchViewport` field that sets it, a rebuild inside `findNearestPoint`, and a release in `dispose()`. #1238 then used that mechanism in `line.ts` and `scatter.ts` to stop measuring in the constructor at all: the flag simply starts `true` and the cache starts `null`, so the first hover measures through the exact path a scroll already used.

#1238 left heatmap out, saying "Heatmap has the same eager call but no stale-marking machinery to reuse". That was already untrue when it was written — #1237 had merged first and had given heatmap exactly that machinery. The same is true of box, violin, violin-box and candlestick. This finishes the job.

Each eager call is one `getBoundingClientRect` per mark, and a layout read straight after the DOM writes that inserted those marks is a **forced synchronous layout**. Measured with a spy on `Element.prototype.getBoundingClientRect`, counting construction only:

| Trace | fixture | before | after |
|---|---|---|---|
| Heatmap | 53×7 calendar | **371** | 0 |
| Heatmap | 2×2 grid | 4 | 0 |
| Candlestick | 4 candles × 5 sections | 20 | 0 |
| Box | 1 box, 5 sections | 5 | 0 |
| Violin-box | 1 violin | 5 | 0 |
| Violin | 2 curves × 2 points | 4 | 0 |

Construction is not a one-off: the controller rebuilds the figure on every live-data append, so a calendar heatmap paid those 371 forced layouts again on each update — before the reader heard anything, for a question only a pointer asks.

## Related Issues

Finishes the work started in #1237 and #1238.

## Changes Made

- **`src/model/heatmap.ts`, `box.ts`, `violin.ts`, `violinBox.ts`, `candlestick.ts`** — `highlightCentersDirty` starts `true` and the constructor assigns `highlightCenters = null` instead of calling `mapSvgElementsToCenters()`. Twelve lines per trace, and no new mechanism: the first hover takes the branch a scroll already took.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**The one risk, checked per trace rather than assumed.** Deferring the build is only safe if `findNearestPoint` is the *only* reader of the cache — otherwise some earlier caller gets `null` where it used to get geometry. Verified across the whole of `src/`: in all five traces every read of `highlightCenters` sits inside the rebuild-then-scan block of `findNearestPoint` (heatmap 565-595, box 666-695, violin 731-760, violin-box 786-815, candlestick 1389-1419), plus the declaration and the constructor's `null`. Nothing outside the owning class touches it, and none of the five has a subclass. The tactile path reads the separate `geometry` field via `getGeometryElements()`, which this does not touch.

**The tests assert the resolved element, not only the call count.** A pure count test would pass if the function started returning the wrong mark quickly. For each of the five, the first hover after the change resolves to the same element it did before — heatmap, box, violin-box and candlestick all to `m3`, violin to row 1 col 1 at `cx="30"` — and the calendar case pins that the 371 reads simply move to the first hover rather than disappearing.

**Also confirmed per trace:** `dispose()` still releases the viewport watch; a trace nobody ever hovers performs zero `getBoundingClientRect` at construction; and the existing `pointerCentersAfterScroll` suite from #1237 still holds for all five.

**Nothing new is cached and nothing new needs invalidating** — this only changes *when* the existing cache is first filled, reusing the existing invalidation rule unchanged.

`npm run lint:fix` and `npm run type-check` pass. Tests were run as `npx jest --selectProjects unit --coverage=false` (536 suites, 6992 tests) and the esm project under `--experimental-vm-modules` (15 suites, 177 tests), both clean with `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJgnXfcaH1G9QZjadPNun)_