### PR TITLE
feat(ui): split the settings dialog into tabs

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -986,7 +986,8 @@ Users can set up multiline braille display support by following these steps:
 
 1. Open any plot in MAIDR.
 2. Press `Ctrl+,` (`Command+,` on macOS) to open the settings dialog.
-3. Press Tab to reach the Braille Display options.
+3. Press Tab to reach the list of settings tabs, then press Right Arrow until you hear "Braille & Tactile" and press Enter to open it.
+4. Press Tab to reach the Braille Display options.
 	- If your braille display model is listed, choose "Single line" or "Multi-line", then tab to the Single-Line Display or Multi-Line Display dropdown and select your braille display model.
 	- If your braille display model is not listed, choose "Configure manually", then enter Braille Display Size (cells per row) and Braille Display Lines (rows). Set the number of lines to 1 for a single-line display.
-4. Press `Alt+S` to save and close the settings dialog.
+5. Press `Alt+S` to save and close the settings dialog. It saves every tab, so you do not need to return to the one you started on.

--- a/e2e_tests/specs/dialogAccessibility.spec.ts
+++ b/e2e_tests/specs/dialogAccessibility.spec.ts
@@ -170,6 +170,38 @@ test.describe('dialog accessibility tree', () => {
     expect(structure.headings[0]).toBe('H2:Settings');
   });
 
+  // `docs/BRAILLE.md` tells blind readers exactly this sequence to reach the
+  // braille display options. It rests on manual activation — an arrow key
+  // moves focus, Enter selects — and on Enter reaching a `<button>` as a
+  // synthesised click, which jsdom does not model. So it is asserted here
+  // rather than in the component tests.
+  test('the settings tabs work by keyboard the way the docs describe', async ({ page }) => {
+    const barPlotPage = await setupBarPlotPage(page);
+    await barPlotPage.openSettingsMenu();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('tab', { name: 'General' })).toBeFocused();
+
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press('ArrowRight');
+    }
+    const brailleTab = page.getByRole('tab', { name: 'Braille & Tactile' });
+    await expect(brailleTab).toBeFocused();
+    // Arrowing past a tab must not open it: on the AI tab that would mean
+    // contacting a provider the reader was only passing over.
+    await expect(page.getByRole('tab', { name: 'General' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await page.keyboard.press('Enter');
+
+    await expect(brailleTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('tabpanel')).toHaveAccessibleName('Braille & Tactile');
+    // Focus stays on the tab, so the next arrow continues along the list.
+    await expect(brailleTab).toBeFocused();
+  });
+
   test('a select menu inside the settings dialog resolves by role', async ({ page }) => {
     const barPlotPage = await setupBarPlotPage(page);
     await barPlotPage.openSettingsMenu();

--- a/e2e_tests/specs/dialogAccessibility.spec.ts
+++ b/e2e_tests/specs/dialogAccessibility.spec.ts
@@ -174,6 +174,10 @@ test.describe('dialog accessibility tree', () => {
     const barPlotPage = await setupBarPlotPage(page);
     await barPlotPage.openSettingsMenu();
 
+    // The dialog opens on "General", which has no select at all; the tactile
+    // display picker is the first enabled one, on the tab beside it.
+    await page.getByRole('tab', { name: 'Braille & Tactile' }).click();
+
     // A Select's menu is a modal too, and it is nested deeper still, so it
     // needs the same container scoping the dialog does.
     await page

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -226,7 +226,9 @@ export abstract class TestConstants {
    * Settings Menu Identifiers
    */
 
-  static readonly SETTINGS_MENU_TITLE = 'General Settings';
+  // The dialog's own title. It used to be the "General Settings" section
+  // heading, which the tabs replaced — every section is now named by its tab.
+  static readonly SETTINGS_MENU_TITLE = 'Settings';
 
   /**
    * Chat Menu Identifiers

--- a/src/state/viewModel/settingsViewModel.ts
+++ b/src/state/viewModel/settingsViewModel.ts
@@ -2,7 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import type { SettingsService } from '@service/settings';
 import type { Disposable } from '@type/disposable';
 import type { DotPadState, DotPadTransport } from '@type/dotPad';
-import type { Settings } from '@type/settings';
+import type { Settings, SettingsSection } from '@type/settings';
 import type { AppStore } from '../store';
 import { createSlice } from '@reduxjs/toolkit';
 import { dotPadSession } from '@service/dotPadSession';
@@ -35,6 +35,9 @@ const { update, reset } = settingsSlice.actions;
  */
 export class SettingsViewModel extends AbstractViewModel<SettingsState> {
   private readonly settingsService: SettingsService;
+
+  /** Set by the caller that opens the dialog; cleared on the next toggle. */
+  private openOnSection: SettingsSection | null = null;
 
   /**
    * Creates a new SettingsViewModel instance and loads initial settings.
@@ -101,8 +104,22 @@ export class SettingsViewModel extends AbstractViewModel<SettingsState> {
   /**
    * Toggles the visibility of the settings modal.
    */
-  public toggle(): void {
+  public toggle(section?: SettingsSection): void {
+    this.openOnSection = section ?? null;
     this.settingsService.toggle();
+  }
+
+  /**
+   * The page the dialog should open on, when its opener asked for one.
+   *
+   * Read once by the dialog as it mounts. It is not in Redux because the
+   * dialog reads this view model directly rather than subscribing to the
+   * store, so a dispatch would not reach it — the same reason the tactile
+   * connection state is held outside the store.
+   * @returns The requested section, or null when the opener had no preference
+   */
+  public get initialSection(): SettingsSection | null {
+    return this.openOnSection;
   }
 
   /**

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -159,6 +159,31 @@ export type BraillePresetSelection
   };
 
 /**
+ * One page of the settings dialog.
+ *
+ * Shared rather than private to the dialog because opening it is no longer
+ * enough on its own: a caller that sends the reader there for one setting —
+ * the chat's "Open Settings", which exists to reach an API key — has to be
+ * able to say which page, and the view model it goes through cannot import
+ * the view.
+ */
+export const SETTINGS_SECTIONS = [
+  'general',
+  'audio',
+  'visual',
+  'braille',
+  'ai',
+  'about',
+] as const;
+
+export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
+
+/**
+ * The page the dialog opens on when the opener asks for no particular one.
+ */
+export const DEFAULT_SETTINGS_SECTION: SettingsSection = 'general';
+
+/**
  * ARIA live region politeness level for screen reader announcements.
  */
 export type AriaMode = 'assertive' | 'polite';

--- a/src/ui/component/Chat.tsx
+++ b/src/ui/component/Chat.tsx
@@ -33,8 +33,13 @@ const Chat: React.FC = () => {
   const lastScrollHeightRef = useRef<number>(0);
   const mutationObserverRef = useRef<MutationObserver | null>(null);
 
+  // Straight to the AI page. This button only appears on the message telling
+  // the reader to enable an agent and enter a key, and since the dialog grew
+  // tabs the page it opens on carries none of those fields — a reader who
+  // followed it would land on Autoplay Duration with nothing saying where to
+  // go next.
   const handleOpenSettings = useCallback((): void => {
-    settingsViewModel.toggle();
+    settingsViewModel.toggle('ai');
   }, [settingsViewModel]);
 
   // Stable callback so memoized message bubbles do not re-render on every

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -561,6 +561,13 @@ const Settings: React.FC = () => {
   const tactileStatusId = `${id}-tactile-status`;
   const tactileMenu = useModalContainer();
   const contentRef = React.useRef<HTMLDivElement>(null);
+  // `HTMLDivElement` because that is what MUI declares `Tab`'s ref as, even
+  // though it renders a `<button>`. Only `focus()` is called on it, which
+  // every element has.
+  const aiTabRef = React.useRef<HTMLDivElement>(null);
+  // Counts refused saves rather than holding a boolean, so a second refusal
+  // re-runs the effect below instead of looking like the first one.
+  const [refusedSaves, setRefusedSaves] = useState(0);
   // The bundle source and the browser cannot change while the dialog is open,
   // so the DOM scan behind this runs once per mount rather than per render.
   const diagnostics = useMemo(() => collectDiagnostics(), []);
@@ -619,6 +626,22 @@ const Settings: React.FC = () => {
     setGeneralSettings(general);
     setLlmSettings(llm);
   }, [general, llm]);
+
+  // Selecting the AI tab is not, on its own, something a reader can perceive.
+  // Its panel is already mounted by the time a save is refused — that is where
+  // the instruction was typed — so switching to it mutates no live region and
+  // announces nothing. Moving focus is what makes the refusal perceivable, and
+  // the tab it lands on is named "AI needs attention".
+  //
+  // In an effect rather than in the key handler so that focus arrives after
+  // the render that marks the tab selected; focusing first would announce the
+  // tab as unselected.
+  useEffect(() => {
+    if (refusedSaves === 0) {
+      return;
+    }
+    aiTabRef.current?.focus();
+  }, [refusedSaves]);
 
   const handleGeneralChange = <K extends keyof GeneralSettings>(
     key: K,
@@ -812,10 +835,13 @@ const Settings: React.FC = () => {
           // Returning silently would leave a reader who pressed the shortcut
           // the dialog advertises with no response at all — no sound, no
           // text, nothing saying why. Opening the tab that holds the field is
-          // the answer to "why not", and puts them where the fix is.
+          // the answer to "why not", and puts them where the fix is; the
+          // effect above then moves focus there, which is the part they can
+          // actually perceive.
           setActiveTab('ai');
           setVisitedTabs(previous =>
             previous.has('ai') ? previous : new Set(previous).add('ai'));
+          setRefusedSaves(previous => previous + 1);
           return;
         }
         handleSave();
@@ -900,11 +926,12 @@ const Settings: React.FC = () => {
           <Tab
             key={tab.id}
             value={tab.id}
+            ref={tab.id === 'ai' ? aiTabRef : undefined}
             id={`${id}-tab-${tab.id}`}
-            // Only the selected panel is rendered, so only the selected tab
-            // has one to point at. Naming an id that is not in the document
-            // is a dangling reference, which is a defect whether or not a
-            // reader happens to follow it.
+            // Named only on the selected tab. A visited tab's panel is in
+            // the document, but hidden — so it is out of the accessibility
+            // tree, and pointing at it would be no better than pointing at
+            // the unvisited ones, which are not there at all.
             aria-controls={
               tab.id === activeTab ? `${id}-panel-${tab.id}` : undefined
             }

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -9,6 +9,7 @@ import type {
   HoverMode,
   LlmModelSettings,
   LlmSettings,
+  SettingsSection,
 } from '@type/settings';
 import { Check as CheckIcon, Error as ErrorIcon } from '@mui/icons-material';
 import {
@@ -44,6 +45,7 @@ import {
   clampEchoCount,
   clampEchoDuration,
   clampFrequencyRange,
+  DEFAULT_SETTINGS_SECTION,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MAX_ECHO_COUNT,
@@ -101,20 +103,19 @@ interface CopyState {
 const SAVE_SHORTCUT_KEY = 's';
 const CANCEL_SHORTCUT_KEY = 'c';
 
-/**
- * One page of the settings dialog.
- *
- * The groups are the modality a setting reaches the reader through — what a
- * reader looking for a setting knows about it — rather than the service that
- * happens to own it.
- */
-type SettingsTabId = 'general' | 'audio' | 'visual' | 'braille' | 'ai' | 'about';
-
 interface SettingsTab {
-  readonly id: SettingsTabId;
+  readonly id: SettingsSection;
   readonly label: string;
 }
 
+/**
+ * The dialog's pages, in the order they are offered.
+ *
+ * The groups are the modality a setting reaches the reader through — what a
+ * reader looking for a setting knows about it — rather than the service that
+ * happens to own it. The ids are shared (`SettingsSection`) so a caller can
+ * ask for a page; the labels are the view's own.
+ */
 const SETTINGS_TABS: readonly SettingsTab[] = [
   { id: 'general', label: 'General' },
   { id: 'audio', label: 'Audio' },
@@ -124,8 +125,6 @@ const SETTINGS_TABS: readonly SettingsTab[] = [
   { id: 'about', label: 'About' },
 ];
 
-const DEFAULT_SETTINGS_TAB: SettingsTabId = 'general';
-
 // Keeps a tab's badge on the same baseline as its text.
 const TAB_LABEL_STYLE: React.CSSProperties = {
   display: 'inline-flex',
@@ -134,8 +133,10 @@ const TAB_LABEL_STYLE: React.CSSProperties = {
 };
 
 interface SettingsTabPanelProps {
-  readonly tabId: SettingsTabId;
-  readonly activeTabId: SettingsTabId;
+  readonly tabId: SettingsSection;
+  readonly activeTabId: SettingsSection;
+  /** Whether this tab has been opened at least once this session. */
+  readonly visited: boolean;
   /** The dialog's `useId` prefix, so panel and tab ids pair up. */
   readonly dialogId: string;
   readonly children: React.ReactNode;
@@ -144,34 +145,58 @@ interface SettingsTabPanelProps {
 /**
  * The rows of one settings tab.
  *
- * An inactive panel renders nothing at all rather than hiding: the edits live
- * in the dialog's state, not in the fields, so unmounting a panel loses no
- * input, and it keeps the API-key probes in the AI panel from running for a
- * reader who never opens it.
+ * Mounted on first visit and kept from then on, rather than either mounting
+ * all six up front or unmounting on every switch. Both halves matter:
+ *
+ * - Not mounting an unvisited panel is what keeps the API-key probes in the
+ *   AI panel from reaching a provider for a reader who never opens it.
+ * - Keeping a visited one is what stops a *second* visit from costing
+ *   anything. `useCredentialProbe` keys its result to the hook instance, so
+ *   remounting resets it to "unknown" — which re-sends the key and, worse,
+ *   disables the model dropdown the reader had already been given, with no
+ *   action on their part. Live regions have the same problem in a milder
+ *   form: a region that unmounts cannot announce what happens while it is
+ *   gone, which is how a tactile display disconnecting on another tab would
+ *   have gone unannounced.
+ *
+ * A kept panel is hidden with `display: none`, which takes it out of the
+ * accessibility tree and the tab order. The `hidden` attribute would not do:
+ * `Grid` sets `display: flex` as an author style, which outranks the user
+ * agent's rule for `[hidden]`.
  *
  * @param props - The panel's configuration.
  * @param props.tabId - The tab this panel belongs to.
  * @param props.activeTabId - The tab currently selected in the dialog.
+ * @param props.visited - Whether this tab has been opened at least once.
  * @param props.dialogId - The dialog's `useId` prefix.
  * @param props.children - The setting rows to render.
- * @returns The panel when its tab is selected, otherwise nothing.
+ * @returns The panel once its tab has been opened, otherwise nothing.
  */
 const SettingsTabPanel: React.FC<SettingsTabPanelProps> = ({
   tabId,
   activeTabId,
+  visited,
   dialogId,
   children,
 }) => {
-  if (tabId !== activeTabId) {
+  if (!visited) {
     return null;
   }
+  const isActive = tabId === activeTabId;
   return (
     <Grid
       container
       spacing={0.5}
       role="tabpanel"
+      // Focusable so that entering the panel announces its name. That name is
+      // the only thing left saying which section the reader is in, now that
+      // the section headings are gone, and About needs it for a second
+      // reason: its first four rows are static text, so tabbing past the
+      // panel itself would land on the copy button and skip them.
+      tabIndex={0}
       id={`${dialogId}-panel-${tabId}`}
       aria-labelledby={`${dialogId}-tab-${tabId}`}
+      sx={isActive ? undefined : { display: 'none' }}
       className={`settings-tab-panel settings-tab-panel-${tabId}`}
     >
       {children}
@@ -512,7 +537,15 @@ const Settings: React.FC = () => {
   const [generalSettings, setGeneralSettings] = useState<GeneralSettings>(general);
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
 
-  const [activeTab, setActiveTab] = useState<SettingsTabId>(DEFAULT_SETTINGS_TAB);
+  // Seeded from the opener so a caller that sends the reader here for one
+  // setting lands them on it. Read once, as the dialog mounts: it is closed
+  // by unmounting, so every open runs this initialiser afresh.
+  const [activeTab, setActiveTab] = useState<SettingsSection>(
+    () => viewModel.initialSection ?? DEFAULT_SETTINGS_SECTION,
+  );
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<SettingsSection>>(
+    () => new Set([viewModel.initialSection ?? DEFAULT_SETTINGS_SECTION]),
+  );
   const [copyState, setCopyState] = useState<CopyState>({ status: 'idle', attempt: 0 });
   // Connection progress lives here rather than in Redux: this dialog reads the
   // view model directly, so a store update would not re-render it. The attempt
@@ -527,6 +560,7 @@ const Settings: React.FC = () => {
   const tactileLabelId = `${id}-tactile-label`;
   const tactileStatusId = `${id}-tactile-status`;
   const tactileMenu = useModalContainer();
+  const contentRef = React.useRef<HTMLDivElement>(null);
   // The bundle source and the browser cannot change while the dialog is open,
   // so the DOM scan behind this runs once per mount rather than per render.
   const diagnostics = useMemo(() => collectDiagnostics(), []);
@@ -677,9 +711,25 @@ const Settings: React.FC = () => {
     setLlmSettings(llm);
   };
 
+  // The second parameter is MUI's `any`. Narrowing it here is sound because
+  // the only values that reach it are the `Tab` values, which come from
+  // `SETTINGS_TABS`.
   const handleTabChange = useCallback(
-    (_event: React.SyntheticEvent, tabId: SettingsTabId): void => {
+    (_event: React.SyntheticEvent, tabId: SettingsSection): void => {
       setActiveTab(tabId);
+      setVisitedTabs(previous =>
+        previous.has(tabId) ? previous : new Set(previous).add(tabId));
+      // The panels share one scroll container, so a switch would otherwise
+      // open the next page part-way down — a lost place for a reader using
+      // magnification.
+      if (contentRef.current) {
+        contentRef.current.scrollTop = 0;
+      }
+      // "Copied to clipboard" belongs to a copy that has now scrolled out of
+      // the conversation. Left alone it reappears on the next visit to About
+      // as though it had just happened.
+      setCopyState(previous =>
+        previous.status === 'idle' ? previous : { status: 'idle', attempt: previous.attempt });
     },
     [],
   );
@@ -757,10 +807,17 @@ const Settings: React.FC = () => {
       }
       const key = e.key.toLowerCase();
       if (key === SAVE_SHORTCUT_KEY) {
+        e.preventDefault();
         if (!isCustomInstructionValid) {
+          // Returning silently would leave a reader who pressed the shortcut
+          // the dialog advertises with no response at all — no sound, no
+          // text, nothing saying why. Opening the tab that holds the field is
+          // the answer to "why not", and puts them where the fix is.
+          setActiveTab('ai');
+          setVisitedTabs(previous =>
+            previous.has('ai') ? previous : new Set(previous).add('ai'));
           return;
         }
-        e.preventDefault();
         handleSave();
       } else if (key === CANCEL_SHORTCUT_KEY) {
         e.preventDefault();
@@ -812,7 +869,32 @@ const Settings: React.FC = () => {
         allowScrollButtonsMobile
         aria-label="Settings sections"
         className="settings-tabs"
-        sx={{ px: 3, borderBottom: 1, borderColor: 'divider' }}
+        sx={{
+          'px': 3,
+          'borderBottom': 1,
+          'borderColor': 'divider',
+          // `ButtonBase` clears the UA outline, and `Tab` replaces it with
+          // nothing. Arrow keys move focus without selecting, so without this
+          // a reader arrowing the tablist has no way to see where they are.
+          '& .settings-tab.Mui-focusVisible': {
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: '-2px',
+          },
+          // Selection is otherwise text colour plus the indicator's
+          // background, and a forced-colours mode overrides both — leaving
+          // six tabs that look alike. A system colour the mode is told not to
+          // override keeps the indicator visible.
+          '@media (forced-colors: active)': {
+            '& .MuiTabs-indicator': {
+              backgroundColor: 'Highlight',
+              forcedColorAdjust: 'none',
+            },
+            '& .settings-tab.Mui-focusVisible': {
+              outlineColor: 'CanvasText',
+            },
+          },
+        }}
       >
         {SETTINGS_TABS.map(tab => (
           <Tab
@@ -856,10 +938,16 @@ const Settings: React.FC = () => {
           tallest panels push past it, and the viewport term keeps the floor
           from squeezing the footer off a short screen. */}
       <DialogContent
+        ref={contentRef}
         className="settings-dialog-content"
         sx={{ minHeight: 'min(400px, 45vh)' }}
       >
-        <SettingsTabPanel tabId="general" activeTabId={activeTab} dialogId={id}>
+        <SettingsTabPanel
+          tabId="general"
+          activeTabId={activeTab}
+          visited={visitedTabs.has('general')}
+          dialogId={id}
+        >
           <Grid size={12}>
             <SettingRow
               label="Autoplay Duration (ms)"
@@ -954,7 +1042,12 @@ const Settings: React.FC = () => {
           </Grid>
         </SettingsTabPanel>
 
-        <SettingsTabPanel tabId="audio" activeTabId={activeTab} dialogId={id}>
+        <SettingsTabPanel
+          tabId="audio"
+          activeTabId={activeTab}
+          visited={visitedTabs.has('audio')}
+          dialogId={id}
+        >
           <Grid size={12}>
             <SettingRow
               label="Volume"
@@ -1124,7 +1217,12 @@ const Settings: React.FC = () => {
           </Grid>
         </SettingsTabPanel>
 
-        <SettingsTabPanel tabId="visual" activeTabId={activeTab} dialogId={id}>
+        <SettingsTabPanel
+          tabId="visual"
+          activeTabId={activeTab}
+          visited={visitedTabs.has('visual')}
+          dialogId={id}
+        >
           <Grid size={12}>
             <SettingRow
               label="Outline Color"
@@ -1254,7 +1352,12 @@ const Settings: React.FC = () => {
           </Grid>
         </SettingsTabPanel>
 
-        <SettingsTabPanel tabId="braille" activeTabId={activeTab} dialogId={id}>
+        <SettingsTabPanel
+          tabId="braille"
+          activeTabId={activeTab}
+          visited={visitedTabs.has('braille')}
+          dialogId={id}
+        >
           <Grid size={12}>
             <SettingRow
               label="Braille Display"
@@ -1488,7 +1591,12 @@ const Settings: React.FC = () => {
           </Grid>
         </SettingsTabPanel>
 
-        <SettingsTabPanel tabId="ai" activeTabId={activeTab} dialogId={id}>
+        <SettingsTabPanel
+          tabId="ai"
+          activeTabId={activeTab}
+          visited={visitedTabs.has('ai')}
+          dialogId={id}
+        >
           {(Object.keys(llmSettings.models) as Llm[]).map((modelKey) => {
             const model = llmSettings.models[modelKey];
             return (
@@ -1595,7 +1703,12 @@ const Settings: React.FC = () => {
           )}
         </SettingsTabPanel>
 
-        <SettingsTabPanel tabId="about" activeTabId={activeTab} dialogId={id}>
+        <SettingsTabPanel
+          tabId="about"
+          activeTabId={activeTab}
+          visited={visitedTabs.has('about')}
+          dialogId={id}
+        >
           <Grid size={12}>
             <SettingRow
               label="maidr.js Version"
@@ -1698,27 +1811,34 @@ const Settings: React.FC = () => {
         alignItems="center"
         className="settings-footer"
       >
-        {/* Only while that tab is closed: the AI panel carries the same
-            warning beside the field itself, and the footer's job here is the
-            one part the panel cannot give — where to go. A `status` region so
-            the reason reaches a reader who is several tabs away when Save
-            goes disabled; the text is constant while they type, so it
-            announces once rather than on every keystroke. On its own row,
-            because sharing the buttons' row wraps "Save & Close" off the
-            bottom of the dialog, and inset by `px` so it lines up with the
-            setting labels above it and with the Reset button's own text. */}
-        {!isCustomInstructionValid && activeTab !== 'ai' && (
-          <Grid size={12} sx={{ px: 2 }}>
-            <Typography
-              variant="caption"
-              role="status"
-              className="settings-footer-hint"
-              sx={{ color: 'error.main' }}
-            >
-              {`Custom instructions on the AI tab must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`}
-            </Typography>
-          </Grid>
-        )}
+        {/* Says where the edit blocking Save is, for a reader who is not on
+            that tab to see the panel's own warning. Suppressed on the AI tab
+            itself, where that warning already sits beside the field.
+
+            Rendered even while empty, for the same reason the copy status
+            below is: a live region has to be in the DOM before its text
+            changes for the change to be announced, and this one's text can
+            only appear on a tab switch — the fields that invalidate the
+            instruction are on the tab where the hint is silent. Created
+            already carrying its message, it would announce nothing at all.
+
+            On its own row, because sharing the buttons' row wraps "Save &
+            Close" off the bottom of the dialog, and inset by `px` so it
+            lines up with the setting labels above it and with the Reset
+            button's own text. */}
+        <Grid size={12} sx={{ px: 2 }}>
+          <Typography
+            variant="caption"
+            role="status"
+            aria-live="polite"
+            className="settings-footer-hint"
+            sx={{ color: 'error.main' }}
+          >
+            {!isCustomInstructionValid && activeTab !== 'ai'
+              ? `Custom instructions on the AI tab must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`
+              : ''}
+          </Typography>
+        </Grid>
         <Grid size="auto" className="settings-grid-padding">
           <Button
             variant="text"

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -20,7 +20,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   FormControl,
   FormControlLabel,
   Grid,
@@ -31,6 +30,8 @@ import {
   Select,
   Slider,
   Switch,
+  Tab,
+  Tabs,
   TextareaAutosize,
   TextField,
   Typography,
@@ -49,6 +50,7 @@ import {
   MAX_FREQUENCY_HZ,
   MIN_FREQUENCY_HZ,
 } from '@type/settings';
+import { visuallyHidden } from '@ui/visuallyHidden';
 import {
   clampBrailleLines,
   clampBrailleSize,
@@ -98,6 +100,84 @@ interface CopyState {
 // cannot drift apart and announce a shortcut that no longer fires.
 const SAVE_SHORTCUT_KEY = 's';
 const CANCEL_SHORTCUT_KEY = 'c';
+
+/**
+ * One page of the settings dialog.
+ *
+ * The groups are the modality a setting reaches the reader through — what a
+ * reader looking for a setting knows about it — rather than the service that
+ * happens to own it.
+ */
+type SettingsTabId = 'general' | 'audio' | 'visual' | 'braille' | 'ai' | 'about';
+
+interface SettingsTab {
+  readonly id: SettingsTabId;
+  readonly label: string;
+}
+
+const SETTINGS_TABS: readonly SettingsTab[] = [
+  { id: 'general', label: 'General' },
+  { id: 'audio', label: 'Audio' },
+  { id: 'visual', label: 'Visual' },
+  { id: 'braille', label: 'Braille & Tactile' },
+  { id: 'ai', label: 'AI' },
+  { id: 'about', label: 'About' },
+];
+
+const DEFAULT_SETTINGS_TAB: SettingsTabId = 'general';
+
+// Keeps a tab's badge on the same baseline as its text.
+const TAB_LABEL_STYLE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+};
+
+interface SettingsTabPanelProps {
+  readonly tabId: SettingsTabId;
+  readonly activeTabId: SettingsTabId;
+  /** The dialog's `useId` prefix, so panel and tab ids pair up. */
+  readonly dialogId: string;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * The rows of one settings tab.
+ *
+ * An inactive panel renders nothing at all rather than hiding: the edits live
+ * in the dialog's state, not in the fields, so unmounting a panel loses no
+ * input, and it keeps the API-key probes in the AI panel from running for a
+ * reader who never opens it.
+ *
+ * @param props - The panel's configuration.
+ * @param props.tabId - The tab this panel belongs to.
+ * @param props.activeTabId - The tab currently selected in the dialog.
+ * @param props.dialogId - The dialog's `useId` prefix.
+ * @param props.children - The setting rows to render.
+ * @returns The panel when its tab is selected, otherwise nothing.
+ */
+const SettingsTabPanel: React.FC<SettingsTabPanelProps> = ({
+  tabId,
+  activeTabId,
+  dialogId,
+  children,
+}) => {
+  if (tabId !== activeTabId) {
+    return null;
+  }
+  return (
+    <Grid
+      container
+      spacing={0.5}
+      role="tabpanel"
+      id={`${dialogId}-panel-${tabId}`}
+      aria-labelledby={`${dialogId}-tab-${tabId}`}
+      className={`settings-tab-panel settings-tab-panel-${tabId}`}
+    >
+      {children}
+    </Grid>
+  );
+};
 
 interface SettingRowProps {
   label: string;
@@ -432,6 +512,7 @@ const Settings: React.FC = () => {
   const [generalSettings, setGeneralSettings] = useState<GeneralSettings>(general);
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
 
+  const [activeTab, setActiveTab] = useState<SettingsTabId>(DEFAULT_SETTINGS_TAB);
   const [copyState, setCopyState] = useState<CopyState>({ status: 'idle', attempt: 0 });
   // Connection progress lives here rather than in Redux: this dialog reads the
   // view model directly, so a store update would not re-render it. The attempt
@@ -596,6 +677,13 @@ const Settings: React.FC = () => {
     setLlmSettings(llm);
   };
 
+  const handleTabChange = useCallback(
+    (_event: React.SyntheticEvent, tabId: SettingsTabId): void => {
+      setActiveTab(tabId);
+    },
+    [],
+  );
+
   const handleClose = useCallback((): void => {
     viewModel.toggle();
   }, [viewModel]);
@@ -706,22 +794,167 @@ const Settings: React.FC = () => {
       onKeyDown={handleDialogKeyDown}
       className="settings-dialog"
     >
-      {/* Renders as an `h2`, so the dialog also gains the top-level heading
-          it lacked — the section headings below were the only ones in it,
-          leaving nothing to land on when navigating by heading. */}
+      {/* Renders as an `h2`, and it is now the dialog's only heading: each
+          panel is named by its own tab, so a heading repeating that name
+          would announce the same words twice. */}
       <DialogTitle id={titleId} className="settings-dialog-title">
         Settings
       </DialogTitle>
 
-      <DialogContent className="settings-dialog-content">
-        <Grid size="grow">
-          <Typography variant="h6" component="h3" fontWeight="bold" gutterBottom>
-            General Settings
-          </Typography>
-        </Grid>
+      {/* The tablist sits outside `DialogContent` so it stays put while a
+          panel scrolls; inside it, a long panel would carry the tabs off
+          screen and leave no way back to the other sections. */}
+      <Tabs
+        value={activeTab}
+        onChange={handleTabChange}
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
+        aria-label="Settings sections"
+        className="settings-tabs"
+        sx={{ px: 3, borderBottom: 1, borderColor: 'divider' }}
+      >
+        {SETTINGS_TABS.map(tab => (
+          <Tab
+            key={tab.id}
+            value={tab.id}
+            id={`${id}-tab-${tab.id}`}
+            // Only the selected panel is rendered, so only the selected tab
+            // has one to point at. Naming an id that is not in the document
+            // is a dangling reference, which is a defect whether or not a
+            // reader happens to follow it.
+            aria-controls={
+              tab.id === activeTab ? `${id}-panel-${tab.id}` : undefined
+            }
+            className="settings-tab"
+            sx={{ minWidth: 0, px: 1.5, textTransform: 'none' }}
+            label={(
+              <span className="settings-tab-label" style={TAB_LABEL_STYLE}>
+                {tab.label}
+                {/* Marks the tab holding the edit that is blocking Save, so
+                    the reason is reachable from whichever tab is open. The
+                    icon is decorative and the text beside it carries the
+                    meaning, because colour and shape alone say nothing to a
+                    reader. It extends the visible label rather than
+                    replacing it, and it leads with a space: a name computed
+                    from an element's contents is the concatenation of them,
+                    which would otherwise announce "AIneeds attention". */}
+                {tab.id === 'ai' && !isCustomInstructionValid && (
+                  <>
+                    <ErrorIcon color="error" fontSize="small" aria-hidden="true" />
+                    <span style={visuallyHidden}>{' needs attention'}</span>
+                  </>
+                )}
+              </span>
+            )}
+          />
+        ))}
+      </Tabs>
 
-        {/* General Settings */}
-        <Grid container spacing={0.5}>
+      {/* A floor under the shortest panels so switching tabs does not resize
+          the dialog under the reader's pointer or magnifier. Only the two
+          tallest panels push past it, and the viewport term keeps the floor
+          from squeezing the footer off a short screen. */}
+      <DialogContent
+        className="settings-dialog-content"
+        sx={{ minHeight: 'min(400px, 45vh)' }}
+      >
+        <SettingsTabPanel tabId="general" activeTabId={activeTab} dialogId={id}>
+          <Grid size={12}>
+            <SettingRow
+              label="Autoplay Duration (ms)"
+              input={(
+                <FormControl fullWidth>
+                  <TextField
+                    fullWidth
+                    type="number"
+                    size="small"
+                    value={generalSettings.autoplayDuration}
+                    onChange={e =>
+                      handleGeneralChange(
+                        'autoplayDuration',
+                        Number(e.target.value),
+                      )}
+                    slotProps={{
+                      input: {
+                        inputProps: {
+                          'aria-label': 'Autoplay Duration',
+                        },
+                      },
+                    }}
+                  />
+                </FormControl>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="ARIA Mode"
+              input={(
+                <FormControl>
+                  <RadioGroup
+                    row
+                    value={generalSettings.ariaMode}
+                    onChange={e =>
+                      handleGeneralChange(
+                        'ariaMode',
+                        e.target.value as AriaMode,
+                      )}
+                    aria-label="ARIA Mode"
+                  >
+                    <FormControlLabel
+                      value="assertive"
+                      control={<Radio size="small" />}
+                      label="Assertive"
+                    />
+                    <FormControlLabel
+                      value="polite"
+                      control={<Radio size="small" />}
+                      label="Polite"
+                    />
+                  </RadioGroup>
+                </FormControl>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Hover Mode"
+              input={(
+                <FormControl>
+                  <RadioGroup
+                    row
+                    value={generalSettings.hoverMode}
+                    onChange={e =>
+                      handleGeneralChange(
+                        'hoverMode',
+                        e.target.value as HoverMode,
+                      )}
+                    aria-label="Hover Mode"
+                  >
+                    <FormControlLabel
+                      value="off"
+                      control={<Radio size="small" />}
+                      label="Off"
+                    />
+                    <FormControlLabel
+                      value="pointermove"
+                      control={<Radio size="small" />}
+                      label="Hover"
+                    />
+                    <FormControlLabel
+                      value="click"
+                      control={<Radio size="small" />}
+                      label="Click"
+                    />
+                  </RadioGroup>
+                </FormControl>
+              )}
+            />
+          </Grid>
+        </SettingsTabPanel>
+
+        <SettingsTabPanel tabId="audio" activeTabId={activeTab} dialogId={id}>
           <Grid size={12}>
             <SettingRow
               label="Volume"
@@ -744,6 +977,64 @@ const Settings: React.FC = () => {
                       },
                     }}
                     className="settings-slider-value-label"
+                  />
+                </FormControl>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Min Frequency (Hz)"
+              input={(
+                <FormControl fullWidth>
+                  <TextField
+                    fullWidth
+                    type="number"
+                    size="small"
+                    value={generalSettings.minFrequency}
+                    onChange={e =>
+                      handleGeneralChange(
+                        'minFrequency',
+                        Number(e.target.value),
+                      )}
+                    slotProps={{
+                      input: {
+                        inputProps: {
+                          'aria-label': 'Minimum Frequency',
+                          'min': MIN_FREQUENCY_HZ,
+                          'max': MAX_FREQUENCY_HZ,
+                        },
+                      },
+                    }}
+                  />
+                </FormControl>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Max Frequency (Hz)"
+              input={(
+                <FormControl fullWidth>
+                  <TextField
+                    fullWidth
+                    type="number"
+                    size="small"
+                    value={generalSettings.maxFrequency}
+                    onChange={e =>
+                      handleGeneralChange(
+                        'maxFrequency',
+                        Number(e.target.value),
+                      )}
+                    slotProps={{
+                      input: {
+                        inputProps: {
+                          'aria-label': 'Maximum Frequency',
+                          'min': MIN_FREQUENCY_HZ,
+                          'max': MAX_FREQUENCY_HZ,
+                        },
+                      },
+                    }}
                   />
                 </FormControl>
               )}
@@ -831,6 +1122,9 @@ const Settings: React.FC = () => {
               )}
             />
           </Grid>
+        </SettingsTabPanel>
+
+        <SettingsTabPanel tabId="visual" activeTabId={activeTab} dialogId={id}>
           <Grid size={12}>
             <SettingRow
               label="Outline Color"
@@ -958,6 +1252,9 @@ const Settings: React.FC = () => {
               )}
             />
           </Grid>
+        </SettingsTabPanel>
+
+        <SettingsTabPanel tabId="braille" activeTabId={activeTab} dialogId={id}>
           <Grid size={12}>
             <SettingRow
               label="Braille Display"
@@ -1189,176 +1486,9 @@ const Settings: React.FC = () => {
               )}
             />
           </Grid>
-          <Grid size={12}>
-            <SettingRow
-              label="Min Frequency (Hz)"
-              input={(
-                <FormControl fullWidth>
-                  <TextField
-                    fullWidth
-                    type="number"
-                    size="small"
-                    value={generalSettings.minFrequency}
-                    onChange={e =>
-                      handleGeneralChange(
-                        'minFrequency',
-                        Number(e.target.value),
-                      )}
-                    slotProps={{
-                      input: {
-                        inputProps: {
-                          'aria-label': 'Minimum Frequency',
-                          'min': MIN_FREQUENCY_HZ,
-                          'max': MAX_FREQUENCY_HZ,
-                        },
-                      },
-                    }}
-                  />
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid size={12}>
-            <SettingRow
-              label="Max Frequency (Hz)"
-              input={(
-                <FormControl fullWidth>
-                  <TextField
-                    fullWidth
-                    type="number"
-                    size="small"
-                    value={generalSettings.maxFrequency}
-                    onChange={e =>
-                      handleGeneralChange(
-                        'maxFrequency',
-                        Number(e.target.value),
-                      )}
-                    slotProps={{
-                      input: {
-                        inputProps: {
-                          'aria-label': 'Maximum Frequency',
-                          'min': MIN_FREQUENCY_HZ,
-                          'max': MAX_FREQUENCY_HZ,
-                        },
-                      },
-                    }}
-                  />
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid size={12}>
-            <SettingRow
-              label="Autoplay Duration (ms)"
-              input={(
-                <FormControl fullWidth>
-                  <TextField
-                    fullWidth
-                    type="number"
-                    size="small"
-                    value={generalSettings.autoplayDuration}
-                    onChange={e =>
-                      handleGeneralChange(
-                        'autoplayDuration',
-                        Number(e.target.value),
-                      )}
-                    slotProps={{
-                      input: {
-                        inputProps: {
-                          'aria-label': 'Autoplay Duration',
-                        },
-                      },
-                    }}
-                  />
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid size={12}>
-            <SettingRow
-              label="ARIA Mode"
-              input={(
-                <FormControl>
-                  <RadioGroup
-                    row
-                    value={generalSettings.ariaMode}
-                    onChange={e =>
-                      handleGeneralChange(
-                        'ariaMode',
-                        e.target.value as AriaMode,
-                      )}
-                    aria-label="ARIA Mode"
-                  >
-                    <FormControlLabel
-                      value="assertive"
-                      control={<Radio size="small" />}
-                      label="Assertive"
-                    />
-                    <FormControlLabel
-                      value="polite"
-                      control={<Radio size="small" />}
-                      label="Polite"
-                    />
-                  </RadioGroup>
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid size={12}>
-            <SettingRow
-              label="Hover Mode"
-              input={(
-                <FormControl>
-                  <RadioGroup
-                    row
-                    value={generalSettings.hoverMode}
-                    onChange={e =>
-                      handleGeneralChange(
-                        'hoverMode',
-                        e.target.value as HoverMode,
-                      )}
-                    aria-label="Hover Mode"
-                  >
-                    <FormControlLabel
-                      value="off"
-                      control={<Radio size="small" />}
-                      label="Off"
-                    />
-                    <FormControlLabel
-                      value="pointermove"
-                      control={<Radio size="small" />}
-                      label="Hover"
-                    />
-                    <FormControlLabel
-                      value="click"
-                      control={<Radio size="small" />}
-                      label="Click"
-                    />
-                  </RadioGroup>
-                </FormControl>
-              )}
-            />
-          </Grid>
-        </Grid>
+        </SettingsTabPanel>
 
-        <Grid size={12}>
-          <Divider className="settings-divider" />
-        </Grid>
-
-        {/* LLM Settings */}
-        <Grid container spacing={0.5} className="settings-section">
-          <Grid size={12}>
-            <Typography
-              variant="h6"
-              component="h3"
-              fontWeight="bold"
-              gutterBottom
-              className="settings-section-title"
-            >
-              LLM Settings
-            </Typography>
-          </Grid>
-
+        <SettingsTabPanel tabId="ai" activeTabId={activeTab} dialogId={id}>
           {(Object.keys(llmSettings.models) as Llm[]).map((modelKey) => {
             const model = llmSettings.models[modelKey];
             return (
@@ -1463,25 +1593,9 @@ const Settings: React.FC = () => {
               </Grid>
             </Grid>
           )}
-        </Grid>
+        </SettingsTabPanel>
 
-        <Grid size={12}>
-          <Divider className="settings-divider" />
-        </Grid>
-
-        {/* About */}
-        <Grid container spacing={0.5} className="settings-section">
-          <Grid size={12}>
-            <Typography
-              variant="h6"
-              component="h3"
-              fontWeight="bold"
-              gutterBottom
-              className="settings-section-title"
-            >
-              About
-            </Typography>
-          </Grid>
+        <SettingsTabPanel tabId="about" activeTabId={activeTab} dialogId={id}>
           <Grid size={12}>
             <SettingRow
               label="maidr.js Version"
@@ -1574,11 +1688,7 @@ const Settings: React.FC = () => {
               )}
             />
           </Grid>
-        </Grid>
-
-        <Grid size={12}>
-          <Divider className="settings-divider" />
-        </Grid>
+        </SettingsTabPanel>
       </DialogContent>
 
       {/* Footer Actions */}
@@ -1588,6 +1698,27 @@ const Settings: React.FC = () => {
         alignItems="center"
         className="settings-footer"
       >
+        {/* Only while that tab is closed: the AI panel carries the same
+            warning beside the field itself, and the footer's job here is the
+            one part the panel cannot give — where to go. A `status` region so
+            the reason reaches a reader who is several tabs away when Save
+            goes disabled; the text is constant while they type, so it
+            announces once rather than on every keystroke. On its own row,
+            because sharing the buttons' row wraps "Save & Close" off the
+            bottom of the dialog, and inset by `px` so it lines up with the
+            setting labels above it and with the Reset button's own text. */}
+        {!isCustomInstructionValid && activeTab !== 'ai' && (
+          <Grid size={12} sx={{ px: 2 }}>
+            <Typography
+              variant="caption"
+              role="status"
+              className="settings-footer-hint"
+              sx={{ color: 'error.main' }}
+            >
+              {`Custom instructions on the AI tab must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`}
+            </Typography>
+          </Grid>
+        )}
         <Grid size="auto" className="settings-grid-padding">
           <Button
             variant="text"
@@ -1603,6 +1734,7 @@ const Settings: React.FC = () => {
           container
           spacing={1}
           justifyContent="flex-end"
+          alignItems="center"
           className="settings-footer-actions"
         >
           <Grid size="auto">

--- a/test/ui/settings.copyDiagnostics.test.tsx
+++ b/test/ui/settings.copyDiagnostics.test.tsx
@@ -126,11 +126,16 @@ function renderSettings(): void {
       <Settings />
     </MaidrContext.Provider>,
   );
+
+  // Everything here lives on the About tab, and only the selected tab's panel
+  // is mounted. The dialog opens on "General", so the tab is part of reaching
+  // these controls at all.
+  fireEvent.click(screen.getByRole('tab', { name: 'About' }));
 }
 
 /**
  * Finds the copy button.
- * @returns The About section's copy button.
+ * @returns The About panel's copy button.
  */
 function copyButton(): HTMLElement {
   return screen.getByRole('button', { name: COPY_BUTTON_NAME });
@@ -142,8 +147,9 @@ function copyButton(): HTMLElement {
  * Looked up the way assistive technology resolves it — through
  * `aria-describedby` — rather than through a test hook, so a dangling
  * reference fails here instead of passing against an element nothing points
- * to. The dialog renders several `role="status"` regions (one per LLM
- * credential field), which is why a role query alone will not do.
+ * to. The dialog renders several `role="status"` regions — one per LLM
+ * credential field on the AI tab, another for the tactile display, and the
+ * footer's blocked-save hint — which is why a role query alone will not do.
  * @param element - The control whose description to resolve.
  * @returns The referenced element.
  */

--- a/test/ui/settings.frequencyRange.test.tsx
+++ b/test/ui/settings.frequencyRange.test.tsx
@@ -119,6 +119,10 @@ function renderSettings(): jest.Mock<SettingsViewModel['saveAndClose']> {
 function savedGeneral(minFrequency: string, maxFrequency: string): SettingsState['general'] {
   const saveAndClose = renderSettings();
 
+  // The dialog opens on "General"; the pitch range lives one tab over, and
+  // only the selected tab's panel is mounted.
+  fireEvent.click(screen.getByRole('tab', { name: 'Audio' }));
+
   fireEvent.change(screen.getByLabelText('Minimum Frequency'), {
     target: { value: minFrequency },
   });

--- a/test/ui/settings.probeStatus.test.tsx
+++ b/test/ui/settings.probeStatus.test.tsx
@@ -23,7 +23,7 @@ import type { Settings as SettingsState } from '@type/settings';
 import { afterAll, afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { MaidrContext } from '@state/context';
 import { ViewModelRegistry } from '@state/viewModel/registry';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { DEFAULT_SETTINGS } from '@type/settings';
 import Settings from '@ui/component/Settings';
 // The `/jest-globals` entry point, not the bare one: it augments the `expect`
@@ -127,6 +127,10 @@ function renderSettings(): void {
  * @returns The announcement the status region ends up carrying.
  */
 async function settledAnnouncement(): Promise<string> {
+  // The provider rows sit on the AI tab, and only the selected tab's panel
+  // is mounted — the probe this waits on does not start until it opens.
+  fireEvent.click(screen.getByRole('tab', { name: /^AI/ }));
+
   // The label sits on the MUI wrapper and the description on the native
   // input inside it, so the region is reached the way the input names it.
   const field = await screen.findByLabelText('OpenAI API Key');

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -382,6 +382,41 @@ describe('settings tabs', () => {
     );
   });
 
+  it('should move focus to that tab every time a save is refused', () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: {
+        ...DEFAULT_SETTINGS.llm,
+        expertiseLevel: 'custom',
+        customInstruction: 'too short',
+      },
+    });
+
+    // Open the AI tab first, which is the ordinary case: it is where the
+    // instruction was typed. Its panel — and the warning inside it — is
+    // mounted from then on, so selecting it again changes nothing in the DOM
+    // and announces nothing on its own. Moving focus is the whole response.
+    openTab(/^AI/);
+    openTab('General');
+
+    // Twice, because a second refusal must answer as loudly as the first. It
+    // is the repeat that a state flag would have swallowed.
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      (screen.getByLabelText('Autoplay Duration') as HTMLElement).focus();
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 's', altKey: true });
+
+      expect(document.activeElement).toBe(
+        screen.getByRole('tab', { name: 'AI needs attention' }),
+      );
+      // Selected before focus arrives, so the tab is not announced as an
+      // unselected one the reader has merely landed on.
+      expect(document.activeElement).toHaveAttribute('aria-selected', 'true');
+
+      openTab('General');
+    }
+  });
+
   it('should drop the footer hint on the tab that already shows the reason', () => {
     renderSettings({
       ...DEFAULT_SETTINGS,

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -208,6 +208,84 @@ describe('settings tabs', () => {
     expect(saved.general.highContrastLevels).toBe(7);
   });
 
+  it('should move focus along the tablist without selecting as it goes', () => {
+    renderSettings();
+
+    // `docs/BRAILLE.md` tells blind readers to Tab to the tablist, arrow to
+    // "Braille & Tactile" and press Enter. This covers the arrow half of that
+    // sequence: focus has to move without selecting, or a reader arrowing
+    // past a tab would open every panel they cross — which for the AI panel
+    // means contacting a provider they were only passing.
+    //
+    // The Enter half is deliberately not asserted here. `Tab` is a `<button>`,
+    // so Enter reaches it as a synthesised click, and jsdom does not
+    // synthesise one. `dialogAccessibility.spec.ts` walks the whole documented
+    // sequence in a real browser instead.
+    const tabs = screen.getAllByRole('tab');
+    tabs[0].focus();
+    for (let i = 0; i < 3; i++) {
+      fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowRight' });
+    }
+
+    expect(document.activeElement).toHaveTextContent('Braille & Tactile');
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent('General');
+    expect(screen.getByRole('tabpanel')).toHaveAccessibleName('General');
+  });
+
+  it('should keep a visited panel mounted so re-entering it costs nothing', () => {
+    renderSettings();
+
+    openTab(/^AI/);
+    const field = screen.getByLabelText('OpenAI API Key');
+
+    openTab('General');
+
+    // Still the same element, not a replacement: `useCredentialProbe` keys
+    // its result to the hook instance, so a remount would drop back to
+    // "unknown" — re-sending the key and disabling the model dropdown the
+    // reader had already been given.
+    openTab(/^AI/);
+    expect(screen.getByLabelText('OpenAI API Key')).toBe(field);
+  });
+
+  it('should keep an unvisited panel out of the document entirely', () => {
+    renderSettings();
+
+    // The other side of that bargain: nothing of the AI panel exists until
+    // the reader asks for it, so no provider is contacted for a reader who
+    // never opens it.
+    expect(screen.queryByLabelText('OpenAI API Key')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+
+    openTab(/^AI/);
+    openTab('General');
+
+    // Visited and now hidden, so it is out of the accessibility tree even
+    // though it is still in the DOM.
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+    expect(
+      screen.getByRole('tabpanel'),
+    ).toHaveAccessibleName('General');
+  });
+
+  it('should keep an LLM edit made on a tab the reader has left', () => {
+    const saveAndClose = renderSettings();
+
+    openTab(/^AI/);
+    // The label names the MUI wrapper, so the field itself is the input
+    // inside it — the same shape `settings.probeStatus.test.tsx` reaches for.
+    const field = screen
+      .getByLabelText('OpenAI API Key')
+      .querySelector('input') as HTMLInputElement;
+    fireEvent.change(field, { target: { value: 'sk-typed-on-the-ai-tab' } });
+
+    openTab('About');
+    fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON_NAME }));
+
+    const [saved] = saveAndClose.mock.calls[0];
+    expect(saved.llm.models.OPENAI.apiKey).toBe('sk-typed-on-the-ai-tab');
+  });
+
   it('should say where the edit blocking Save is when its tab is closed', () => {
     renderSettings({
       ...DEFAULT_SETTINGS,
@@ -234,6 +312,74 @@ describe('settings tabs', () => {
     expect(
       screen.getByRole('tab', { name: 'AI needs attention' }),
     ).toBeInTheDocument();
+  });
+
+  it('should announce the footer hint by mutating a region that was already there', async () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: {
+        ...DEFAULT_SETTINGS.llm,
+        expertiseLevel: 'custom',
+        customInstruction: 'too short',
+      },
+    });
+
+    openTab(/^AI/);
+
+    // The region has to exist before its text does. Observed rather than
+    // asserted on the text, because the text alone reads the same whether the
+    // region was mutated or created holding it — and only the mutation is
+    // what a screen reader announces.
+    const region = document.querySelector('.settings-footer-hint');
+    expect(region).not.toBeNull();
+
+    const mutations: string[] = [];
+    const observer = new MutationObserver(() => {
+      mutations.push((region as HTMLElement).textContent ?? '');
+    });
+    observer.observe(region as HTMLElement, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    // Leaving the AI tab is the only way the hint can appear: the fields that
+    // invalidate the instruction are on the tab that suppresses it.
+    openTab('General');
+    // `MutationObserver` delivers on a microtask, so the records are not in
+    // hand until the queue drains.
+    await Promise.resolve();
+    observer.disconnect();
+
+    expect(mutations).not.toHaveLength(0);
+    expect(mutations[mutations.length - 1]).toBe(
+      'Custom instructions on the AI tab must be at least 10 characters long',
+    );
+  });
+
+  it('should open the tab holding the reason when a blocked Alt+S is pressed', () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: {
+        ...DEFAULT_SETTINGS.llm,
+        expertiseLevel: 'custom',
+        customInstruction: 'too short',
+      },
+    });
+
+    // The dialog advertises Alt+S on the Save button, and `docs/BRAILLE.md`
+    // tells readers to use it. Swallowing the keypress leaves someone who
+    // took that advice with no response of any kind — so it takes them to
+    // the field instead.
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 's', altKey: true });
+
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent('AI');
+    // The panel is named by the badged tab, so entering it repeats why the
+    // reader was sent here.
+    expect(screen.getByRole('tabpanel')).toHaveAccessibleName('AI needs attention');
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Custom instructions must be at least',
+    );
   });
 
   it('should drop the footer hint on the tab that already shows the reason', () => {

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Component test for the settings dialog's tabs.
+ *
+ * The dialog used to render every setting in one scroll — roughly thirty rows
+ * deep — so finding one meant paging past all the others. The rows are now
+ * split across six tabs, which puts three things at risk that the flat list
+ * could not get wrong:
+ *
+ * - **Edits have to survive a tab switch.** Only the selected panel is
+ *   mounted, so an edit typed on one tab is no longer backed by a field in
+ *   the DOM when Save is pressed from another. It has to be saved anyway.
+ * - **The tablist has to be operable and named.** It is the only way to reach
+ *   five of the six panels, by keyboard as much as by pointer.
+ * - **A blocked Save has to stay explainable.** Save is disabled while the
+ *   custom instruction is too short, and that field is on a tab the reader
+ *   may not be looking at.
+ */
+
+import type { CommandExecutor } from '@service/commandExecutor';
+import type { ChatViewModel } from '@state/viewModel/chatViewModel';
+import type { SettingsViewModel } from '@state/viewModel/settingsViewModel';
+import type { Settings as SettingsState } from '@type/settings';
+import { describe, expect, it, jest } from '@jest/globals';
+import { MaidrContext } from '@state/context';
+import { ViewModelRegistry } from '@state/viewModel/registry';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DEFAULT_SETTINGS } from '@type/settings';
+import Settings from '@ui/component/Settings';
+// The `/jest-globals` entry point augments the imported `expect`; the bare
+// one only augments the ambient global.
+import '@testing-library/jest-dom/jest-globals';
+
+/** The `SettingsViewModel` surface `Settings` actually calls. */
+type SettingsStub = Pick<
+  SettingsViewModel,
+  | 'state'
+  | 'load'
+  | 'reset'
+  | 'toggle'
+  | 'saveAndClose'
+  | 'tactileDisplayState'
+  | 'onTactileDisplayStateChange'
+  | 'supportsTactileTransport'
+  | 'connectTactileDisplay'
+  | 'disconnectTactileDisplay'
+  | 'preloadTactileDisplay'
+>;
+
+/** The `ChatViewModel` surface `Settings` actually calls. */
+type ChatStub = Pick<ChatViewModel, 'updateWelcomeMessage'>;
+
+const TAB_LABELS = [
+  'General',
+  'Audio',
+  'Visual',
+  'Braille & Tactile',
+  'AI',
+  'About',
+];
+
+const SAVE_BUTTON_NAME = 'Save & Close Settings';
+
+/**
+ * Renders the settings dialog with stub view models.
+ *
+ * Only the leaves are stubbed: the registry is the production one, so the
+ * component reaches its view models the same way it does at runtime.
+ * @param state - The settings the dialog opens with.
+ * @returns The `saveAndClose` stub, which carries what would be persisted.
+ */
+function renderSettings(
+  state: SettingsState = DEFAULT_SETTINGS,
+): jest.Mock<SettingsViewModel['saveAndClose']> {
+  const saveAndClose = jest.fn<SettingsViewModel['saveAndClose']>();
+  const settings: SettingsStub = {
+    state,
+    load: jest.fn(),
+    reset: jest.fn(),
+    toggle: jest.fn(),
+    saveAndClose,
+    // The tactile-display picker sits on one of the tabs. Nothing here
+    // exercises it, but the component reads its state on every render and
+    // subscribes on mount, so the stub has to answer both.
+    tactileDisplayState: {
+      status: 'disconnected',
+      deviceName: null,
+      transport: null,
+      geometry: null,
+      message: '',
+    },
+    onTactileDisplayStateChange: jest.fn(() => ({ dispose: jest.fn() })),
+    supportsTactileTransport: jest.fn(() => false),
+    connectTactileDisplay: jest.fn(async () => ({
+      status: 'disconnected' as const,
+      deviceName: null,
+      transport: null,
+      geometry: null,
+      message: '',
+    })),
+    disconnectTactileDisplay: jest.fn(),
+    preloadTactileDisplay: jest.fn(),
+  };
+  const chat: ChatStub = { updateWelcomeMessage: jest.fn() };
+
+  const registry = new ViewModelRegistry();
+  registry.register('settings', settings as SettingsViewModel);
+  registry.register('chat', chat as ChatViewModel);
+
+  render(
+    <MaidrContext.Provider
+      value={{
+        viewModelRegistry: registry,
+        commandExecutor: {} as unknown as CommandExecutor,
+      }}
+    >
+      <Settings />
+    </MaidrContext.Provider>,
+  );
+
+  return saveAndClose;
+}
+
+/**
+ * Selects a tab the way a pointer user does.
+ * @param name - The tab's accessible name.
+ */
+function openTab(name: string | RegExp): void {
+  fireEvent.click(screen.getByRole('tab', { name }));
+}
+
+describe('settings tabs', () => {
+  it('should offer every section as a named tab', () => {
+    renderSettings();
+
+    // Named, because the tablist is the dialog's table of contents: a reader
+    // arrowing through it hears these and nothing else.
+    expect(
+      screen.getAllByRole('tab').map(tab => tab.textContent),
+    ).toEqual(TAB_LABELS);
+    expect(screen.getByRole('tablist')).toHaveAccessibleName(
+      'Settings sections',
+    );
+  });
+
+  it('should open on General with only that panel mounted', () => {
+    renderSettings();
+
+    expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    // One panel, not six hidden ones: the rows of the other five must not sit
+    // in the accessibility tree waiting to be tabbed into.
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+    expect(screen.getByLabelText('Autoplay Duration')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Volume')).not.toBeInTheDocument();
+  });
+
+  it('should name each panel after the tab that opens it', () => {
+    renderSettings();
+
+    for (const label of TAB_LABELS) {
+      openTab(label === 'AI' ? /^AI/ : label);
+
+      const panel = screen.getByRole('tabpanel');
+      const tab = screen.getByRole('tab', { selected: true });
+      // Resolved through the DOM the way assistive technology resolves it, so
+      // a reference that points at nothing fails here rather than passing on
+      // the markup that was meant to produce it.
+      expect(panel.getAttribute('aria-labelledby')).toBe(tab.id);
+      expect(tab.getAttribute('aria-controls')).toBe(panel.id);
+      expect(panel).toHaveAccessibleName(label);
+
+      // The unselected tabs have no panel in the document, so they must not
+      // name one: an `aria-controls` pointing at an absent id is a dangling
+      // reference.
+      for (const other of screen.getAllByRole('tab')) {
+        if (other !== tab) {
+          expect(other).not.toHaveAttribute('aria-controls');
+        }
+      }
+    }
+  });
+
+  it('should keep an edit made on a tab the reader has left', () => {
+    const saveAndClose = renderSettings();
+
+    openTab('Audio');
+    fireEvent.change(screen.getByLabelText('Volume'), {
+      target: { value: '35' },
+    });
+
+    // The field that carried the edit is unmounted by this point, so what is
+    // saved can only come from the dialog's own state.
+    openTab('Visual');
+    fireEvent.change(screen.getByLabelText('High Contrast Levels'), {
+      target: { value: '7' },
+    });
+    openTab('General');
+    fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON_NAME }));
+
+    const [saved] = saveAndClose.mock.calls[0];
+    expect(saved.general.volume).toBe(35);
+    expect(saved.general.highContrastLevels).toBe(7);
+  });
+
+  it('should say where the edit blocking Save is when its tab is closed', () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: {
+        ...DEFAULT_SETTINGS.llm,
+        expertiseLevel: 'custom',
+        customInstruction: 'too short',
+      },
+    });
+
+    // Disabled, and — now that the field can be several tabs away — with no
+    // way to reach the reason from where the reader is standing. The hint and
+    // the tab's badge are that way back.
+    expect(screen.getByRole('button', { name: SAVE_BUTTON_NAME })).toBeDisabled();
+
+    const hint = screen.getByText(
+      'Custom instructions on the AI tab must be at least 10 characters long',
+    );
+    // A live region, so it reaches a reader who is on another tab when Save
+    // goes disabled rather than only one who happens to read the footer.
+    expect(hint).toHaveAttribute('role', 'status');
+    // The visible label stays inside the accessible name rather than being
+    // replaced by it, so "AI" is still what a reader hears the tab called.
+    expect(
+      screen.getByRole('tab', { name: 'AI needs attention' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should drop the footer hint on the tab that already shows the reason', () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: {
+        ...DEFAULT_SETTINGS.llm,
+        expertiseLevel: 'custom',
+        customInstruction: 'too short',
+      },
+    });
+
+    openTab(/^AI/);
+
+    // The panel's own warning sits beside the field. Repeating it in the
+    // footer would announce the same sentence twice to a reader who is
+    // already looking at the field it is about.
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Custom instructions must be at least',
+    );
+    expect(
+      screen.queryByText(/Custom instructions on the AI tab/),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`Ctrl+,` opened one flat scroll of roughly thirty setting rows. Reaching the tactile display picker or an API key meant paging past the echo sliders and the high-contrast colours first; at a 900px viewport only the first twelve rows were on screen at once.

The rows now sit on six tabs. The grouping is by the modality a setting reaches the reader through — what someone looking for a setting already knows about it — rather than by the service that happens to own it.

| Tab | Rows |
| --- | --- |
| **General** | Autoplay Duration, ARIA Mode, Hover Mode |
| **Audio** | Volume, Min/Max Frequency, 3D Echo Count, Echo Volume, Echo Duration |
| **Visual** | Outline Color, High Contrast Mode / Levels / Light / Dark |
| **Braille & Tactile** | Braille Display (presets or manual), Tactile Graphics Display |
| **AI** | The four LLM providers, Expertise Level, Custom Instructions |
| **About** | maidr.js version, Loaded From, Browser, OS, Copy diagnostics |

Every panel now fits without scrolling, and four of the six leave the dialog at exactly the same height, so switching tabs does not resize it under a pointer or a magnifier.

No setting was added, removed, renamed, or given a new default. Save, Close, Reset, `Escape` and the `Alt+S` / `Alt+C` accelerators still commit every tab at once.

## Related Issues

None; no open issue tracked this.

## Changes Made

Three commits: the split, then two rounds of fixes that review turned up on it. They are kept separate because each is only legible against the one before it.

### `813481a` — the split

- A `Tabs` tablist named "Settings sections", outside `DialogContent` so it stays put while a panel scrolls. Manual activation (arrow moves focus, `Enter` selects), scrollable with scroll buttons on a narrow viewport.
- Each panel is a `tabpanel` named by its tab through `aria-labelledby`, and focusable, so entering one announces which section you are in — the job the removed `h3`s used to do. About needs that for a second reason: its first four rows are static text, so without it `Tab` skips straight to the copy button.
- The three `h3` section headings and the dividers between them are gone; the `h2` "Settings" title is the only heading left.
- `minHeight: min(400px, 45vh)` on the content area — a floor under the shortest panels, with a viewport term so it cannot squeeze the footer off a short screen.
- Save is disabled while the custom instruction is under 10 characters, and that field can now be several tabs away, so the AI tab takes a badge (decorative icon plus visually hidden text — the reason never rests on colour) and the footer names the tab.

### `66fe44e` — what the split cost, put back

Four things it took away, all invisible to a sighted pointer user and all landing on the reader this dialog exists for:

- **Unmounting an inactive panel was the root of three.** `useCredentialProbe` keys its result to the hook instance, so returning to the AI tab reset it to "unknown": the key went back over the wire, and the model dropdown the reader had already been given went inoperable for the length of a probe, with no action on their part. Live regions fared worse — a region that is not mounted cannot announce, so a **tactile display disconnecting while the reader was on another tab was announced nowhere at all** (`dotPadSession` pushes that state unsolicited, from the vendor SDK callback), and the AI panel's assertive warning re-fired on every visit. Panels now **mount on first visit and stay**, which keeps the part worth having: nothing of the AI panel exists, and no provider is contacted, for a reader who never opens it. Hidden with `display: none`, because `Grid`'s own `display: flex` outranks the UA `[hidden]` rule.
- **The footer hint could not announce**, for the reason this file already documents twelve lines away — it was created holding its message, and a live region has to be in the DOM before its text changes. Now rendered while empty. Its only trigger is a tab switch (the fields that invalidate the instruction are on the tab that suppresses the hint), so being created with the text was the only path it had.
- **`Alt+S` while blocked** returned without preventing the default or saying anything: a reader who used the shortcut the dialog advertises got no response of any kind. It now opens the tab holding the field.
- **The chat's "Open Settings" button** exists to reach an API key and was landing on General, which has no credential field and nothing pointing onward. Openers can now name a page — `SettingsSection` moved to `@type/settings` so the view model can carry one without importing the view.

Plus four smaller ones: the tabs had **no focus indicator at all** (`ButtonBase` clears the outline, `Tab` replaces it with nothing — and with arrows moving focus without selecting, there was nothing to see); selection was carried by colour alone, which a forced-colours mode overrides; switching tabs kept the previous page's scroll offset; and "Copied to clipboard" reappeared on a later visit to About as though it had just happened.

### `12ef5a1` — making the refused save perceivable

The automated review caught that the `Alt+S` fix above only *selected* the AI tab and never moved focus, and it was worse than reported: with panels now persisting, the AI panel is already mounted by the time a save is refused — that is where the instruction was typed — so the switch mutated no live region and announced nothing on the *first* press either, not just the second. The shortcut answered silently again, which is what it had just been changed to stop doing.

Focus now moves to the tab, whose name already reads "AI needs attention". Two details carry weight: it happens in an effect rather than in the key handler, so focus arrives *after* the render that marks the tab selected (focusing first announces it as a tab the reader merely landed on); and it is keyed on a **count** of refusals rather than a flag, which would have fired once and swallowed every refusal after it — the same shape as the bug being fixed.

Also corrects the rationale comment on `aria-controls`. The behaviour was already right; the stated reason no longer was, since a visited panel *is* in the document now. It is named only on the selected tab because a hidden panel is out of the accessibility tree, so pointing at it would be no better than pointing at one that was never rendered.

### Tests and docs

- `test/ui/settings.tabs.test.tsx` (new, 13 cases): the tab/panel naming contract; that no unselected tab names an absent panel; that edits to both the general and the LLM slice survive a tab the reader has left; that a visited panel is the *same* element on re-entry and an unvisited one is absent entirely; that arrows move focus without selecting; that the footer hint arrives as a **mutation of a region that was already there**, observed with a `MutationObserver` rather than asserted on its text; and both halves of the blocked-save affordance, including focus asserted **twice in a loop**, since one pass would have passed against the flag version.
- `dialogAccessibility.spec.ts`: a new case walking the exact sequence `docs/BRAILLE.md` promises — `Tab`, three `ArrowRight`, `Enter` — in a real browser. It is here and not in jsdom because `Enter` reaches a `<button>` as a synthesised click, which jsdom does not model.
- The three existing settings component tests now open the tab holding what they assert on.
- `e2e_tests/utils/constants.ts`: `SETTINGS_MENU_TITLE` was the "General Settings" section heading; it is now the dialog's own title.
- `docs/BRAILLE.md`: the multiline setup steps said "Press Tab to reach the Braille Display options", which no longer lands there.

## Screenshots (if applicable)

Captured with Playwright against `examples/barplot.html`. Described rather than embedded — I have no way to upload image attachments from this environment, and a broken `<img>` is worse than a description.

**Before** — one scrolling list: Volume, 3D Echo Count, Echo Volume, Echo Duration, Outline Color, four High Contrast rows, the Braille Display radios, then the scrollbar, with the tactile display, the frequency range, ARIA Mode, Hover Mode, all four LLM providers and the whole About section below the fold.

**After** — six tabs under the "Settings" title, above a panel that fits. Dialog height is 606px on General, Audio, Visual and About; 643px on Braille & Tactile; 722px on AI — identical whether a tab is being opened for the first time or revisited, since hidden panels take no space. Nothing scrolls on any tab. Arrowing the tablist draws a 2px outline on the focused tab while the selected one keeps its underline. Under emulated forced colours the selected tab keeps a `Highlight` underline while the rest stay bare. When the custom instruction is too short, the AI tab carries a red dot and the footer reads, in red above the buttons, "Custom instructions on the AI tab must be at least 10 characters long". At 420×720 the tablist collapses to scroll buttons and every tab stays reachable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verified in a real browser as well as in jsdom, because most of what broke here is invisible to jsdom:

- **Accessible names read out of Chromium's own accessibility tree**, not a library's re-implementation: dialog `"Settings"`, tablist `"Settings sections"`, exactly one `tabpanel` (the visited-but-hidden ones are out of the tree), and the badged tab computing as `"AI needs attention"` — the visible label extended, not replaced.
- **Keyboard**: `Tab` reaches the tablist, arrows move focus without activating, `Enter` selects, `Tab` then enters the panel. `Escape` closes. `Alt+S` from About persisted an echo count typed on Audio. Three consecutive refused saves, each from a different starting focus, each landed focus on the AI tab with `aria-selected="true"` already set; a valid `Alt+S` still saves and closes from any tab.
- **The regressions, each re-checked after the fix**: the AI panel's key field is the same element on re-entry; an unvisited panel is absent from the DOM; scroll returns to 0 on a switch; the copy status clears; the chat button lands on AI.

`npm run lint`, `npm run type-check`, `npm run build` and `npm test` (7,204 tests) all pass. Playwright passes in full on Chromium (534 tests, including the new keyboard case) — Firefox and WebKit could not run here, as this container ships only a Chromium binary, so CI is the authority for those two.

**One thing I could not verify and would value a second pair of hands on:** whether NVDA and JAWS announce the footer hint. The mechanism is now the one this codebase already relies on for its copy status — text mutating inside a region that was mounted empty — rather than the insertion-of-a-populated-node form the automated review rightly flagged as historically divergent between screen readers. But I tested against Chromium's accessibility tree, not against a real screen reader.

**Two things deliberately left alone**, both predating this PR, so as not to widen the diff — each worth a follow-up: the AI panel's `Alert` is MUI's default `role="alert"`, which interrupts assertively for what is field validation; and `Save` uses `disabled` rather than `aria-disabled`, so it is out of the tab order and its `title` reaches nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QUbQ9yPxyGENZ4z5QxzEj