### PR TITLE
feat(keybinding): answer an unassigned key instead of doing nothing

### DIFF
--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -46,9 +46,13 @@ A key that no shortcut in the current mode uses answers with a short warning —
 — together with the warning tone, so a guess is never met with silence.
 
 Keys held with Control, Command, or Option are left alone, because that is
-where the browser and your screen reader keep their own commands. Inside the
-settings, chat, and command palette dialogs there is no warning either: help is
-not reachable from them, and what you type there is usually text.
+where the browser and your screen reader keep their own commands.
+
+The warning appears only where the help shortcut itself works — reading a
+chart, in braille mode, and in label mode. Anywhere it does not, such as the
+dialogs, review mode, and inside a grid cell, an unassigned key stays silent:
+there would be nothing useful to point you at, and what you press there is
+often text rather than a missed shortcut.
 
 ## Monitor Mode (Live Charts)
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -39,6 +39,17 @@ Below is a detailed list of keyboard shortcuts for various functions:
 | Open/Close keyboard shortcut help       | Control + /                 | Command + /                 |
 | Open AI chat (API key set in Settings)  | Shift + / (?)               | Shift + / (?)               |
 
+## Unassigned Keys
+
+A key that no shortcut in the current mode uses answers with a short warning —
+"Invalid key. Press Control Slash for keyboard help." (Command Slash on a Mac)
+— together with the warning tone, so a guess is never met with silence.
+
+Keys held with Control, Command, or Option are left alone, because that is
+where the browser and your screen reader keep their own commands. Inside the
+settings, chat, and command palette dialogs there is no warning either: help is
+not reachable from them, and what you type there is usually text.
+
 ## Monitor Mode (Live Charts)
 
 On charts configured with `live: true`, press **M** to toggle monitor mode. While monitoring is on, every newly streamed data point is automatically sonified and announced by your screen reader without moving your current position. See the [Live & Streaming Data](LIVE_DATA.html) guide for details.

--- a/src/command/invalidKey.ts
+++ b/src/command/invalidKey.ts
@@ -1,0 +1,119 @@
+import type { AudioService } from '@service/audio';
+import type { NotificationService } from '@service/notification';
+import type { Command } from './command';
+import { Platform } from '@util/platform';
+
+/**
+ * Keys that carry no MAIDR action anywhere, so pressing one is not a mistake.
+ *
+ * Modifiers and Caps Lock are half of a chord rather than a press of their
+ * own. Tab moves focus out of the chart, and Insert, the lock keys and the
+ * function row belong to the browser or the screen reader -- NVDA and JAWS
+ * build their own commands on Insert, and warning there would fire on someone
+ * else's shortcut. The last three are a keypress the browser could not name,
+ * which usually means an IME or a dead key partway through composing a
+ * character.
+ */
+const IGNORED_KEYS = new Set([
+  'Alt',
+  'CapsLock',
+  'Control',
+  'Meta',
+  'Shift',
+  'ContextMenu',
+  'Insert',
+  'NumLock',
+  'Pause',
+  'PrintScreen',
+  'ScrollLock',
+  'Tab',
+  'Dead',
+  'Process',
+  'Unidentified',
+]);
+
+/** `F1` through `F12`, which the browser and the screen reader claim. */
+const FUNCTION_KEY = /^F\d{1,2}$/;
+
+/**
+ * Announces that the key just pressed does nothing here, and says how to find
+ * the keys that do.
+ *
+ * Silence was the previous answer, and silence is indistinguishable from a
+ * chart that has stopped responding: a reader who guesses a key learns
+ * nothing from it, least of all that a list of the real ones exists. The
+ * chord is spelled out in words because a screen reader announcing
+ * `Ctrl + /` may say only "control" -- punctuation is commonly skipped at
+ * default verbosity -- and it names Command on macOS because that is what the
+ * binding actually is there.
+ *
+ * Constructed directly by `KeybindingService` rather than through
+ * `CommandFactory`: the factory maps a key of a scope's keymap to a command,
+ * and this one answers for every key that is *not* in it.
+ */
+export class InvalidKeyCommand implements Command {
+  private readonly notificationService: NotificationService;
+  private readonly audioService: AudioService;
+
+  /**
+   * Creates an instance of InvalidKeyCommand.
+   * @param notificationService - Speaks the warning.
+   * @param audioService - Plays the warning tone alongside it.
+   */
+  public constructor(
+    notificationService: NotificationService,
+    audioService: AudioService,
+  ) {
+    this.notificationService = notificationService;
+    this.audioService = audioService;
+  }
+
+  /**
+   * Warns about an unassigned keypress, or stays silent if the press was
+   * never aimed at MAIDR.
+   * @param event - The keydown event no binding claimed.
+   */
+  public execute(event?: Event): void {
+    if (!InvalidKeyCommand.isUnassignedPress(event)) {
+      return;
+    }
+
+    this.notificationService.notify(
+      `Invalid key. Press ${Platform.ctrlSpoken} Slash for keyboard help.`,
+    );
+    // The conditional variant: a reader who switched sonification off asked
+    // for silence, and the spoken warning lands either way.
+    this.audioService.playWarningToneIfEnabled();
+  }
+
+  /**
+   * Decides whether an unclaimed keypress was a reader reaching for a MAIDR
+   * shortcut, as opposed to input meant for something else.
+   *
+   * Anything held with Ctrl, Cmd or Alt is left alone. Those chords are where
+   * the browser, the operating system and the screen reader keep their own
+   * commands -- VoiceOver alone owns every Ctrl+Option combination -- and
+   * answering "invalid key" to a working screen-reader command would be both
+   * wrong and unstoppable. Shift is not in that list: Shift and a letter is
+   * still someone typing a key at the chart.
+   * @param event - The event to judge.
+   * @returns True when the press deserves a warning.
+   */
+  private static isUnassignedPress(event?: Event): boolean {
+    // Duck-typed rather than `instanceof KeyboardEvent`, which is not defined
+    // outside a DOM.
+    const press = event as Partial<KeyboardEvent> | undefined;
+    if (!press || typeof press.key !== 'string') {
+      return false;
+    }
+    // A held-down key repeats many times a second; one warning is the answer
+    // to all of them.
+    if (press.repeat) {
+      return false;
+    }
+    if (press.ctrlKey || press.metaKey || press.altKey) {
+      return false;
+    }
+    return !IGNORED_KEYS.has(press.key) && !FUNCTION_KEY.test(press.key);
+  }
+}

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -6,6 +6,7 @@ import type { KeybindingEntry, Keys } from '@type/event';
 import type { Observer } from '@type/observable';
 import type { Settings } from '@type/settings';
 import { CommandFactory } from '@command/factory';
+import { InvalidKeyCommand } from '@command/invalidKey';
 import { PointerGuidanceCommand } from '@command/pointerGuidance';
 import { Scope } from '@type/event';
 import { Constant } from '@util/constant';
@@ -22,6 +23,16 @@ function key(hotkey: string, description: string, options?: Partial<KeybindingEn
     ...options,
   };
 }
+
+/**
+ * The chord that opens the help menu, and the mark of a scope that can point a
+ * reader at it.
+ *
+ * Named rather than repeated so the two uses cannot drift apart: the scopes
+ * below bind it, and {@link KeybindingService.warnOnUnassignedKeys} advertises
+ * it only where it is bound. Rebinding help here moves both at once.
+ */
+const HELP_CHORD = `${Platform.ctrl}+/`;
 
 /**
  * Tactile display bindings, shared by every scope the display can be up in.
@@ -120,7 +131,7 @@ const BRAILLE_KEYMAP = {
   TOGGLE_MONITOR: key(`m`, 'Toggle Monitor Mode (Live Charts)'),
 
   // Misc
-  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_HELP: key(HELP_CHORD, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
   TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
   TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
 
@@ -189,7 +200,7 @@ const CANDLESTICK_DELTA_KEYMAP = {
   TOGGLE_REVIEW: key(`r`, 'Toggle Review Mode'),
 
   // Misc
-  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_HELP: key(HELP_CHORD, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
   TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
   TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
 
@@ -246,7 +257,7 @@ const FIGURE_LABEL_KEYMAP = {
   ANNOUNCE_CAPTION: key(`c`, 'Announce Caption'),
 
   // Misc
-  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_HELP: key(HELP_CHORD, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
 } as const;
 
 /**
@@ -299,7 +310,7 @@ const SUBPLOT_KEYMAP = {
   TOGGLE_MONITOR: key(`m`, 'Toggle Monitor Mode (Live Charts)'),
 
   // Misc
-  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_HELP: key(HELP_CHORD, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
   TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
   TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
 } as const;
@@ -319,7 +330,7 @@ const TRACE_LABEL_KEYMAP = {
   ANNOUNCE_CAPTION: key(`c`, 'Announce Caption'),
 
   // Misc
-  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_HELP: key(HELP_CHORD, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
 } as const;
 
 /**
@@ -397,7 +408,7 @@ const TRACE_KEYMAP = {
   TOGGLE_MONITOR: key(`m`, 'Toggle Monitor Mode (Live Charts)'),
 
   // Misc
-  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_HELP: key(HELP_CHORD, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
   TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
   TOGGLE_COMMAND_PALETTE: key(`${Platform.ctrl}+shift+p`, 'Open Command Palette', { helpKey: `${Platform.ctrl} + shift + p` }),
   TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
@@ -535,6 +546,15 @@ export function getKeymapForScope(scope: Scope): ScopeKeymap {
  */
 export class KeybindingService {
   private readonly commandFactory: CommandFactory;
+  private readonly invalidKeyCommand: InvalidKeyCommand;
+
+  /**
+   * The keydown event a binding last claimed.
+   *
+   * Read only by {@link warnOnUnassignedKeys}, which compares by identity to
+   * tell an unassigned press from one a shortcut has just handled.
+   */
+  private lastBoundEvent: KeyboardEvent | null = null;
 
   /**
    * Creates a new KeybindingService instance with command factory.
@@ -542,6 +562,10 @@ export class KeybindingService {
    */
   public constructor(commandContext: CommandContext) {
     this.commandFactory = new CommandFactory(commandContext);
+    this.invalidKeyCommand = new InvalidKeyCommand(
+      commandContext.notificationService,
+      commandContext.audioService,
+    );
   }
 
   /**
@@ -579,6 +603,7 @@ export class KeybindingService {
         if (commandName === 'STOP_AUTOPLAY') {
           hotkeys('*', scope, (event: KeyboardEvent): void => {
             if (hotkeys.command || hotkeys.ctrl) {
+              this.lastBoundEvent = event;
               const command = this.commandFactory.create(commandName);
               command.execute(event);
             }
@@ -586,6 +611,7 @@ export class KeybindingService {
         }
 
         hotkeys(hotkey, { scope }, (event: KeyboardEvent): void => {
+          this.lastBoundEvent = event;
           if (commandName !== 'ALLOW_DEFAULT') {
             event.preventDefault();
             const command = this.commandFactory.create(commandName);
@@ -593,9 +619,47 @@ export class KeybindingService {
           }
         });
       }
+
+      this.warnOnUnassignedKeys(scope, keymap as ScopeKeymap);
     }
 
     this.setScope(initialScope);
+  }
+
+  /**
+   * Speaks up when a key this scope has no shortcut for is pressed.
+   *
+   * The old answer was silence, which a reader cannot tell apart from a chart
+   * that has stopped responding, and which never mentions that a key list
+   * exists at all. Only scopes that bind {@link HELP_CHORD} take the warning:
+   * the advice it gives has to be advice the reader can act on, and inside a
+   * modal -- settings, chat, the command palette -- help is not reachable and
+   * the keystroke is likelier to be typing than a missed shortcut.
+   *
+   * hotkeys-js dispatches every `*` handler for an event before any of the
+   * handlers bound to that specific key, so at this point no shortcut has had
+   * the chance to claim the press yet. Deferring the check to a microtask lets
+   * the rest of the dispatch run first, and makes hotkeys-js itself the judge
+   * of what counts as bound -- there is no second copy of its key parsing here
+   * to fall out of step with the keymaps.
+   *
+   * @param scope - The scope whose unassigned keys should warn.
+   * @param keymap - That scope's keymap, checked for the help chord.
+   */
+  private warnOnUnassignedKeys(scope: Scope, keymap: ScopeKeymap): void {
+    if (keymap.TOGGLE_HELP?.hotkey !== HELP_CHORD) {
+      return;
+    }
+
+    hotkeys('*', scope, (event: KeyboardEvent): void => {
+      queueMicrotask(() => {
+        const claimed = this.lastBoundEvent === event;
+        this.lastBoundEvent = null;
+        if (!claimed) {
+          this.invalidKeyCommand.execute(event);
+        }
+      });
+    });
   }
 
   /**

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -35,4 +35,17 @@ export abstract class Platform {
   public static get enter(): string {
     return Platform.IS_MAC ? 'return' : 'enter';
   }
+
+  /**
+   * Returns the control/command key's name as it should be spoken.
+   *
+   * Separate from {@link ctrl}, which yields the lower-case token hotkeys-js
+   * parses. A screen reader reads an announcement out loud, so the word has to
+   * be the one the reader would say -- capitalised, and never abbreviated to
+   * the symbol, which many voices skip entirely.
+   * @returns 'Command' on macOS, 'Control' on other platforms
+   */
+  public static get ctrlSpoken(): string {
+    return Platform.IS_MAC ? 'Command' : 'Control';
+  }
 }

--- a/test/command/invalidKey.test.ts
+++ b/test/command/invalidKey.test.ts
@@ -1,0 +1,119 @@
+import type { AudioService } from '@service/audio';
+import type { NotificationService } from '@service/notification';
+import { InvalidKeyCommand } from '@command/invalidKey';
+import { describe, expect, it, jest } from '@jest/globals';
+import { Platform } from '@util/platform';
+
+interface Mocks {
+  command: InvalidKeyCommand;
+  notify: jest.Mock<(message: string) => void>;
+  playWarningToneIfEnabled: jest.Mock<() => void>;
+}
+
+function createCommand(): Mocks {
+  const notify = jest.fn<(message: string) => void>();
+  const playWarningToneIfEnabled = jest.fn<() => void>();
+
+  const command = new InvalidKeyCommand(
+    { notify } as unknown as NotificationService,
+    { playWarningToneIfEnabled } as unknown as AudioService,
+  );
+
+  return { command, notify, playWarningToneIfEnabled };
+}
+
+/** Builds the shape {@link InvalidKeyCommand} duck-types, without a DOM. */
+function press(key: string, modifiers: Partial<KeyboardEvent> = {}): Event {
+  return { key, ...modifiers } as unknown as Event;
+}
+
+describe('invalidKeyCommand.execute', () => {
+  it('announces the help chord and warns by ear on an unassigned key', () => {
+    const { command, notify, playWarningToneIfEnabled } = createCommand();
+
+    command.execute(press('q'));
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(playWarningToneIfEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  it('spells the chord out in words a screen reader will read', () => {
+    const { command, notify } = createCommand();
+
+    command.execute(press('q'));
+
+    // Not `Ctrl + /`: a screen reader at default verbosity commonly skips the
+    // punctuation, leaving the reader with half an instruction. Which of the
+    // two words appears depends on the machine the suite runs on.
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^Invalid key\. Press (?:Control|Command) Slash for keyboard help\.$/,
+      ) as unknown as string,
+    );
+  });
+
+  it('names the modifier this platform actually binds help to', () => {
+    const { command, notify } = createCommand();
+
+    command.execute(press('q'));
+
+    // `Platform.ctrl` is the token hotkeys-js binds the help chord with. The
+    // announcement has to name the same physical key -- saying 'Control' on a
+    // Mac would send the reader to a chord that is not bound there -- and only
+    // the wording differs, since hotkeys-js takes 'ctrl' where speech wants
+    // the whole word.
+    const [message] = notify.mock.calls[0];
+    expect(message.includes('Command')).toBe(Platform.ctrl === 'command');
+  });
+
+  it('warns on a shifted key, which is still someone typing at the chart', () => {
+    const { command, notify } = createCommand();
+
+    command.execute(press('Q', { shiftKey: true }));
+
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['ctrl', { ctrlKey: true }],
+    ['command', { metaKey: true }],
+    ['alt', { altKey: true }],
+  ])('stays silent for a %s chord, which the browser or screen reader owns', (_name, modifier) => {
+    const { command, notify, playWarningToneIfEnabled } = createCommand();
+
+    command.execute(press('q', modifier));
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(playWarningToneIfEnabled).not.toHaveBeenCalled();
+  });
+
+  it.each(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock', 'Tab', 'Insert', 'F1', 'F12'])(
+    'stays silent for %s, which was never aimed at a shortcut',
+    (key) => {
+      const { command, notify } = createCommand();
+
+      command.execute(press(key));
+
+      expect(notify).not.toHaveBeenCalled();
+    },
+  );
+
+  it('warns once for a held key rather than on every repeat', () => {
+    const { command, notify } = createCommand();
+
+    command.execute(press('q'));
+    command.execute(press('q', { repeat: true }));
+    command.execute(press('q', { repeat: true }));
+
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an event that is not a keypress at all', () => {
+    const { command, notify } = createCommand();
+
+    command.execute();
+    command.execute({} as Event);
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/test/service/keybindingInvalidKey.test.ts
+++ b/test/service/keybindingInvalidKey.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { CommandContext } from '@command/command';
+import type { TextViewModel } from '@state/viewModel/textViewModel';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { KeybindingService } from '@service/keybinding';
+import { Scope } from '@type/event';
+
+const KEY_CODE = {
+  b: 66,
+  q: 81,
+  t: 84,
+} as const;
+
+interface Harness {
+  service: KeybindingService;
+  notify: jest.Mock<(message: string) => void>;
+  toggleText: jest.Mock<() => void>;
+}
+
+function createService(): Harness {
+  const notify = jest.fn<(message: string) => void>();
+  const toggleText = jest.fn<() => void>();
+
+  // Only the collaborators the exercised paths reach: CommandFactory just
+  // stores the rest of the context.
+  const commandContext = {
+    notificationService: { notify },
+    audioService: { playWarningToneIfEnabled: jest.fn() },
+    textViewModel: { toggle: toggleText } as unknown as TextViewModel,
+  } as unknown as CommandContext;
+
+  return { service: new KeybindingService(commandContext), notify, toggleText };
+}
+
+/** Dispatches a keydown and lets the deferred unassigned-key check run. */
+async function press(keyCode: number, init: KeyboardEventInit = {}): Promise<void> {
+  document.body.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, keyCode, ...init }),
+  );
+  await Promise.resolve();
+}
+
+describe('keybindingService unassigned-key warning', () => {
+  let harness: Harness | null = null;
+
+  afterEach(() => {
+    harness?.service.unregister();
+    harness = null;
+  });
+
+  it('warns when a key no shortcut in the scope claims is pressed', async () => {
+    harness = createService();
+    harness.service.register(Scope.TRACE);
+
+    await press(KEY_CODE.q);
+
+    expect(harness.notify).toHaveBeenCalledWith(
+      expect.stringContaining('Slash for keyboard help') as unknown as string,
+    );
+  });
+
+  it('stays silent when the key runs a shortcut', async () => {
+    harness = createService();
+    harness.service.register(Scope.TRACE);
+
+    await press(KEY_CODE.t);
+
+    expect(harness.toggleText).toHaveBeenCalledTimes(1);
+    expect(harness.notify).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for a key bound in another scope only', async () => {
+    harness = createService();
+    // `b` toggles braille in TRACE; the settings dialog binds nothing at all.
+    harness.service.register(Scope.SETTINGS);
+
+    await press(KEY_CODE.b);
+
+    expect(harness.notify).not.toHaveBeenCalled();
+  });
+
+  it('warns again on the next unassigned key', async () => {
+    harness = createService();
+    harness.service.register(Scope.TRACE);
+
+    await press(KEY_CODE.q);
+    await press(KEY_CODE.q);
+
+    expect(harness.notify).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

A key that no shortcut in the current scope claims used to produce nothing at all — no sound, no announcement. A reader cannot tell that apart from a chart that has stopped responding, and nothing about it reveals that a list of the real keys exists. Guessing was the only way in, and guessing wrong taught nothing.

Such a press now answers **"Invalid key. Press Control Slash for keyboard help."** together with the existing warning tone.

The chord is spelled out in words on purpose: a screen reader at default verbosity commonly skips punctuation, so `Ctrl + /` can reach the listener as just "control" — half an instruction. And it says **Command Slash** on macOS, because `command+/` is the chord actually bound there.

## Related Issues

None filed; raised directly.

## Changes Made

**`src/command/invalidKey.ts`** (new) — `InvalidKeyCommand`. Decides whether an unclaimed press was aimed at MAIDR, then notifies and plays the warning tone. Constructed directly by `KeybindingService`, the way `Mousebindingservice` constructs `PointerGuidanceCommand`: `CommandFactory` maps a key *of* a scope's keymap to a command, and this one answers for every key that is not in it.

**`src/service/keybinding.ts`** — registers one `*` handler per scope that binds the help chord, and marks the event a binding claimed.

- **Which scopes warn.** Only those that bind `HELP_CHORD`. The advice has to be advice the reader can act on, and inside settings, chat, the command palette or the help dialog itself, help is not reachable and the keystroke is likelier to be text than a missed shortcut. That list is derived from the keymaps rather than hardcoded, and the chord is now a named constant the six keymaps share, so rebinding help moves both halves at once.
- **How "unclaimed" is decided.** By hotkeys-js itself, not by a second copy of its key parsing that could drift from the keymaps. It dispatches every `*` handler *before* the handlers bound to that specific key, so the check waits on a microtask for the rest of the dispatch to finish and then compares event identity.
- Nothing calls `preventDefault`, so no key changes what it did before.

**`src/util/platform.ts`** — `Platform.ctrlSpoken` (`Control` / `Command`), the spoken counterpart to `Platform.ctrl`'s hotkeys-js token.

**What stays silent.** Anything held with Ctrl, Cmd or Alt — that is where the browser, the OS and the screen reader keep their own commands, VoiceOver owning every Ctrl+Option among them, and answering "invalid key" to a working screen-reader command would be both wrong and unstoppable. Also the modifiers themselves, Caps Lock, Tab, the lock keys, Insert, F1–F12, IME/dead keys, and the repeats of a held key. Shift is deliberately *not* on that list: Shift and a letter is still someone typing a key at the chart.

## Screenshots (if applicable)

Not applicable — the change is an announcement and a tone.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Tests.** `test/command/invalidKey.test.ts` covers the message and every ignore rule. `test/service/keybindingInvalidKey.test.ts` runs against the real hotkeys-js in jsdom — an unassigned key warns, a key that runs a shortcut does not, and a scope without the help chord stays quiet — which is what pins the wildcard-then-microtask ordering this depends on.

**Verified locally:** `npm run lint:fix`, `npm run type-check`, `npm run build` all clean; `npm test` green at 550 unit suites / 7592 tests plus 15 ESM suites / 177 tests.

**Docs.** `docs/CONTROLS.md` gains a short "Unassigned Keys" section covering the message and what is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U977UMv7uEhebax7npqVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01U977UMv7uEhebax7npqVX7)_