### PR TITLE
fix(ui): make the settings dialog's blocked save explain itself

### DIFF
--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -559,6 +559,7 @@ const Settings: React.FC = () => {
   const copyStatusId = `${id}-copy-status`;
   const tactileLabelId = `${id}-tactile-label`;
   const tactileStatusId = `${id}-tactile-status`;
+  const saveBlockedId = `${id}-save-blocked`;
   const tactileMenu = useModalContainer();
   const contentRef = React.useRef<HTMLDivElement>(null);
   // `HTMLDivElement` because that is what MUI declares `Tab`'s ref as, even
@@ -819,6 +820,31 @@ const Settings: React.FC = () => {
     = llmSettings.expertiseLevel !== 'custom'
       || llmSettings.customInstruction.length >= MIN_CUSTOM_INSTRUCTION_LENGTH;
 
+  /**
+   * Answers a save that cannot go through.
+   *
+   * Doing nothing would leave a reader with no response at all — no sound, no
+   * text, nothing saying why. Opening the tab that holds the field is the
+   * answer to "why not", and puts them where the fix is; the effect above
+   * then moves focus there, which is the part they can actually perceive.
+   */
+  const refuseSave = useCallback((): void => {
+    setActiveTab('ai');
+    setVisitedTabs(previous =>
+      previous.has('ai') ? previous : new Set(previous).add('ai'));
+    setRefusedSaves(previous => previous + 1);
+  }, []);
+
+  // The single entry point for "the reader asked to save", so the button and
+  // the shortcut cannot answer a refusal differently.
+  const handleSaveRequest = useCallback((): void => {
+    if (!isCustomInstructionValid) {
+      refuseSave();
+      return;
+    }
+    handleSave();
+  }, [isCustomInstructionValid, refuseSave, handleSave]);
+
   // Dialog-scoped: KeybindingService's hotkeys.filter blocks shortcuts while
   // focus is in a non-MAIDR <input>, which would silently break Alt+s / Alt+c
   // inside the manual cells/lines fields.
@@ -831,26 +857,13 @@ const Settings: React.FC = () => {
       const key = e.key.toLowerCase();
       if (key === SAVE_SHORTCUT_KEY) {
         e.preventDefault();
-        if (!isCustomInstructionValid) {
-          // Returning silently would leave a reader who pressed the shortcut
-          // the dialog advertises with no response at all — no sound, no
-          // text, nothing saying why. Opening the tab that holds the field is
-          // the answer to "why not", and puts them where the fix is; the
-          // effect above then moves focus there, which is the part they can
-          // actually perceive.
-          setActiveTab('ai');
-          setVisitedTabs(previous =>
-            previous.has('ai') ? previous : new Set(previous).add('ai'));
-          setRefusedSaves(previous => previous + 1);
-          return;
-        }
-        handleSave();
+        handleSaveRequest();
       } else if (key === CANCEL_SHORTCUT_KEY) {
         e.preventDefault();
         handleClose();
       }
     },
-    [isCustomInstructionValid, handleSave, handleClose],
+    [handleSaveRequest, handleClose],
   );
 
   return (
@@ -1896,21 +1909,51 @@ const Settings: React.FC = () => {
             </Button>
           </Grid>
           <Grid size="auto">
+            {/* `aria-disabled`, not `disabled`. A disabled button leaves the
+                tab order, so a reader working through the footer never meets
+                Save at all and never learns it is unavailable, let alone why
+                — and `title` cannot tell them either, since it needs a hover
+                they have no way to perform. Kept focusable, the button
+                announces its own state and carries the reason as its
+                description, and pressing it answers the same way the
+                shortcut does instead of doing nothing. */}
             <Button
               variant="contained"
               color="primary"
-              onClick={handleSave}
-              disabled={!isCustomInstructionValid}
-              title={
-                !isCustomInstructionValid
-                  ? `Custom instructions must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`
-                  : ''
+              onClick={handleSaveRequest}
+              aria-disabled={!isCustomInstructionValid || undefined}
+              aria-describedby={
+                isCustomInstructionValid ? undefined : saveBlockedId
               }
               aria-label="Save & Close Settings"
               aria-keyshortcuts={`Alt+${SAVE_SHORTCUT_KEY}`}
+              // Reads as unavailable without being it. `disabled` would style
+              // this for free, at the cost of the reachability above.
+              sx={
+                isCustomInstructionValid
+                  ? undefined
+                  : {
+                      'backgroundColor': 'action.disabledBackground',
+                      'color': 'action.disabled',
+                      'boxShadow': 'none',
+                      '&:hover': {
+                        backgroundColor: 'action.disabledBackground',
+                        boxShadow: 'none',
+                      },
+                    }
+              }
             >
               Save & Close
             </Button>
+            {/* The button's description. Separate from the footer hint above,
+                which is a live region announcing a change and stays quiet on
+                the AI tab; this is a static description, and has to be there
+                on every tab, because the button is. */}
+            {!isCustomInstructionValid && (
+              <span id={saveBlockedId} style={visuallyHidden}>
+                {`Custom instructions on the AI tab must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`}
+              </span>
+            )}
           </Grid>
         </Grid>
       </Grid>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -1732,36 +1732,49 @@ const Settings: React.FC = () => {
                       aria-describedby={customInstructionStatusId}
                     />
                   </FormControl>
-                  {/* Rendered whether or not there is anything to say, and
-                      polite rather than assertive. `Alert` defaults to
-                      `role="alert"`, which interrupts — too much for a field
-                      the reader is in the middle of typing. But simply asking
-                      for `role="status"` instead would have traded one fault
-                      for a worse one: a status region created already holding
-                      its text is routinely not announced at all, while an
-                      alert on insertion is. Keeping the region mounted and
-                      letting its text change is what makes it both polite and
-                      reliably heard. */}
-                  <div
-                    id={customInstructionStatusId}
-                    role="status"
-                    aria-live="polite"
-                  >
-                    {llmSettings.customInstruction.length
-                      < MIN_CUSTOM_INSTRUCTION_LENGTH && (
-                      <Alert severity="warning" role="presentation" sx={{ mt: 1 }}>
-                        Custom instructions must be at least
-                        {' '}
-                        {MIN_CUSTOM_INSTRUCTION_LENGTH}
-                        {' '}
-                        characters long
-                      </Alert>
-                    )}
-                  </div>
                 </Grid>
               </Grid>
             </Grid>
           )}
+
+          {/* The warning about the instruction's length, and deliberately
+              outside the block above rather than in it.
+
+              `Alert` defaults to `role="alert"`, which interrupts — too much
+              for a field the reader is in the middle of typing. But simply
+              asking for `role="status"` instead would trade one fault for a
+              worse one: a status region created already holding its text is
+              routinely not announced at all, where an alert on insertion is.
+              What makes the polite role work is the region outliving its
+              content, so that the warning arrives as a change to something
+              already there.
+
+              Which is why it cannot live inside the `custom` block. That
+              block mounts the moment the reader picks "Custom" from the
+              dropdown — with the instruction still empty, so the warning is
+              true immediately — and a region mounting alongside its own
+              first message is the very case this shape exists to avoid.
+              Out here it lives as long as the panel, and every arrival of
+              the warning is a mutation. It costs no space while empty. */}
+          <Grid size={12}>
+            <div
+              id={customInstructionStatusId}
+              role="status"
+              aria-live="polite"
+            >
+              {llmSettings.expertiseLevel === 'custom'
+                && llmSettings.customInstruction.length
+                < MIN_CUSTOM_INSTRUCTION_LENGTH && (
+                <Alert severity="warning" role="presentation" sx={{ mt: 1 }}>
+                  Custom instructions must be at least
+                  {' '}
+                  {MIN_CUSTOM_INSTRUCTION_LENGTH}
+                  {' '}
+                  characters long
+                </Alert>
+              )}
+            </div>
+          </Grid>
         </SettingsTabPanel>
 
         <SettingsTabPanel

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -560,6 +560,7 @@ const Settings: React.FC = () => {
   const tactileLabelId = `${id}-tactile-label`;
   const tactileStatusId = `${id}-tactile-status`;
   const saveBlockedId = `${id}-save-blocked`;
+  const customInstructionStatusId = `${id}-custom-instruction-status`;
   const tactileMenu = useModalContainer();
   const contentRef = React.useRef<HTMLDivElement>(null);
   // `HTMLDivElement` because that is what MUI declares `Tab`'s ref as, even
@@ -1723,21 +1724,41 @@ const Settings: React.FC = () => {
                       }}
                       placeholder="Enter custom instruction..."
                       aria-label="Custom Instructions"
+                      // The field that blocks Save has to say so itself. A
+                      // reader who lands on it hears the requirement as its
+                      // description, rather than having to find the warning
+                      // sitting underneath.
+                      aria-invalid={!isCustomInstructionValid || undefined}
+                      aria-describedby={customInstructionStatusId}
                     />
                   </FormControl>
+                  {/* Rendered whether or not there is anything to say, and
+                      polite rather than assertive. `Alert` defaults to
+                      `role="alert"`, which interrupts — too much for a field
+                      the reader is in the middle of typing. But simply asking
+                      for `role="status"` instead would have traded one fault
+                      for a worse one: a status region created already holding
+                      its text is routinely not announced at all, while an
+                      alert on insertion is. Keeping the region mounted and
+                      letting its text change is what makes it both polite and
+                      reliably heard. */}
+                  <div
+                    id={customInstructionStatusId}
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {llmSettings.customInstruction.length
+                      < MIN_CUSTOM_INSTRUCTION_LENGTH && (
+                      <Alert severity="warning" role="presentation" sx={{ mt: 1 }}>
+                        Custom instructions must be at least
+                        {' '}
+                        {MIN_CUSTOM_INSTRUCTION_LENGTH}
+                        {' '}
+                        characters long
+                      </Alert>
+                    )}
+                  </div>
                 </Grid>
-                {llmSettings.customInstruction.length
-                  < MIN_CUSTOM_INSTRUCTION_LENGTH && (
-                  <Grid size={12} sx={{ mt: 1 }}>
-                    <Alert severity="warning">
-                      Custom instructions must be at least
-                      {' '}
-                      {MIN_CUSTOM_INSTRUCTION_LENGTH}
-                      {' '}
-                      characters long
-                    </Alert>
-                  </Grid>
-                )}
               </Grid>
             </Grid>
           )}

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -388,7 +388,49 @@ describe('settings tabs', () => {
     // The panel is named by the badged tab, so entering it repeats why the
     // reader was sent here.
     expect(screen.getByRole('tabpanel')).toHaveAccessibleName('AI needs attention');
-    expect(screen.getByRole('alert')).toHaveTextContent(
+    expect(
+      document.getElementById(
+        screen.getByLabelText('Custom Instructions').getAttribute('aria-describedby') as string,
+      ),
+    ).toHaveTextContent('Custom instructions must be at least');
+  });
+
+  it('should announce the instruction warning by mutating, not by appearing', async () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: { ...DEFAULT_SETTINGS.llm, expertiseLevel: 'custom', customInstruction: '' },
+    });
+
+    openTab(/^AI/);
+    const field = screen.getByLabelText('Custom Instructions');
+    const region = document.getElementById(
+      field.getAttribute('aria-describedby') as string,
+    );
+    // Present before it has anything to say. A region created already holding
+    // its text is routinely not announced, which is why the polite role only
+    // works if the region outlives its content.
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute('role', 'status');
+
+    const mutations: string[] = [];
+    const observer = new MutationObserver(() => {
+      mutations.push((region as HTMLElement).textContent ?? '');
+    });
+    observer.observe(region as HTMLElement, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    // Long enough to clear the bar, so the warning goes away and comes back.
+    fireEvent.change(field, { target: { value: 'a'.repeat(20) } });
+    await Promise.resolve();
+    fireEvent.change(field, { target: { value: 'short' } });
+    await Promise.resolve();
+    observer.disconnect();
+
+    expect(mutations).not.toHaveLength(0);
+    expect(mutations[mutations.length - 1]).toContain(
       'Custom instructions must be at least',
     );
   });
@@ -471,9 +513,16 @@ describe('settings tabs', () => {
     // The panel's own warning sits beside the field. Repeating it in the
     // footer would announce the same sentence twice to a reader who is
     // already looking at the field it is about.
-    expect(screen.getByRole('alert')).toHaveTextContent(
+    // Resolved the way a reader reaches it — through the field's own
+    // description — rather than by role, which would not distinguish it from
+    // the dialog's other status regions.
+    const field = screen.getByLabelText('Custom Instructions');
+    expect(field).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = field.getAttribute('aria-describedby');
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
       'Custom instructions must be at least',
     );
+
     // The footer's own region specifically: the Save button's description
     // carries similar words and is meant to be there on every tab.
     expect(document.querySelector('.settings-footer-hint')).toHaveTextContent('');

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -16,9 +16,10 @@
  *   another tab. It has to be saved anyway.
  * - **The tablist has to be operable and named.** It is the only way to reach
  *   five of the six panels, by keyboard as much as by pointer.
- * - **A blocked Save has to stay explainable.** Save is disabled while the
- *   custom instruction is too short, and that field is on a tab the reader
- *   may not be looking at.
+ * - **A blocked Save has to stay explainable.** Save is marked unavailable
+ *   while the custom instruction is too short — `aria-disabled`, so it keeps
+ *   its tab stop — and that field is on a tab the reader may not be looking
+ *   at.
  */
 
 import type { CommandExecutor } from '@service/commandExecutor';

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -296,17 +296,28 @@ describe('settings tabs', () => {
       },
     });
 
-    // Disabled, and — now that the field can be several tabs away — with no
-    // way to reach the reason from where the reader is standing. The hint and
-    // the tab's badge are that way back.
-    expect(screen.getByRole('button', { name: SAVE_BUTTON_NAME })).toBeDisabled();
+    // Marked unavailable rather than `disabled`, so it keeps its place in the
+    // tab order and the reason stays reachable from the button itself.
+    const save = screen.getByRole('button', { name: SAVE_BUTTON_NAME });
+    expect(save).toHaveAttribute('aria-disabled', 'true');
+    expect(save).not.toBeDisabled();
 
-    const hint = screen.getByText(
+    // Two nodes carry the reason, and each has a job the other cannot do.
+    // The footer's is a live region: it announces the moment Save becomes
+    // unavailable, to a reader who is looking elsewhere.
+    const hint = document.querySelector('.settings-footer-hint');
+    expect(hint).toHaveAttribute('role', 'status');
+    expect(hint).toHaveTextContent(
       'Custom instructions on the AI tab must be at least 10 characters long',
     );
-    // A live region, so it reaches a reader who is on another tab when Save
-    // goes disabled rather than only one who happens to read the footer.
-    expect(hint).toHaveAttribute('role', 'status');
+
+    // The button's is a description, read when the reader arrives at it —
+    // which a live region fired minutes earlier would not be.
+    const describedBy = save.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
+      'Custom instructions on the AI tab must be at least 10 characters long',
+    );
     // The visible label stays inside the accessible name rather than being
     // replaced by it, so "AI" is still what a reader hears the tab called.
     expect(
@@ -382,6 +393,34 @@ describe('settings tabs', () => {
     );
   });
 
+  it('should keep an unavailable Save reachable and answering', () => {
+    const saveAndClose = renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: {
+        ...DEFAULT_SETTINGS.llm,
+        expertiseLevel: 'custom',
+        customInstruction: 'too short',
+      },
+    });
+
+    const save = screen.getByRole('button', { name: SAVE_BUTTON_NAME });
+    // In the tab order, which `disabled` would have taken it out of — the
+    // whole point, since a button a reader never reaches cannot explain
+    // itself however good its description is.
+    expect(save).not.toHaveAttribute('tabindex', '-1');
+    save.focus();
+    expect(document.activeElement).toBe(save);
+
+    fireEvent.click(save);
+
+    // Answers rather than doing nothing, and answers the same way the
+    // shortcut does — the two go through one path.
+    expect(saveAndClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      screen.getByRole('tab', { name: 'AI needs attention' }),
+    );
+  });
+
   it('should move focus to that tab every time a save is refused', () => {
     renderSettings({
       ...DEFAULT_SETTINGS,
@@ -435,8 +474,8 @@ describe('settings tabs', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(
       'Custom instructions must be at least',
     );
-    expect(
-      screen.queryByText(/Custom instructions on the AI tab/),
-    ).not.toBeInTheDocument();
+    // The footer's own region specifically: the Save button's description
+    // carries similar words and is meant to be there on every tab.
+    expect(document.querySelector('.settings-footer-hint')).toHaveTextContent('');
   });
 });

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -10,9 +10,10 @@
  * split across six tabs, which puts three things at risk that the flat list
  * could not get wrong:
  *
- * - **Edits have to survive a tab switch.** Only the selected panel is
- *   mounted, so an edit typed on one tab is no longer backed by a field in
- *   the DOM when Save is pressed from another. It has to be saved anyway.
+ * - **Edits have to survive a tab switch.** A panel the reader has left is
+ *   hidden, and one they have never opened is not rendered at all, so an
+ *   edit is no longer backed by a reachable field when Save is pressed from
+ *   another tab. It has to be saved anyway.
  * - **The tablist has to be operable and named.** It is the only way to reach
  *   five of the six panels, by keyboard as much as by pointer.
  * - **A blocked Save has to stay explainable.** Save is disabled while the
@@ -175,9 +176,9 @@ describe('settings tabs', () => {
       expect(tab.getAttribute('aria-controls')).toBe(panel.id);
       expect(panel).toHaveAccessibleName(label);
 
-      // The unselected tabs have no panel in the document, so they must not
-      // name one: an `aria-controls` pointing at an absent id is a dangling
-      // reference.
+      // Only the selected tab names a panel. The others either have none in
+      // the document or have one that is hidden, and so out of the
+      // accessibility tree — nothing worth pointing at either way.
       for (const other of screen.getAllByRole('tab')) {
         if (other !== tab) {
           expect(other).not.toHaveAttribute('aria-controls');
@@ -194,8 +195,9 @@ describe('settings tabs', () => {
       target: { value: '35' },
     });
 
-    // The field that carried the edit is unmounted by this point, so what is
-    // saved can only come from the dialog's own state.
+    // The field that carried the edit is hidden by this point, and out of the
+    // accessibility tree, so what is saved can only come from the dialog's
+    // own state rather than from anything the reader could still reach.
     openTab('Visual');
     fireEvent.change(screen.getByLabelText('High Contrast Levels'), {
       target: { value: '7' },

--- a/test/ui/settings.tabs.test.tsx
+++ b/test/ui/settings.tabs.test.tsx
@@ -438,6 +438,51 @@ describe('settings tabs', () => {
     );
   });
 
+  it('should announce the warning when Custom is picked, not spring it into being', async () => {
+    renderSettings({
+      ...DEFAULT_SETTINGS,
+      llm: { ...DEFAULT_SETTINGS.llm, expertiseLevel: 'basic', customInstruction: '' },
+    });
+
+    openTab(/^AI/);
+
+    // The region has to be there before "Custom" is picked. Choosing it is
+    // the ordinary way into this state — the instruction is empty, so the
+    // warning is true immediately — and if the region arrived carrying that
+    // first message it would be the case the polite role cannot survive.
+    const region = document.querySelector('[id$="-custom-instruction-status"]');
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveTextContent('');
+
+    const mutations: string[] = [];
+    const observer = new MutationObserver(() => {
+      mutations.push((region as HTMLElement).textContent ?? '');
+    });
+    observer.observe(region as HTMLElement, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    // A MUI `Select`, so it opens on mousedown and commits on the option
+    // click rather than taking a value the way a native select would.
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Expertise Level' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Custom' }));
+    // `MutationObserver` delivers on a microtask, so the records are not in
+    // hand until the queue drains.
+    await Promise.resolve();
+    observer.disconnect();
+
+    // The field itself arrived with the switch; only the warning had to be a
+    // change to something already standing.
+    expect(screen.getByLabelText('Custom Instructions')).toBeInTheDocument();
+    expect(mutations).not.toHaveLength(0);
+    expect(mutations[mutations.length - 1]).toContain(
+      'Custom instructions must be at least',
+    );
+  });
+
   it('should keep an unavailable Save reachable and answering', () => {
     const saveAndClose = renderSettings({
       ...DEFAULT_SETTINGS,


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #1241. Two accessibility defects were found during that review, judged out of scope because they predate the tab split, and recorded there as follow-ups. This is that follow-up. Both are about the same moment — the reader cannot save, and the dialog does a poor job of telling them why.

Neither was introduced by #1241, but the tab split raised the stakes on both: the field that blocks Save is now on a tab the reader may not be looking at.

## Related Issues

Follows up on #1241 (the two items listed under "Two things deliberately left alone" in its description).

## Changes Made

### `c6cf32f` — an unavailable Save that can be reached

`disabled` takes a button out of the tab order. A reader working through the footer met Reset, then Close, then wrapped — never learning that Save existed, that it was unavailable, or why. The `title` carrying the reason could not help either: it needs a hover a keyboard user cannot perform, and `aria-label` outranks it in the name computation regardless.

It is now `aria-disabled`. The button keeps its place in the tab order, announces its own unavailable state, and carries the reason as a description. That description is a separate node from the footer hint on purpose — the footer hint is a live region that deliberately goes quiet on the AI tab, and a description has to be there on every tab, because the button is.

Pressing it now answers the way `Alt+S` does rather than doing nothing. Both go through one `handleSaveRequest`, so a refusal cannot come out differently depending on how the reader asked for it.

### `0443388`, `f3e4911` — a warning that is polite *and* still heard

The warning under the custom instruction is a MUI `Alert`, which defaults to `role="alert"` and so interrupts assertively — too much for a field the reader is in the middle of typing, and against the repo's own rule reserving assertive for the result of the reader's own navigation.

**Simply asking for `role="status"` instead would have made it worse.** The warning appears and disappears as the instruction crosses the length bar, and a status region created already holding its text is routinely not announced at all, where an alert on insertion is. So the region is now the part that stays: rendered whether or not there is anything to say, with its text changing. That is what a live region announces on, and it is the shape the copy status and the footer hint in this same file already use.

`f3e4911` finishes that thought. The region was still inside the block gated on the Custom expertise level, which put it back in the shape it was reshaped to avoid — **picking "Custom" from the dropdown is the ordinary way into this state**, the instruction is empty at that moment, so the region was mounting alongside its own first message. It now sits outside that block and lives as long as the panel.

The field also identifies itself as the one at fault — `aria-invalid`, plus a description pointing at that region — rather than leaving a reader to discover the warning sitting underneath it.

### `ebf9ff7`, `fbfd2a0` — comments that outlived what they described

Four comments in the tab tests were written against behaviour that has since changed, and are the kind a later reader trusts. Three described an inactive panel as unmounted, from before panels started mounting on first visit and staying — they asserted the opposite of what the code does. The fourth called Save "disabled" one commit after it stopped being, which is exactly the distinction the tests around it now turn on, since one of them asserts it is deliberately *not* `disabled`.

The assertions were already right in every case; only the stated reasons were stale.

## Screenshots (if applicable)

No visual change. `Save & Close` renders exactly as it did — greyed out, reading as unavailable — because the disabled palette is applied through `sx` instead of coming free with the `disabled` attribute. The warning still sits 20px under the textarea, left-aligned with it, and its region occupies no space while empty: the dialog measures the same height on the AI tab with a valid instruction as with an invalid one.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Read back out of Chromium's own accessibility tree, since the whole point is what assistive technology is handed:

```
AX name       : "Save & Close Settings"
AX description: "Custom instructions on the AI tab must be at least 10 characters long"
AX disabled   : true
AX focusable  : true
```

`disabled` and `focusable` both true is the goal state — unavailable, and still reachable. Tabbing from Close now lands on Save, which it did not before; pressing Enter there keeps the dialog open and moves focus to the tab reading "AI needs attention".

The live region was watched on the running page rather than only in jsdom:

```
region exists before Custom is picked : yes, empty
mutations on picking Custom           : ["Custom instructions must be at least 10 …"]
mutations on typing across the bar    : ["", "Custom instructions must be at least 10 …"]
```

Three test cases were added, each pinning a property rather than the markup that produces it: that Save keeps its tab stop and answers a press; that the warning region exists *before* it has anything to say, across a typed valid→invalid transition; and that it exists before **Custom is picked**, which is the path `f3e4911` fixes. A fourth property — that the field's `aria-describedby` resolves to that region — is asserted inside an existing case.

### What the live region does and does not carry

The claim is that the warning announces because its region outlives its content. After `f3e4911` that holds for every transition *within* a mounted AI panel — typing across the length bar, and picking "Custom" from the dropdown.

It does not hold for the panel's own first mount, which can arrive with the warning already inside it whenever the dialog opens on saved settings that are already `custom` and too short. Two routes reach that: a refused `Alt+S` from another tab, and simply opening the AI tab. **An earlier version of this description named only the first; the review was right that it is both.**

On neither route is the live region the mechanism, and on neither is the reader left without the reason:

- The tab is named **"AI needs attention"**, so selecting it — however they got there — announces that something on it wants attention.
- The field carries `aria-invalid` and a description resolving to the same text, so reaching it states the requirement.
- On the refused-save route, focus is moved to that tab deliberately, which is what makes the refusal perceptible at all.

So the live region is what covers changes; the tab name and the field description are what cover arrival. `should open the tab holding the reason when a blocked Alt+S is pressed` exercises the first-mount case.

**Still not verified, and unchanged from #1241:** none of this has been through NVDA or JAWS. That matters more for the warning region than for the Save button, since the reason the region is mounted-and-mutated rather than inserted is precisely a screen-reader behaviour I can reason about but not observe here.

**The third item from #1241's follow-up list is not here.** That was the NVDA/JAWS pass itself, which needs a real screen reader.

`npm run lint`, `npm run type-check`, `npm run build` and `npm test` (7,207) all pass, as does the Playwright suite on Chromium (534). Firefox and WebKit could not run here — this container ships only a Chromium binary — so CI is the authority for those two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QUbQ9yPxyGENZ4z5QxzEj