### PR TITLE
fix(i18n): follow a browser that reports only a single language

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -12,7 +12,7 @@ The first row of the **General** tab is **Language**:
 
 | Option          | Effect                                                                 |
 | --------------- | ---------------------------------------------------------------------- |
-| Browser default | Follow the browser's language; English when MAIDR has no dictionary for it |
+| Browser default | Follow the browser's language (its preference list, or its single language where the list is empty); English when MAIDR has no dictionary for it |
 | English         | Always English                                                         |
 | 한국어          | Always Korean                                                          |
 

--- a/e2e_tests/specs/languageAutoDetect.spec.ts
+++ b/e2e_tests/specs/languageAutoDetect.spec.ts
@@ -1,0 +1,65 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { BarPlotPage } from '../page-objects/plots/barplot-page';
+
+/**
+ * A reader who has never opened MAIDR's settings should hear the chart in
+ * their browser's language from the first announcement — the pre-activation
+ * instruction a screen reader reads before the chart is ever focused — and
+ * the wrapper should declare that language so the screen reader switches
+ * voice. Nothing is stored in these tests: the language comes from the
+ * browser alone.
+ */
+
+/**
+ * What a screen reader meets before activation: the wrapper's accessible name
+ * and the language the article declares.
+ * @param page - The Playwright page
+ * @returns The pre-activation instruction and the article's `lang`
+ */
+async function preActivationState(page: Page): Promise<{ instruction: string; lang: string }> {
+  const barPlotPage = new BarPlotPage(page);
+  await barPlotPage.navigateToBarPlot();
+  const wrapper = page.locator('article[id^="maidr-article"] figure > div[tabindex="0"]').first();
+  await expect(wrapper).toHaveAttribute('aria-label', /.+/);
+  return {
+    instruction: (await wrapper.getAttribute('aria-label')) ?? '',
+    lang: (await page.locator('article[id^="maidr-article"]').first().getAttribute('lang')) ?? '',
+  };
+}
+
+test.describe('language from the browser', () => {
+  test.describe('a Korean browser', () => {
+    test.use({ locale: 'ko-KR' });
+
+    test('loads in Korean before the chart is activated', async ({ page }) => {
+      const { instruction, lang } = await preActivationState(page);
+
+      expect(lang).toBe('ko');
+      expect(instruction).toContain('maidr 그래프입니다');
+      expect(instruction).not.toContain('This is a maidr plot');
+    });
+
+    test('announces the first data point in Korean', async ({ page }) => {
+      const barPlotPage = new BarPlotPage(page);
+      await barPlotPage.navigateToBarPlot();
+      await barPlotPage.activateMaidr();
+
+      await page.keyboard.press('ArrowRight');
+
+      await expect(page.locator('[id^="maidr-text-container"]').first()).toContainText(/은|는/);
+      await expect(page.locator('[id^="maidr-text-container"]').first()).not.toContainText(' is ');
+    });
+  });
+
+  test.describe('an English browser', () => {
+    test.use({ locale: 'en-US' });
+
+    test('loads in English', async ({ page }) => {
+      const { instruction, lang } = await preActivationState(page);
+
+      expect(lang).toBe('en');
+      expect(instruction).toContain('This is a maidr plot');
+    });
+  });
+});

--- a/src/util/i18n/index.ts
+++ b/src/util/i18n/index.ts
@@ -61,22 +61,41 @@ export function isLanguageSetting(value: unknown): value is LanguageSetting {
 }
 
 /**
+ * The languages the browser asks for, in preference order.
+ *
+ * `navigator.languages` is the full list, but some embedded browsers leave
+ * it empty and set only `navigator.language`; a reader there would otherwise
+ * fall through to English no matter what their browser is set to.
+ * @returns The browser's languages, or none outside a browser
+ */
+export function browserLanguages(): readonly string[] {
+  if (typeof navigator === 'undefined') {
+    return [];
+  }
+  const languages = navigator.languages ?? [];
+  if (languages.length > 0) {
+    return languages;
+  }
+  return navigator.language ? [navigator.language] : [];
+}
+
+/**
  * Picks the locale a language preference means.
  *
  * `auto` follows the first browser language MAIDR supports, matched on its
  * primary subtag so `ko-KR` finds Korean. When none match, English.
  * @param setting - The stored preference
- * @param browserLanguages - The browser's languages in preference order, `navigator.languages` by default
+ * @param languages - The browser's languages in preference order, {@link browserLanguages} by default
  * @returns The locale to speak
  */
 export function resolveLocale(
   setting: LanguageSetting,
-  browserLanguages: readonly string[] = typeof navigator === 'undefined' ? [] : navigator.languages ?? [],
+  languages: readonly string[] = browserLanguages(),
 ): Locale {
   if (setting !== 'auto') {
     return setting;
   }
-  for (const language of browserLanguages) {
+  for (const language of languages) {
     const primary = language.toLowerCase().split('-')[0];
     if (isLocale(primary)) {
       return primary;

--- a/test/util/i18n/i18n.test.ts
+++ b/test/util/i18n/i18n.test.ts
@@ -1,4 +1,5 @@
 import {
+  browserLanguages,
   DEFAULT_LOCALE,
   getLocale,
   interpolate,
@@ -59,6 +60,38 @@ describe('i18n', () => {
       setLocale('ko');
 
       expect(listener.mock.calls).toEqual([['ko'], ['en']]);
+    });
+  });
+
+  describe('browserLanguages', () => {
+    const original = Object.getOwnPropertyDescriptors(navigator);
+
+    function stubNavigator(languages: readonly string[] | undefined, language: string): void {
+      Object.defineProperty(navigator, 'languages', { value: languages, configurable: true });
+      Object.defineProperty(navigator, 'language', { value: language, configurable: true });
+    }
+
+    afterEach(() => {
+      Object.defineProperties(navigator, original);
+    });
+
+    it('should prefer the full preference list', () => {
+      stubNavigator(['ko-KR', 'en-US'], 'en-US');
+
+      expect(browserLanguages()).toEqual(['ko-KR', 'en-US']);
+    });
+
+    it('should fall back to the single language when the list is empty', () => {
+      stubNavigator([], 'ko-KR');
+
+      expect(browserLanguages()).toEqual(['ko-KR']);
+      expect(resolveLocale('auto')).toBe('ko');
+    });
+
+    it('should fall back to the single language when the list is missing', () => {
+      stubNavigator(undefined, 'ko');
+
+      expect(resolveLocale('auto')).toBe('ko');
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #1246. A reader whose browser is set to Korean must hear the chart in Korean from the very first announcement without ever opening settings. That already holds through the **Browser default** language setting, but it read only `navigator.languages`, and some embedded browsers (WebViews, kiosk shells) leave that list empty and set only `navigator.language`. A Korean reader in such a browser fell through to English.

## Related Issues

Follows #1246.

## Changes Made

- `browserLanguages()` in `src/util/i18n/index.ts` returns `navigator.languages` when it has entries and otherwise falls back to `[navigator.language]`. `resolveLocale('auto')` uses it by default.
- Unit tests cover the full list, the empty list, and a missing list.
- New end-to-end spec `e2e_tests/specs/languageAutoDetect.spec.ts` runs Chromium with `locale: 'ko-KR'` and nothing stored, and asserts the pre-activation instruction and the article's `lang` are Korean before any focus, and that the first data point is announced in Korean; an `en-US` browser is checked the same way. This pins the "Korean browser loads in Korean" guarantee in CI rather than only in a unit test of the resolver.
- One sentence in `docs/LOCALIZATION.md` describing the fallback.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verified locally: lint and type-check clean, the i18n and settings-language unit suites pass, and the new e2e spec passes in Chromium against the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117eUjVDozabMwNNBBVmigY

---
_Generated by [Claude Code](https://claude.ai/code/session_0117eUjVDozabMwNNBBVmigY)_