### PR TITLE
feat(ui): read the description table the way the chart's author asked

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -174,6 +174,7 @@ export class Controller implements Disposable {
       this.context,
       this.displayService,
       this.rotorNavigationService,
+      this.formatterService,
     );
     this.helpService = new HelpService(this.context, this.displayService);
     this.chatService = new ChatService(

--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -421,6 +421,10 @@ export class AreaTrace extends LineTrace {
 
     return {
       headers: [...table.headers, TOTAL],
+      // The line's own columns keep their axes; the total is summed here out
+      // of every band at that x rather than read off an axis the layer
+      // declared, so it carries none and keeps the dialog's own rounding.
+      columnAxes: table.columnAxes && [...table.columnAxes, undefined],
       // Looked up by the x in column 0 of the row the line built, never by
       // index, for the reason `columnTotals` gives. A column reached only by
       // gaps carries NaN, which the dialog blanks rather than printing a stack

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -353,12 +353,20 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
       return [main, isMeasured(value) ? value : MISSING_TEXT];
     });
 
+    // The category column sits on whichever axis carries the names and the
+    // magnitude column on the other one, swapping with the headers above, so a
+    // layer that formats its magnitudes as currency -- or spells "Sat" out as
+    // "Saturday" -- reads the same way here as when the reader walks the bars.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = isVertical
+      ? ['x', 'y']
+      : ['y', 'x'];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -1,7 +1,7 @@
 import type { BoxplotSectionType } from '@type/boxplotSection';
 import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
-import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Edge, LineRequest, WhiskerRequest } from '@util/svg';
 import type { Dimension, NearestPoint } from './abstract';
 import { BoxplotSection } from '@type/boxplotSection';
@@ -234,12 +234,21 @@ export class BoxTrace extends AbstractTrace {
       return [groupNameAt(this.points, pointIdx), ...sectionValues];
     });
 
+    // The group column sits on whichever axis carries the categories and every
+    // section column on the other one, so a layer that formats its values as
+    // currency, or names its categories through a format function, reads the
+    // same way in the table as it does when the reader walks it.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      isHorizontal ? 'y' : 'x',
+      ...this.sections.map<AxisType>(() => (isHorizontal ? 'x' : 'y')),
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/boxen.ts
+++ b/src/model/boxen.ts
@@ -367,12 +367,22 @@ export class BoxenTrace extends AbstractTrace {
       ...(point.upperOutliers ?? []).map(value => [point.z, 'upper outlier', value]),
     ]);
 
+    // Swapped the same way the headers just were: the distribution sits on
+    // whichever axis carries the categories and its value on the other one.
+    // `Quantile` is the rung's own name -- a percentile or an outlier -- and
+    // is measured on nothing.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      isHorizontal ? 'y' : 'x',
+      undefined,
+      isHorizontal ? 'x' : 'y',
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -8,7 +8,7 @@ import type {
 } from '@type/grammar';
 import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionState, TextState, TraceState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionState, TextState, TraceState } from '@type/state';
 import type { Ohlc } from '@util/candlePattern';
 import type { LineRequest } from '@util/svg';
 import { AbstractTrace } from '@model/abstract';
@@ -750,12 +750,30 @@ export class Candlestick extends AbstractTrace {
       ...(this.hasOpen ? [c.trend ?? ''] : []),
     ]);
 
+    // The periods run along one axis and every price column sits on the other
+    // -- volatility included, because the cursor announces that against the
+    // same axis. Volume is not a price and a trend is a word, so neither is
+    // read off an axis at all.
+    const priceAxis: AxisType = this.orientation === Orientation.HORIZONTAL
+      ? 'x'
+      : 'y';
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      this.orientation === Orientation.HORIZONTAL ? 'y' : 'x',
+      priceAxis,
+      ...(this.hasOpen ? [priceAxis] : []),
+      priceAxis,
+      priceAxis,
+      priceAxis,
+      ...(hasVolume ? [undefined] : []),
+      ...(this.hasOpen ? [undefined] : []),
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -604,12 +604,24 @@ export class CandlestickDeltaTrace extends AbstractTrace {
       deltas[index] > 0 ? ABOVE_LINE : deltas[index] < 0 ? BELOW_LINE : ON_LINE,
     ]);
 
+    // The x column carries the candle's own x and the two price columns -- the
+    // compared field and the reference line -- the value axis. The delta is a
+    // difference this layer computes rather than a price the chart draws, and
+    // the position is a word, so neither is read off an axis.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      'x',
+      'y',
+      'y',
+      undefined,
+      undefined,
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/choropleth.ts
+++ b/src/model/choropleth.ts
@@ -510,6 +510,9 @@ export class ChoroplethTrace extends AbstractTrace {
       stats,
       dataTable: {
         headers: [this.xAxis, this.yAxis],
+        // The region name is read off x and its shaded value off y -- the two
+        // axes every move announcement already names them with.
+        columnAxes: ['x', 'y'],
         rows: every.map(region => [region.name, region.value]),
       },
     };

--- a/src/model/dumbbell.ts
+++ b/src/model/dumbbell.ts
@@ -2,7 +2,7 @@ import type { ExtremaTarget } from '@type/extrema';
 import type { DumbbellData, DumbbellPoint, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Orientation } from '@type/grammar';
 import { defaultFormat } from '@util/format';
@@ -394,12 +394,24 @@ export class DumbbellTrace extends AbstractTrace {
       this.changes[index],
     ]);
 
+    // The category column sits on whichever axis carries the names, the same
+    // swap the headers above make, and both ends on the value axis. `Change`
+    // is a subtraction the chart draws on neither, so it keeps the dialog's
+    // own rounding.
+    const valueAxis: AxisType = this.orientation === Orientation.HORIZONTAL ? 'x' : 'y';
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      this.orientation === Orientation.HORIZONTAL ? 'y' : 'x',
+      valueAxis,
+      valueAxis,
+      undefined,
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -2,7 +2,7 @@ import type { ExtremaTarget } from '@type/extrema';
 import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Orientation } from '@type/grammar';
 import { MathUtil } from '@util/math';
@@ -576,6 +576,20 @@ export class ErrorBarTrace extends AbstractTrace {
       ...(shows('lower') ? ['Lower'] : []),
       ...(shows('upper') ? ['Upper'] : []),
     ];
+    // Built from the same conditions the headers are, so the two cannot come
+    // apart: the group column is the z the legend is read off, the category
+    // column sits on whichever axis the announcement calls the main one, and
+    // the estimate and both bounds are readings on the other.
+    const groupAxis: AxisType = 'z';
+    const categoryAxis: AxisType = isHorizontal ? 'y' : 'x';
+    const valueAxis: AxisType = isHorizontal ? 'x' : 'y';
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      ...(grouped ? [groupAxis] : []),
+      categoryAxis,
+      ...(shows('value') ? [valueAxis] : []),
+      ...(shows('lower') ? [valueAxis] : []),
+      ...(shows('upper') ? [valueAxis] : []),
+    ];
     const rows: (string | number)[][] = this.groups.flatMap((group, index) =>
       group.map((point) => {
         const cells: (string | number)[] = [
@@ -598,7 +612,7 @@ export class ErrorBarTrace extends AbstractTrace {
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/flow.ts
+++ b/src/model/flow.ts
@@ -761,6 +761,9 @@ export class FlowTrace extends AbstractTrace implements PointCloudHighlightable 
       stats,
       dataTable: {
         headers: ['From', 'To', this.valueLabel],
+        // Both ends of a ribbon are node names, which this chart carries on x,
+        // and the amount is the y reading `cross` announces.
+        columnAxes: ['x', 'x', 'y'],
         rows: this.nodes.flatMap(node =>
           node.out.map(edge => [
             this.nodes[edge.from].name,

--- a/src/model/forest.ts
+++ b/src/model/forest.ts
@@ -280,6 +280,16 @@ export class ForestTrace extends ErrorBarTrace {
       ...(this.nullValue === null ? [] : ['Crosses null']),
       ...(hasPooled ? ['Row'] : []),
     ];
+    // The parent's columns keep the axes it gave them, and the appended three
+    // sit on none: the weight is a share of one computed here, the verdict a
+    // comparison against the null value, and the row kind a flag -- not
+    // readings taken on an axis the figure draws.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = base.columnAxes && [
+      ...base.columnAxes,
+      ...(hasWeight ? [undefined] : []),
+      ...(this.nullValue === null ? [] : [undefined]),
+      ...(hasPooled ? [undefined] : []),
+    ];
     // Row `index` is study `index`: the parent builds its rows by flattening
     // the same groups `points` -- and so `studies` -- is flattened from.
     const rows = base.rows.map((row, index) => {
@@ -299,7 +309,7 @@ export class ForestTrace extends ErrorBarTrace {
       ];
     });
 
-    return { headers, rows };
+    return { headers, columnAxes, rows };
   }
 
   /**

--- a/src/model/funnel.ts
+++ b/src/model/funnel.ts
@@ -250,6 +250,11 @@ export class FunnelTrace extends BarTrace {
   ): DescriptionState['dataTable'] {
     return {
       headers: [...base.headers, 'Retained', 'Share of entry'],
+      // The stage name and its count keep the axes the parent gave them. The
+      // two ratios are computed here out of the counts, so the funnel never
+      // declared an axis for them -- and a layer that formats its counts as
+      // currency must not print "$24.0%" over a share it never plotted.
+      columnAxes: base.columnAxes && [...base.columnAxes, undefined, undefined],
       rows: base.rows.map((row, stage) => [
         ...row,
         stage === 0 ? 'entry stage' : this.asRatioCell(this.retention[stage]),

--- a/src/model/gantt.ts
+++ b/src/model/gantt.ts
@@ -464,6 +464,17 @@ export class GanttTrace extends AbstractTrace {
     // the announcement never says it without one.
     const lengthHeader = this.unit === undefined ? 'Length' : `Length (${this.unit})`;
     const headers = [laneLabel, 'Label', 'Start', 'End', lengthHeader];
+    // The lane column sits on whichever axis carries the lanes, the same swap
+    // the header above makes. Start and End are already rendered through the
+    // time axis's own format by `atTime`, so naming it here would run the
+    // author's formatter twice; the label and the computed length have no axis.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      this.orientation === Orientation.HORIZONTAL ? 'y' : 'x',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ];
     const allRows: (string | number)[][] = this.lanes.flatMap((lane, index) =>
       // An empty lane is a row of the schedule -- the nested shape exists to
       // express one -- and mapping over the intervals it does not have
@@ -499,7 +510,7 @@ export class GanttTrace extends AbstractTrace {
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/gauge.ts
+++ b/src/model/gauge.ts
@@ -337,12 +337,17 @@ export class GaugeTrace extends AbstractTrace {
     ];
     const rows: (string | number)[][] = [[this.measureName, this.value]];
 
+    // The measure's name sits on x and its reading on y, the axes the
+    // announcement already names the two by -- so a dial whose value is a
+    // currency or a percentage prints in the table the way it is spoken.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = ['x', 'y'];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -2,7 +2,7 @@ import type { ExtremaTarget } from '@type/extrema';
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -260,12 +260,21 @@ export class Heatmap extends AbstractTrace {
       ])
       .reverse();
 
+    // The leading column names a row of the grid, so it sits on y; every other
+    // column holds cell magnitudes, which are z -- the axis the colorbar is
+    // labelled and formatted from -- even though its header names an x level.
+    // Sized off the same grid row as the headers, so the two cannot part.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      'y',
+      ...columns.map<AxisType>(() => 'z'),
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/hexbin.ts
+++ b/src/model/hexbin.ts
@@ -444,12 +444,17 @@ export class HexbinTrace extends AbstractTrace {
       });
     }
 
+    // A bin's centre is a reading on x and y, and its count on z -- the axis
+    // `countLabel` is named from, and the one the announcement already speaks
+    // the count through -- so the table says what the cursor says.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = ['x', 'y', 'z'];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -90,12 +90,20 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
       return [main, isMeasured(count) ? count : MISSING_TEXT, min, max];
     });
 
+    // The bin's own value and its two bounds are all read off the binned
+    // axis, swapping with the headers above, and the count off the other one:
+    // a layer that formats its bin edges as a date says the same thing here as
+    // it does when the reader walks the bins.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = isVertical
+      ? ['x', 'y', 'x', 'x']
+      : ['y', 'x', 'y', 'y'];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -584,16 +584,23 @@ export class LineTrace extends AbstractTrace {
       point.label === undefined || point.label === '' ? (point.y ?? '') : point.label;
 
     let headers: string[];
+    // The sample's x, its reading on y, and -- when there is more than one
+    // series -- the series column, which is the z axis whether or not a
+    // subclass renamed the noun over it. Built in the same branch as the
+    // headers so the two cannot come apart.
+    let columnAxes: DescriptionState['dataTable']['columnAxes'];
     let allRows: (string | number)[][];
 
     if (isMultiline) {
       headers = [this.xAxis, this.yAxis, this.seriesColumnHeader];
+      columnAxes = ['x', 'y', 'z'];
       allRows = this.points.flatMap((line, i) => {
         const lineName = this.groupNameAt(i);
         return line.map(p => [p.x, cellOf(p), lineName]);
       });
     } else {
       headers = [this.xAxis, this.yAxis];
+      columnAxes = ['x', 'y'];
       allRows = (this.points[0] ?? []).map(p => [p.x, cellOf(p)]);
     }
 
@@ -613,7 +620,7 @@ export class LineTrace extends AbstractTrace {
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/mosaic.ts
+++ b/src/model/mosaic.ts
@@ -203,6 +203,16 @@ export class MosaicTrace extends SegmentedTrace {
       'Share of all',
       ...(hasCounts ? ['Count'] : []),
     ];
+    // The parent's three columns keep the axes it gave them; the two added
+    // here have none, since a column's share of the whole chart and a cell
+    // tally are computed from the table rather than read off an axis. Dropped
+    // whole rather than padded, so a short array cannot misname a column.
+    const baseAxes = base.dataTable.columnAxes;
+    const columnAxes = baseAxes && [
+      ...baseAxes,
+      undefined,
+      ...(hasCounts ? [undefined] : []),
+    ];
     const rows = base.dataTable.rows.map((row, index) => {
       const col = columns === 0 ? -1 : index % columns;
       const width = this.widths[col];
@@ -216,7 +226,7 @@ export class MosaicTrace extends SegmentedTrace {
       ];
     });
 
-    return { ...base, stats, dataTable: { headers, rows } };
+    return { ...base, stats, dataTable: { headers, columnAxes, rows } };
   }
 
   /**

--- a/src/model/network.ts
+++ b/src/model/network.ts
@@ -584,6 +584,11 @@ export class NetworkTrace extends AbstractTrace implements PointCloudHighlightab
       stats,
       dataTable: {
         headers: [this.nodeLabel, this.linkLabel, ...(grouped ? ['Group'] : []), 'Linked to'],
+        // The node sits on x and its degree on y, as `text` announces them.
+        // `Group` is a position among the components and `Linked to` is
+        // several names joined into one cell rather than one x reading, so
+        // neither takes an axis. Built on `grouped`, like the headers above.
+        columnAxes: ['x', 'y', ...(grouped ? [undefined] : []), undefined],
         // Walked component by component, most connected first, which is the
         // order the arrows take a reader through the chart and the order the
         // group sizes above are in. `this.nodes` is the order the producer

--- a/src/model/parallel.ts
+++ b/src/model/parallel.ts
@@ -369,12 +369,16 @@ export class ParallelTrace extends LineTrace {
     // The first column holds the axis a reading was taken on and the second
     // the reading, in that axis's own units. `LineTrace` heads them with the
     // layer's single x and y labels, which name neither column here.
-    const { headers, rows } = base.dataTable;
+    const { headers, columnAxes, rows } = base.dataTable;
     return {
       ...base,
       stats,
       dataTable: {
         headers: [this.axisColumnLabel, this.valueColumnLabel, ...headers.slice(2)],
+        // Re-headed, not rearranged: the columns are still the line's x, its
+        // reading and the observation, so each keeps the axis it was measured
+        // on and the table reads a value the way an announcement does.
+        columnAxes,
         rows,
       },
     };

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -339,12 +339,18 @@ export class PieTrace extends AbstractTrace {
       this.percentages[col],
     ]);
 
+    // The label column sits on x and the magnitude on y, the two axes the
+    // announcement already speaks a slice through. The share is divided out of
+    // the basis here, so the layer declared no axis for it -- and a pie that
+    // formats its magnitudes as currency must not print "$33.3%" over one.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = ['x', 'y', undefined];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/ridgeline.ts
+++ b/src/model/ridgeline.ts
@@ -469,12 +469,22 @@ export class RidgelineTrace extends AbstractTrace {
       });
     }
 
+    // The groups stack down y and the value they were measured at sits on x,
+    // the same pair the headers above are named from. The density is the
+    // estimator's own output -- the z label only heads the column, it is not
+    // an axis the curve was read off -- so it keeps the dialog's rounding.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      'y',
+      'x',
+      undefined,
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1,7 +1,7 @@
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { GridNavigable, PointCloudHighlightable, PointNavigable, XValue } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionStat, DescriptionState, HighlightState, TextState, TraceEmptyState, TraceState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionStat, DescriptionState, HighlightState, TextState, TraceEmptyState, TraceState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Constant } from '@util/constant';
 import { defaultFormat } from '@util/format';
@@ -1256,12 +1256,23 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       });
     }
 
+    // The two coordinates are readings on x and y, and the depth column on z,
+    // the axis its own header is named from. `Name` is what a point *is*
+    // rather than a reading off any axis, so it keeps the dialog's own
+    // rounding. Built from the same two conditions the headers were.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      'x',
+      'y',
+      ...(this.hasZ ? ['z' as AxisType] : []),
+      ...(hasNames ? [undefined] : []),
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -296,6 +296,14 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       ? [this.xAxis, this.yAxis, zLabel ?? 'Series']
       : [this.yAxis, this.xAxis, zLabel ?? 'Series'];
 
+    // Swapped on the same condition as the headers above, so the two cannot
+    // fall out of step: the category column sits on whichever axis carries the
+    // categories and the magnitude on the other. The series column is the
+    // fill, which is the z axis the legend is read off.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = isVertical
+      ? ['x', 'y', 'z']
+      : ['y', 'x', 'z'];
+
     // Every row of the navigable grid, the summary row included: a reader can
     // reach it with PageUp and the chart announces it there, so a table that
     // stops short of it does not describe the chart they are walking. The
@@ -320,7 +328,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/survival.ts
+++ b/src/model/survival.ts
@@ -302,6 +302,10 @@ export class SurvivalTrace extends StepTrace {
       stats,
       dataTable: {
         headers: [...base.dataTable.headers, 'Censored'],
+        // The step chart's columns keep their axes; the flag is a mark on a
+        // time rather than a reading taken on an axis, so it sits on none and
+        // is left to the dialog's own rendering.
+        columnAxes: base.dataTable.columnAxes && [...base.dataTable.columnAxes, undefined],
         rows: base.dataTable.rows.map((row, index) => [...row, flags[index] ?? '']),
       },
     };

--- a/src/model/treemap.ts
+++ b/src/model/treemap.ts
@@ -786,6 +786,11 @@ export class TreemapTrace extends AbstractTrace {
       dataTable: this.valued
         ? {
             headers: ['Path', this.nodeLabel, this.valueLabel, 'Share of total'],
+            // The name sits on x and the magnitude on y, the axes the
+            // announcement already speaks a node through. The path is an
+            // ancestry joined here and the share is divided out of the total,
+            // so neither is a reading the layer declared an axis for.
+            columnAxes: [undefined, 'x', 'y', undefined],
             rows: every.map(node => [
               this.ancestorsOf(node).join(' > '),
               node.name,
@@ -798,6 +803,9 @@ export class TreemapTrace extends AbstractTrace {
             // the ancestry and the name are the whole of what a pure
             // hierarchy has to tabulate.
             headers: ['Path', this.nodeLabel],
+            // The same two columns, so the same two entries: the joined
+            // ancestry sits on no axis, the name on x.
+            columnAxes: [undefined, 'x'],
             rows: every.map(node => [
               this.ancestorsOf(node).join(' > '),
               node.name,

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -237,12 +237,22 @@ export class ViolinKdeTrace extends AbstractTrace {
       );
     });
 
+    // The violin name sits on whichever axis carries the categories and the
+    // sampled value on the other one, so both read the way the layer's own
+    // format asks for. `Density` is the height of the curve, which no axis
+    // declares.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      isHorizontal ? 'y' : 'x',
+      isHorizontal ? 'x' : 'y',
+      undefined,
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -1,7 +1,7 @@
 import type { BoxPoint, BoxSelector, MaidrLayer, ViolinOptions } from '@type/grammar';
 import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { AudioState, AxisType, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Edge, LineRequest, WhiskerRequest } from '@util/svg';
 import type { Dimension, NearestPoint } from './abstract';
 import { BoxplotSection } from '@type/boxplotSection';
@@ -229,12 +229,21 @@ export class ViolinBoxTrace extends AbstractTrace {
       return [groupNameAt(this.points, pointIdx, 'Violin'), ...sectionValues];
     });
 
+    // The violin column sits on whichever axis carries the categories and
+    // every section column on the other one, so a layer that formats its
+    // values -- or names its categories through a format function -- reads the
+    // same way here as it does when the reader walks the box.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      isHorizontal ? 'y' : 'x',
+      ...this.sections.map<AxisType>(() => (isHorizontal ? 'x' : 'y')),
+    ];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/waterfall.ts
+++ b/src/model/waterfall.ts
@@ -284,6 +284,16 @@ export class WaterfallTrace extends AbstractTrace {
     }
 
     const headers = [this.xAxis, 'Change', 'Running total', 'Kind'];
+    // The step name sits on x and both magnitudes on y, which is the pair
+    // `text` announces and the axis it announces the running total through --
+    // `end` is where the bar's top is drawn, not a total this trace summed.
+    // `kind` is a word for the direction, so it is read off no axis at all.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = [
+      'x',
+      'y',
+      'y',
+      undefined,
+    ];
     const rows: (string | number)[][] = this.points.map(point => [
       point.x,
       Number(point.delta),
@@ -300,7 +310,7 @@ export class WaterfallTrace extends AbstractTrace {
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/model/wordCloud.ts
+++ b/src/model/wordCloud.ts
@@ -318,12 +318,17 @@ export class WordCloudTrace extends AbstractTrace {
       toShare(weights[term], total),
     ]);
 
+    // The term sits on x and its weight on y, the axes the announcement
+    // already speaks both through. The share is divided out of the total
+    // here, so the layer never declared an axis for it.
+    const columnAxes: DescriptionState['dataTable']['columnAxes'] = ['x', 'y', undefined];
+
     return {
       chartType: this.getChartTypeLabel(),
       title: this.title,
       axes: this.getDescriptionAxes(),
       stats,
-      dataTable: { headers, rows },
+      dataTable: { headers, columnAxes, rows },
     };
   }
 

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -1,5 +1,6 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
+import type { FormatterService } from '@service/formatter';
 import type { RotorNavigationService } from '@service/rotor';
 import type { Disposable } from '@type/disposable';
 import type { DescriptionStat, DescriptionState, DisplayDescriptionState } from '@type/state';
@@ -77,6 +78,7 @@ export class DescriptionService implements Disposable {
   private readonly context: Context;
   private readonly display: DisplayService;
   private readonly rotor: RotorNavigationService;
+  private readonly formatter: FormatterService;
 
   /**
    * Whether a layer tab moved the model's active layer during this visit to
@@ -89,10 +91,12 @@ export class DescriptionService implements Disposable {
     context: Context,
     display: DisplayService,
     rotor: RotorNavigationService,
+    formatter: FormatterService,
   ) {
     this.context = context;
     this.display = display;
     this.rotor = rotor;
+    this.formatter = formatter;
   }
 
   /**
@@ -119,7 +123,7 @@ export class DescriptionService implements Disposable {
 
       const subplots = this.context.getSubplotSummaries();
       const layers = this.context.getLayerSummaries();
-      const rounded = this.rounded(description);
+      const rounded = this.rounded(description, active.getId());
       // Orientation first, and the figure's own notes last: which way the
       // chart is drawn qualifies everything under it -- for the box, violin
       // and boxen families it reverses the order of the table's rows -- while
@@ -209,7 +213,9 @@ export class DescriptionService implements Disposable {
    */
   private rounded(
     description: DescriptionState,
+    layerId: string,
   ): Pick<DisplayDescriptionState, 'stats' | 'dataTable'> {
+    const cellOf = this.columnFormatters(description, layerId);
     return {
       stats: description.stats.map(stat => ({
         ...stat,
@@ -217,9 +223,54 @@ export class DescriptionService implements Disposable {
       })),
       dataTable: {
         headers: description.dataTable.headers,
-        rows: description.dataTable.rows.map(row => row.map(roundCell)),
+        rows: description.dataTable.rows.map(row =>
+          row.map((cell, column) => cellOf(column)(cell)),
+        ),
       },
     };
+  }
+
+  /**
+   * How each column of the data table reads, by column index.
+   *
+   * The layer's own formatter where its author declared one for that column's
+   * axis, and this service's rounding everywhere else. A candlestick whose x
+   * carries a date format and whose y carries a currency one announces
+   * "Nov 3" and "$180.25" as the reader walks it; before this the table beside
+   * those announcements printed the epoch milliseconds and the bare float, so
+   * one dialog described one value two ways and neither surface said which was
+   * meant.
+   *
+   * Asked per column rather than per cell so the lookup happens once for a
+   * table of a thousand rows, and gated on the format having been *authored*
+   * so a chart nobody formatted reads exactly as it did before -- an axis with
+   * no `format` still has a formatter, and using it would quietly replace the
+   * blank a non-finite cell renders as with the word `missing` in every empty
+   * cell of a sparse table.
+   *
+   * @param description - The description as the trace built it.
+   * @param layerId - The layer the description came from.
+   * @returns A function from column index to that column's cell formatter.
+   */
+  private columnFormatters(
+    description: DescriptionState,
+    layerId: string,
+  ): (column: number) => (cell: string | number | number[]) => string | number {
+    const axes = description.dataTable.columnAxes;
+    if (!axes) {
+      return () => roundCell;
+    }
+
+    const perColumn = axes.map((axis) => {
+      if (axis === undefined || !this.formatter.hasAuthoredFormat(layerId, axis)) {
+        return roundCell;
+      }
+      const format = this.formatter.getFormatter(layerId, axis);
+      return (cell: string | number | number[]): string | number =>
+        Array.isArray(cell) ? cell.map(entry => format(entry)).join(', ') : format(cell);
+    });
+
+    return column => perColumn[column] ?? roundCell;
   }
 
   /**

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -3,6 +3,7 @@ import type { DisplayService } from '@service/display';
 import type { FormatterService } from '@service/formatter';
 import type { RotorNavigationService } from '@service/rotor';
 import type { Disposable } from '@type/disposable';
+import type { FormatFunction } from '@type/grammar';
 import type { DescriptionStat, DescriptionState, DisplayDescriptionState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
 import { Scope } from '@type/event';
@@ -48,6 +49,44 @@ function roundCell(value: string | number | number[]): string | number {
     return Number.isNaN(value) ? value : (roundNonFinite(value) ?? value);
   }
   return defaultFormat(value);
+}
+
+/**
+ * One cell read through the layer's own formatter.
+ *
+ * Two kinds of cell the format must not reach, both of them cells with no
+ * value in them. An empty cell is how a sparse table shows an absent value,
+ * and a chart's own `format.function` sees it as text rather than as absence:
+ * `Number(value).toFixed(1)` meeting `''` yields `0.0`, inventing a reading
+ * for a cell that has none. A non-finite number has to stay a number for the
+ * dialog's own blanking check, which any formatter would turn into the word
+ * `missing`, printed in every empty cell of the table.
+ *
+ * Both fall through to {@link roundCell}, which is exactly what the column
+ * would have done had its author declared no format -- so adding a format
+ * changes how the values read and never how their absence does.
+ *
+ * @param value - The value as the trace reported it.
+ * @param format - The layer's format function for this column's axis.
+ * @returns The formatted value, or the rounded one where a format says nothing.
+ */
+function formattedCell(
+  value: string | number | number[],
+  format: FormatFunction,
+): string | number {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return '';
+    }
+    return value.map(entry => roundNonFinite(entry) ?? format(entry)).join(', ');
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return value;
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return roundCell(value);
+  }
+  return format(value);
 }
 
 /**
@@ -266,8 +305,7 @@ export class DescriptionService implements Disposable {
         return roundCell;
       }
       const format = this.formatter.getFormatter(layerId, axis);
-      return (cell: string | number | number[]): string | number =>
-        Array.isArray(cell) ? cell.map(entry => format(entry)).join(', ') : format(cell);
+      return (cell: string | number | number[]): string | number => formattedCell(cell, format);
     });
 
     return column => perColumn[column] ?? roundCell;

--- a/src/service/formatter.ts
+++ b/src/service/formatter.ts
@@ -13,6 +13,17 @@ interface LayerFormatters {
   x: FormatFunction;
   y: FormatFunction;
   z: FormatFunction;
+  /**
+   * The axes the layer actually declared a format for.
+   *
+   * Every axis has a formatter, because an axis with no `format` falls back to
+   * `defaultFormat`. That fallback is right for an announcement, which has to
+   * say something either way, and wrong for a caller that needs to know
+   * whether the author asked for anything -- the chart description's data
+   * table only departs from its own rounding where a format was authored, so
+   * that a chart nobody formatted reads exactly as it did before.
+   */
+  authored: Set<AxisType>;
 }
 
 /**
@@ -84,6 +95,9 @@ export class FormatterService implements Disposable {
             x: this.resolveAxisFormat(axes?.x?.format),
             y: this.resolveAxisFormat(axes?.y?.format),
             z: this.resolveAxisFormat(axes?.z?.format),
+            authored: new Set(
+              (['x', 'y', 'z'] as const).filter(axis => axes?.[axis]?.format !== undefined),
+            ),
           };
 
           this.formatters.set(layerId, layerFormatters);
@@ -114,6 +128,24 @@ export class FormatterService implements Disposable {
       return defaultFormat;
     }
     return layerFormatters[axis];
+  }
+
+  /**
+   * Whether the layer declared a format for this axis, as opposed to falling
+   * back to the default.
+   *
+   * The chart description's data table asks before it formats: it has its own
+   * rounding, and a reader of an unformatted chart should see exactly what
+   * they saw before. Where an author did ask for currency, a percentage or a
+   * date, the table has to say the same thing the announcement does, or the
+   * two surfaces describe one number two ways.
+   *
+   * @param layerId - The ID of the layer
+   * @param axis - The axis type ('x', 'y', or 'z')
+   * @returns True when the layer's JSON carried a `format` for that axis
+   */
+  public hasAuthoredFormat(layerId: string, axis: AxisType): boolean {
+    return this.formatters.get(layerId)?.authored.has(axis) ?? false;
   }
 
   /**

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -554,6 +554,24 @@ export interface DescriptionState {
    */
   dataTable: {
     headers: string[];
+    /**
+     * Which axis each column's values were measured on, index-aligned with
+     * {@link headers}, so the dialog can read a column the way the chart's
+     * author asked for it to be read.
+     *
+     * A layer may declare a `format` per axis -- currency, a percentage, a
+     * date -- and the announcements honour it, so navigating a candlestick
+     * says "Nov 3" and "$180.25". The table had no way to know which column
+     * was which axis and printed the raw numbers, so one dialog described one
+     * value two ways.
+     *
+     * `undefined` for a column that sits on no axis: a category name, a
+     * quantile label, a computed share, a count the layer never declared a
+     * format for. Omitting the whole array is the same as every column being
+     * undefined, which is what a trace that has not been taught this does --
+     * its table keeps the description's own rounding, exactly as before.
+     */
+    columnAxes?: (AxisType | undefined)[];
     rows: (string | number | number[])[][];
   };
   /**

--- a/test/model/descriptionContract.test.ts
+++ b/test/model/descriptionContract.test.ts
@@ -277,6 +277,180 @@ addCase('choropleth', {
   data: [{ x: 'CA', y: 4 }, { x: 'NV', y: 9 }],
 });
 
+/*
+ * The cases below exist for the *conditional* columns. A table whose width
+ * depends on what the data carries -- a candlestick with no volume, an error
+ * bar with no groups, a treemap of a pure hierarchy -- has a second shape that
+ * the ordinary case never builds, and a column list that drifts from its
+ * headers in that shape is invisible until someone reads that chart.
+ */
+
+addCase('candlestick carrying volume', {
+  id: 'candle-volume',
+  type: TraceType.CANDLESTICK,
+  axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+  data: [
+    { value: '2024-01-01', open: 1, high: 4, low: 0.5, close: 3, volatility: 3.5, volume: 1200 },
+    { value: '2024-01-02', open: 3, high: 5, low: 2, close: 4, volatility: 3, volume: 900 },
+  ],
+});
+
+addCase('candlestick drawing no open', {
+  id: 'candle-no-open',
+  type: TraceType.CANDLESTICK,
+  axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+  data: [
+    { value: '2024-01-01', high: 4, low: 0.5, close: 3, volatility: 3.5 },
+    { value: '2024-01-02', high: 5, low: 2, close: 4, volatility: 3 },
+  ] as unknown as MaidrLayer['data'],
+});
+
+addCase('error bar with groups', {
+  id: 'errorbar-grouped',
+  type: TraceType.ERROR_BAR,
+  axes: { x: { label: 'Dose' }, y: { label: 'Response' }, z: { label: 'Arm' } },
+  // Grouped by nesting, which is what `toGroups` reads -- a flat list is the
+  // one group it is, however its points are labelled.
+  data: [
+    [{ x: 1, y: 5, yMin: 4, yMax: 6, z: 'Treated' }],
+    [{ x: 1, y: 3, yMin: 2, yMax: 4, z: 'Control' }],
+  ],
+});
+
+addCase('error bar drawing bounds only', {
+  id: 'errorbar-bounds',
+  type: TraceType.ERROR_BAR,
+  axes: { x: { label: 'Dose' }, y: { label: 'Response' } },
+  data: [{ x: 1, yMin: 4, yMax: 6 }, { x: 2, yMin: 6, yMax: 8 }],
+});
+
+addCase('forest', {
+  id: 'forest',
+  type: TraceType.FOREST,
+  axes: { x: { label: 'Study' }, y: { label: 'Odds ratio' } },
+  data: [
+    { x: 'Alpha', y: 1.2, yMin: 0.9, yMax: 1.6, weight: 0.4 },
+    { x: 'Beta', y: 0.8, yMin: 0.5, yMax: 1.1, weight: 0.6 },
+  ],
+  forestOptions: { nullValue: 1 },
+} as unknown as MaidrLayer);
+
+addCase('funnel', {
+  id: 'funnel',
+  type: TraceType.FUNNEL,
+  axes: { x: { label: 'Stage' }, y: { label: 'People' } },
+  data: [{ x: 'Visited', y: 1000 }, { x: 'Bought', y: 240 }],
+});
+
+addCase('scatter carrying a third dimension and names', {
+  id: 'scatter-z',
+  type: TraceType.SCATTER,
+  axes: { x: { label: 'Carat' }, y: { label: 'Price' }, z: { label: 'Depth' } },
+  data: [
+    { x: 1, y: 2, z: 60, label: 'Alpha' },
+    { x: 2, y: 3, z: 62, label: 'Beta' },
+  ] as unknown as MaidrLayer['data'],
+});
+
+addCase('network', {
+  id: 'network',
+  type: TraceType.NETWORK,
+  axes: { x: { label: 'Person' }, y: { label: 'Links' } },
+  data: [{ source: 'Ada', target: 'Grace' }, { source: 'Grace', target: 'Alan' }],
+});
+
+addCase('network of several components', {
+  id: 'network-components',
+  type: TraceType.NETWORK,
+  axes: { x: { label: 'Person' }, y: { label: 'Links' } },
+  // Two disconnected pairs, which is what puts the `Group` column in the
+  // table -- one component leaves it out.
+  data: [{ source: 'Ada', target: 'Grace' }, { source: 'Alan', target: 'Edsger' }],
+});
+
+addCase('mosaic carrying counts', {
+  id: 'mosaic',
+  type: TraceType.MOSAIC,
+  axes: { x: { label: 'Class' }, y: { label: 'Share' }, z: { label: 'Survived' } },
+  data: [
+    [{ x: 'First', y: 0.6, width: 0.3, count: 180 }, { x: 'Second', y: 0.4, width: 0.7, count: 120 }],
+    [{ x: 'First', y: 0.4, width: 0.3, count: 120 }, { x: 'Second', y: 0.6, width: 0.7, count: 180 }],
+  ] as unknown as MaidrLayer['data'],
+});
+
+addCase('parallel', {
+  id: 'parallel',
+  type: TraceType.PARALLEL,
+  axes: { x: { label: 'Variable' }, y: { label: 'Value' } },
+  data: [
+    [{ x: 'mpg', y: 21 }, { x: 'hp', y: 110 }],
+    [{ x: 'mpg', y: 30 }, { x: 'hp', y: 66 }],
+  ],
+});
+
+addCase('survival with censoring', {
+  id: 'survival',
+  type: TraceType.SURVIVAL,
+  axes: { x: { label: 'Months' }, y: { label: 'Survival' }, z: { label: 'Arm' } },
+  data: [[
+    { x: 0, y: 1 },
+    { x: 6, y: 0.8, censored: true },
+    { x: 12, y: 0.6 },
+  ]],
+});
+
+addCase('ridgeline', {
+  id: 'ridgeline',
+  type: TraceType.RIDGELINE,
+  axes: { x: { label: 'Days' }, y: { label: 'Cohort' }, z: { label: 'Cohort' } },
+  data: [
+    [{ x: 'Spring', y: 1, density: 0.1 }, { x: 'Spring', y: 2, density: 0.4 }],
+    [{ x: 'Summer', y: 1, density: 0.2 }, { x: 'Summer', y: 2, density: 0.3 }],
+  ],
+});
+
+addCase('violin kde', {
+  id: 'violin-kde',
+  type: TraceType.VIOLIN_KDE,
+  axes: { x: { label: 'Species' }, y: { label: 'Length' } },
+  data: [
+    [{ x: 'setosa', y: 1, density: 0.1 }, { x: 'setosa', y: 2, density: 0.4 }],
+    [{ x: 'virginica', y: 1, density: 0.2 }, { x: 'virginica', y: 2, density: 0.3 }],
+  ],
+});
+
+addCase('treemap of a pure hierarchy', {
+  id: 'treemap-hierarchy',
+  type: TraceType.TREEMAP,
+  axes: { x: { label: 'Region' } },
+  data: [
+    { x: 'North', ancestors: [] },
+    { x: 'Leeds', ancestors: ['North'] },
+  ] as unknown as MaidrLayer['data'],
+});
+
+addCase('histogram drawn horizontally', {
+  id: 'histogram-horizontal',
+  type: TraceType.HISTOGRAM,
+  orientation: Orientation.HORIZONTAL,
+  axes: { x: { label: 'Count' }, y: { label: 'Value' } },
+  data: [
+    { x: 1, y: 3, xMin: 0, xMax: 2, yMin: 0, yMax: 3 },
+    { x: 3, y: 5, xMin: 2, xMax: 4, yMin: 0, yMax: 5 },
+  ],
+});
+
+addCase('gantt drawn horizontally', {
+  id: 'gantt-horizontal',
+  type: TraceType.GANTT,
+  orientation: Orientation.HORIZONTAL,
+  axes: { x: { label: 'Day' }, y: { label: 'Task' } },
+  data: {
+    points: [[{ x: 'Design', start: 0, end: 3 }], [{ x: 'Build', start: 3, end: 9 }]],
+    lanes: ['Design', 'Build'],
+  },
+});
+
 /**
  * Every value the description puts in front of a reader: the stats, the table
  * headers, and every cell.

--- a/test/model/descriptionContract.test.ts
+++ b/test/model/descriptionContract.test.ts
@@ -358,6 +358,22 @@ describe.each(CASES)('the $name description', ({ layer }) => {
     expect(offenders).toEqual([]);
   });
 
+  test('names the axis of every column, or of none', () => {
+    const { headers, columnAxes } = describedBy().dataTable;
+    if (columnAxes === undefined) {
+      return;
+    }
+
+    // The description service reads this by column index to decide which
+    // cells go through the layer's own formatter. One entry short and the
+    // last column silently loses its format; one entry long and the array
+    // has drifted from the headers it is meant to describe.
+    expect(columnAxes).toHaveLength(headers.length);
+    columnAxes.forEach((axis) => {
+      expect(axis === undefined || axis === 'x' || axis === 'y' || axis === 'z').toBe(true);
+    });
+  });
+
   test('claims only the axes the layer actually labelled', () => {
     const description = describedBy();
     const leaked = Object.entries(description.axes)

--- a/test/service/description.test.ts
+++ b/test/service/description.test.ts
@@ -1,5 +1,6 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
+import type { FormatterService } from '@service/formatter';
 import type { RotorNavigationService } from '@service/rotor';
 import type { LayerSummary, PlotState, SubplotSummary } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
@@ -60,6 +61,19 @@ function createMockDisplayService(): DisplayService {
   } as unknown as DisplayService;
 }
 
+/**
+ * The formatter surface `DescriptionService` touches. The figure-level branch
+ * never reaches a layer's formats, so answering "nothing was authored" is the
+ * whole contract here; `descriptionRounding.test.ts` drives a real
+ * `FormatterService` for the branch that does.
+ */
+function createMockFormatterService(): FormatterService {
+  return {
+    hasAuthoredFormat: () => false,
+    getFormatter: () => String,
+  } as unknown as FormatterService;
+}
+
 function figureState(size: number): PlotState {
   return { empty: false, type: 'figure', size } as unknown as PlotState;
 }
@@ -77,7 +91,12 @@ describe('descriptionService figure-level description', () => {
       subplotSummaries: subplots,
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
     const description = service.getDescription();
 
     expect(description).not.toBeNull();
@@ -103,7 +122,12 @@ describe('descriptionService figure-level description', () => {
       authored: ['A subtitle', 'A caption'],
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
     const description = service.getDescription();
 
     expect(description).not.toBeNull();
@@ -120,7 +144,12 @@ describe('descriptionService figure-level description', () => {
       figureYAxis: 'Revenue',
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
     const description = service.getDescription();
 
     expect(description).not.toBeNull();
@@ -133,7 +162,12 @@ describe('descriptionService figure-level description', () => {
       figureXAxis: 'Year',
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
     const description = service.getDescription();
 
     expect(description).not.toBeNull();
@@ -150,7 +184,12 @@ describe('descriptionService figure-level description', () => {
       figureYAxis: 'Revenue',
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
     const description = service.getDescription();
 
     expect(description).not.toBeNull();
@@ -166,7 +205,12 @@ describe('descriptionService figure-level description', () => {
       authored: [],
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
     const description = service.getDescription();
 
     expect(description).not.toBeNull();
@@ -185,7 +229,12 @@ describe('descriptionService figure-level description', () => {
       state: { empty: false, type: 'subplot' } as unknown as PlotState,
     });
 
-    const service = new DescriptionService(context, createMockDisplayService(), createMockRotorService());
+    const service = new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    );
 
     expect(service.getDescription()).toBeNull();
   });

--- a/test/service/descriptionAxisFormat.test.ts
+++ b/test/service/descriptionAxisFormat.test.ts
@@ -1,0 +1,142 @@
+import type { DisplayService } from '@service/display';
+import type { RotorNavigationService } from '@service/rotor';
+import type { Maidr } from '@type/grammar';
+import type { DisplayDescriptionState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { DescriptionService } from '@service/description';
+import { FormatterService } from '@service/formatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * The dialog and the announcements, over a chart whose author formatted it.
+ *
+ * A layer may declare a `format` per axis, and every announcement has honoured
+ * it for a long time -- walking a chart shaped like
+ * `examples/vertical-candlestick.html` announces "Jan 3" and a price in
+ * dollars. The table in the same dialog printed `2023-01-03` and `180.2534`,
+ * because nothing told it which column sat on which axis: one dialog
+ * describing one value two ways, with nothing to say which was meant.
+ *
+ * Driven through a real `Figure`, `Context`, `FormatterService` and
+ * `DescriptionService` rather than mocks, because the defect lived in the
+ * seam between them and a mocked formatter is exactly the thing that cannot
+ * prove it closed.
+ */
+
+/** The sessions the shipped example opens on, in the shape it carries them. */
+const JAN_3 = '2023-01-03';
+const JAN_4 = '2023-01-04';
+
+/**
+ * A one-layer candlestick figure, formatted the way the shipped example is:
+ * a date function on the period axis, currency on the price axis.
+ * @param formatted Whether the layer declares any format at all
+ * @returns The figure and a formatter service built from the same data
+ */
+function candlestickFigure(formatted: boolean): {
+  figure: Figure;
+  formatter: FormatterService;
+} {
+  const maidr: Maidr = {
+    id: 'chart',
+    subplots: [[{
+      layers: [{
+        id: 'candles',
+        type: TraceType.CANDLESTICK,
+        axes: {
+          x: {
+            label: 'Date',
+            // The shipped example's own format, which is what makes the
+            // announcement say "Jan 3" where the payload says "2023-01-03".
+            ...(formatted
+              ? { format: { function: 'return new Date(value).toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })' } }
+              : {}),
+          },
+          y: {
+            label: 'Price',
+            ...(formatted ? { format: { type: 'currency', decimals: 2 } } : {}),
+          },
+        },
+        data: [
+          { value: JAN_3, open: 180.2534, high: 184.117, low: 179.5, close: 183.9, volatility: 4.617 },
+          { value: JAN_4, open: 183.9, high: 186.25, low: 182.1, close: 185.75, volatility: 4.15 },
+        ],
+      }],
+    }]],
+  };
+  return { figure: new Figure(maidr), formatter: new FormatterService(maidr) };
+}
+
+/**
+ * Reads the description the dialog would render for that figure.
+ * @param formatted Whether the layer declares any format at all
+ * @returns The description as the dialog receives it
+ */
+function describeCandlestick(formatted: boolean): DisplayDescriptionState {
+  const { figure, formatter } = candlestickFigure(formatted);
+  const service = new DescriptionService(
+    new Context(figure),
+    { toggleFocus: jest.fn() } as unknown as DisplayService,
+    { resetToDataMode: jest.fn() } as unknown as RotorNavigationService,
+    formatter,
+  );
+  const description = service.getDescription();
+  expect(description).not.toBeNull();
+  return description as DisplayDescriptionState;
+}
+
+/**
+ * One column of the table, by its header.
+ * @param description The description under test
+ * @param header The column heading to read
+ * @returns Every cell under that heading, in row order
+ */
+function column(description: DisplayDescriptionState, header: string): unknown[] {
+  const index = description.dataTable.headers.indexOf(header);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return description.dataTable.rows.map(row => row[index]);
+}
+
+describe('the description table over an authored axis format', () => {
+  test('prints the dates the chart announces, not the payload behind them', () => {
+    const description = describeCandlestick(true);
+
+    expect(column(description, 'Date')).toEqual(['Jan 3', 'Jan 4']);
+  });
+
+  test('prints every price column as the currency the layer declared', () => {
+    const description = describeCandlestick(true);
+
+    expect(column(description, 'Open')).toEqual(['$180.25', '$183.90']);
+    expect(column(description, 'High')).toEqual(['$184.12', '$186.25']);
+    expect(column(description, 'Low')).toEqual(['$179.50', '$182.10']);
+    expect(column(description, 'Close')).toEqual(['$183.90', '$185.75']);
+  });
+
+  test('formats the volatility too, which the cursor announces on that same axis', () => {
+    const description = describeCandlestick(true);
+
+    expect(column(description, 'Volatility')).toEqual(['$4.62', '$4.15']);
+  });
+
+  test('leaves the trend a word, since a price format says nothing about one', () => {
+    const description = describeCandlestick(true);
+
+    // Every cell of this column is a word the chart computed, not a reading on
+    // an axis. A built-in formatter would hand it straight back, but only
+    // because they all pass a non-numeric value through -- a `format.function`
+    // need not, and this column must not depend on which kind it meets.
+    expect(column(description, 'Trend')).toEqual(['Bull', 'Bull']);
+  });
+
+  test('reads a chart nobody formatted exactly as it did before', () => {
+    const description = describeCandlestick(false);
+
+    // The service's own rounding, which is what these columns showed until the
+    // table learned which axis each one sat on.
+    expect(column(description, 'Date')).toEqual([JAN_3, JAN_4]);
+    expect(column(description, 'Open')).toEqual(['180.25', '183.9']);
+  });
+});

--- a/test/service/descriptionLayers.test.ts
+++ b/test/service/descriptionLayers.test.ts
@@ -1,4 +1,5 @@
 import type { DisplayService } from '@service/display';
+import type { FormatterService } from '@service/formatter';
 import type { RotorNavigationService } from '@service/rotor';
 import type { Maidr } from '@type/grammar';
 import type { PlotState, TraceState } from '@type/state';
@@ -50,11 +51,28 @@ function createMockDisplayService(): DisplayService {
   return { toggleFocus: jest.fn() } as unknown as DisplayService;
 }
 
+/**
+ * These layers declare no formats, which is the answer the service needs: the
+ * data table then keeps its own rounding. `descriptionRounding.test.ts` drives
+ * a real `FormatterService` over layers that do declare one.
+ */
+function createMockFormatterService(): FormatterService {
+  return {
+    hasAuthoredFormat: () => false,
+    getFormatter: () => String,
+  } as unknown as FormatterService;
+}
+
 /** Builds a service over a real figure, plus the context it reads. */
 function serviceOver(figure: Figure): { service: DescriptionService; context: Context } {
   const context = new Context(figure);
   return {
-    service: new DescriptionService(context, createMockDisplayService(), createMockRotorService()),
+    service: new DescriptionService(
+      context,
+      createMockDisplayService(),
+      createMockRotorService(),
+      createMockFormatterService(),
+    ),
     context,
   };
 }

--- a/test/service/descriptionRounding.test.ts
+++ b/test/service/descriptionRounding.test.ts
@@ -260,6 +260,34 @@ describe('descriptionService authored axis formats', () => {
     expect(description.dataTable.rows[0][0]).toBe('Group A');
   });
 
+  test('leaves an empty cell empty rather than letting a format invent a value', () => {
+    const description = describeTrace(
+      boxTrace({ min: 5, q1: 10, q2: 15, q3: 20, max: 25 }),
+      // The shape a chart's own format function takes: `Number('')` is 0, so
+      // this would read a blank outlier cell as "0.0" if it ever saw one.
+      formatterFor({ y: { function: 'return Number(value).toFixed(1)' } }),
+    );
+
+    // Columns 1 and 7 are the outlier cells, and this box has no outliers.
+    const cells = row(description, 'A');
+    expect(cells[1]).toBe('');
+    expect(cells[7]).toBe('');
+    expect(cells[2]).toBe('5.0');
+  });
+
+  test('still hands a non-finite cell back as a number for the dialog to blank', () => {
+    const description = describeTrace(
+      boxTrace({ min: Number.NaN, q1: 10, q2: 15, q3: 20, max: 25 }),
+      formatterFor({ y: { type: 'currency', decimals: 2 } }),
+    );
+
+    // A formatter would name it `missing`, which the dialog prints; as a
+    // number it is blanked, exactly as an unformatted column's NaN is.
+    const cells = row(description, 'A');
+    expect(cells[2]).toBeNaN();
+    expect(typeof cells[2]).toBe('number');
+  });
+
   test('leaves an unformatted layer reading exactly as it did before', () => {
     // Every axis has a formatter, because one with no `format` falls back to
     // the default. Using it anyway would print `missing` in every empty cell

--- a/test/service/descriptionRounding.test.ts
+++ b/test/service/descriptionRounding.test.ts
@@ -1,10 +1,12 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
 import type { RotorNavigationService } from '@service/rotor';
+import type { AxisFormat, Maidr } from '@type/grammar';
 import type { DescriptionState } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
 import { BoxTrace } from '@model/box';
 import { DescriptionService } from '@service/description';
+import { FormatterService } from '@service/formatter';
 import { TraceType } from '@type/grammar';
 
 /**
@@ -53,13 +55,41 @@ function boxTrace(
 }
 
 /**
+ * A `FormatterService` over one layer whose axes carry the given formats, keyed
+ * by the id `boxTrace` gives its layer. Real rather than mocked: the point of
+ * the table's formatting is that it says the same thing the announcements do,
+ * and only the service that produces those can prove it.
+ */
+function formatterFor(formats: { x?: AxisFormat; y?: AxisFormat } = {}): FormatterService {
+  const maidr: Maidr = {
+    id: 'chart',
+    subplots: [[{
+      layers: [{
+        id: 'box',
+        type: TraceType.BOX,
+        axes: {
+          x: { label: 'Group', ...(formats.x ? { format: formats.x } : {}) },
+          y: { label: 'Value', ...(formats.y ? { format: formats.y } : {}) },
+        },
+        data: [],
+      }],
+    }]],
+  };
+  return new FormatterService(maidr);
+}
+
+/**
  * Runs a trace's description through the service and returns it.
  */
-function describeTrace(trace: BoxTrace): DescriptionState {
+function describeTrace(
+  trace: BoxTrace,
+  formatter: FormatterService = formatterFor(),
+): DescriptionState {
   const service = new DescriptionService(
     createMockContext(trace),
     createMockDisplayService(),
     { resetToDataMode: jest.fn() } as unknown as RotorNavigationService,
+    formatter,
   );
   const description = service.getDescription();
   expect(description).not.toBeNull();
@@ -190,5 +220,63 @@ describe('descriptionService value rounding', () => {
 
     expect(stat('Group names')).toBe('A');
     expect(description.dataTable.headers).toContain('Lower outlier(s)');
+  });
+});
+
+describe('descriptionService authored axis formats', () => {
+  test('reads a formatted column the way the layer\'s author asked for it', () => {
+    // The vertical box plot example formats its value axis to two decimals.
+    // Navigation already announced "71.35"; the table printed the raw float
+    // beside it, so one dialog described one value two ways.
+    const description = describeTrace(
+      boxTrace({ min: 8.75067648450717, q1: 61.3, q2: 78.9, q3: 96.4, max: 129.24 }),
+      formatterFor({ y: { type: 'fixed', decimals: 4 } }),
+    );
+
+    // 8.75 is what this service's own rounding would have said.
+    expect(row(description, 'A')[2]).toBe('8.7507');
+  });
+
+  test('formats every outlier in a joined cell, not just the first', () => {
+    const description = describeTrace(
+      boxTrace(
+        { min: 5, q1: 10, q2: 15, q3: 20, max: 25 },
+        { lower: [-9.795014876280863, 6.057387303065189] },
+      ),
+      formatterFor({ y: { type: 'currency', decimals: 2 } }),
+    );
+
+    expect(row(description, 'A')[1]).toBe('-$9.80, $6.06');
+  });
+
+  test('formats the group column through the categorical axis, as bar charts do', () => {
+    // The bar example maps abbreviated day names to full ones with an x
+    // format function; a vertical box plot's groups sit on the same axis.
+    const description = describeTrace(
+      boxTrace({ min: 5, q1: 10, q2: 15, q3: 20, max: 25 }),
+      formatterFor({ x: { function: 'return "Group " + value' } }),
+    );
+
+    expect(description.dataTable.rows[0][0]).toBe('Group A');
+  });
+
+  test('leaves an unformatted layer reading exactly as it did before', () => {
+    // Every axis has a formatter, because one with no `format` falls back to
+    // the default. Using it anyway would print `missing` in every empty cell
+    // of this sparse table, where the dialog renders a blank today.
+    const description = describeTrace(boxTrace({ min: 5, q1: 10, q2: 15, q3: 20, max: 25 }));
+
+    expect(row(description, 'A')).toEqual(['A', '', '5', '10', '15', '20', '25', '']);
+  });
+
+  test('formats only the axis the author declared, leaving the other rounded', () => {
+    const description = describeTrace(
+      boxTrace({ min: 8.75067648450717, q1: 61.3, q2: 78.9, q3: 96.4, max: 129.24 }),
+      formatterFor({ y: { type: 'fixed', decimals: 4 } }),
+    );
+
+    // The group name sits on x, which carries no format: still the raw label,
+    // not the default formatter's rendering of it.
+    expect(description.dataTable.rows[0][0]).toBe('A');
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

A chart layer may declare a `format` per axis — currency, a percentage, a date — and every spoken and braille announcement has honoured it for a long time. Walking `examples/vertical-candlestick.html` announces **"Jan 3"** and **"$180"**.

The data table in the same `d` dialog did not. It printed `2023-01-03` and `180.2534`, because nothing told it which column sat on which axis. One dialog described one value two ways, with nothing to say which was meant — and a reader comparing the table against what they had just heard had no way to tell whether they had misheard, or whether the chart disagreed with itself.

This was left as an explicit follow-up on #1243: *"Fixing it needs per-column axis identity on `DescriptionState.dataTable` and a change in every trace that builds one — worth doing, too large to ride along here."*

## Related Issues

Follow-up to #1243.

## Changes Made

**Per-column axis identity.** `DescriptionState.dataTable` gains an optional `columnAxes: (AxisType | undefined)[]`, index-aligned with `headers`. `DescriptionService` reads it and routes each column through the layer's own formatter.

**Gated on the format being *authored*, not merely resolved.** An axis with no `format` still has a formatter — the default — so the service asks `FormatterService.hasAuthoredFormat` first. A chart nobody formatted reads exactly as it did before, rather than gaining the word `missing` in every empty cell of a sparse table.

**Blanks stay blank.** An axis format is a reading for a value, and two kinds of cell hold none. An empty cell is how a sparse table shows an absent value, and a chart's own `format.function` sees it as text rather than absence: `Number(value).toFixed(1)` meeting `''` yields `0.0`, inventing a reading for a cell that has none. A non-finite number has to reach the dialog as a number for its own blanking check. Both fall through to the rounding the column would have used with no format at all, so declaring a format changes how values read and never how their absence does.

**All 32 traces that build a table now declare their columns.** A category column takes its axis like any other — the bar example maps `"Sat"` to `"Saturday"` through an x format function, and a category name is an axis value. A column the chart *computes* rather than measures takes none: a share, a running total, a rank, a delta, a duration, a joined ancestry, a trend word. Gantt's `Start` and `End` take none either, because `atTime` has already run the author's formatter over them and naming the axis would run it twice.

Where a family swaps which axis carries its categories, the column list is built from the same expression that swaps the headers; where a column is conditional, from the same condition. The two cannot drift.

## Screenshots (if applicable)

Not visual — the change is in what the dialog's table says. For the candlestick example, before and after:

| Column | Announced | Table before | Table after |
| --- | --- | --- | --- |
| Date | `Jan 3` | `2023-01-03` | `Jan 3` |
| Open | `$180.25` | `180.2534` | `$180.25` |
| Volatility | `$4.62` | `4.617` | `$4.62` |
| Trend | `Bull` | `Bull` | `Bull` |

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verified locally:** `npm run lint:fix` (no changes), `npm run type-check` (clean), `npm run build` (15/15), unit **549 suites / 7746 tests**, ESM **15 suites / 177 tests**. The full `npm test` was run as its constituent projects rather than in one invocation, because the runner's default worker count exhausts memory on this machine.

**On the tests.** `test/service/descriptionAxisFormat.test.ts` drives a real `Figure`, `Context`, `FormatterService` and `DescriptionService` rather than mocks — the defect lived in the seam between them, and a mocked formatter is exactly the thing that cannot prove it closed. It also pins the *unformatted* chart to what it printed before, which is the half of the contract that would otherwise regress silently.

`test/model/descriptionContract.test.ts` gains a test asserting `columnAxes` is either absent or exactly as long as its headers, plus sixteen cases for the *conditional* shapes — a candlestick with no open, a candlestick carrying volume, an error bar with groups, an error bar drawing bounds only, a treemap of a pure hierarchy, a network of several components, a horizontal histogram, a horizontal gantt. A table whose width depends on its data has a second shape the ordinary case never builds, and a column list that drifts there is invisible until someone reads that chart. Each of those cases was checked to produce a genuinely different table width from its sibling, so none of them is a case that passes by describing the same shape twice.

**Two judgement calls worth a reviewer's eye:**

1. **Candlestick's `Volatility` column takes the price axis.** It is `high − low`, a difference rather than a price — but `text` announces it through `crossAxis`, which *is* the price axis, so the table and the cursor agree. A currency format renders it `$4.62`, which reads correctly as a range in dollars.
2. **A stacked area's `Total` column takes no axis**, while `TextService` announces `state.stack.value` through the y formatter. So a layer with an authored y format announces the total formatted while the table prints the bare rounded float. A running total is computed rather than measured, which is the rule everywhere else here; changing it would be a decision about the *announcement*, not a fix to these files. Flagged rather than silently resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qQxbADuB9BZPwjv46ntaR

---
_Generated by [Claude Code](https://claude.ai/code/session_019qQxbADuB9BZPwjv46ntaR)_