### PR TITLE
feat(i18n): ship every language but English as a locale pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,10 @@ jobs:
       - name: Install Playwright chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Build core bundle
-        run: node scripts/build.js core
+      # The example pages fetch a locale pack from beside maidr.js when the
+      # browser asks for a language, so the packs have to be in dist too.
+      - name: Build core bundle and locale packs
+        run: node scripts/build.js core locales
 
       - name: Run e2e specs
         id: e2e

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For detailed encoding schemes for each plot type, see the [Braille Generation do
 
 ## Languages
 
-Every announcement and dialog can be read in English, 한국어, 日本語, 中文, Español, Deutsch, Français, Italiano, or हिन्दी. Choose the language on the **General** tab of Settings; by default MAIDR follows the browser's language. Chart data is read as the author wrote it; only MAIDR's own words are translated.
+Every announcement and dialog can be read in English, 한국어, 日本語, 中文, Español, Deutsch, Français, Italiano, or हिन्दी. Choose the language on the **General** tab of Settings; by default MAIDR follows the browser's language. English is built in and each other language is a small locale pack beside `maidr.js` that MAIDR fetches when needed (or `import 'maidr/locale/ko'`). Chart data is read as the author wrote it; only MAIDR's own words are translated.
 For how the dictionaries work and how to add a language, see the [Languages documentation](docs/LOCALIZATION.md).
 
 ## Examples

--- a/cdnjs/maidr.json
+++ b/cdnjs/maidr.json
@@ -25,7 +25,15 @@
         "files": [
           "maidr.js",
           "maidr.css",
-          "maidr-math.css"
+          "maidr-math.css",
+          "locale-ko.js",
+          "locale-ja.js",
+          "locale-zh.js",
+          "locale-es.js",
+          "locale-de.js",
+          "locale-fr.js",
+          "locale-it.js",
+          "locale-hi.js"
         ]
       }
     ]

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -27,6 +27,36 @@ Chart data is never translated. Axis labels, category names, and titles are
 read exactly as the chart's author wrote them; only MAIDR's own words around
 them change. The AI chat is asked to answer in the chosen language.
 
+## Loading a language
+
+English is built into `maidr.js`. Every other language is a **locale pack**, a
+small file beside the bundle, so a page pays only for the languages it uses.
+
+MAIDR fetches the pack itself when a language is chosen, from the directory
+`maidr.js` was loaded from: a page that loads
+`https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js` fetches
+`https://cdn.jsdelivr.net/npm/maidr/dist/locale-ko.js` the moment Korean is
+needed. Until the pack arrives, announcements are in English; the pack
+re-renders them as soon as it registers.
+
+To have the first announcement already in the reader's language, or on a page
+that cannot fetch at runtime, load the pack yourself, before or after the
+bundle:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/locale-ko.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+```
+
+```ts
+import 'maidr/locale/ko';
+```
+
+Either order works: a pack loaded first waits in `window.maidrLocales` until
+the bundle adopts the queue. When the packs live somewhere else, name the
+directory in `window.maidrLocaleBaseUrl` before the bundle runs; when MAIDR
+cannot locate them at all, it warns once and stays in English.
+
 ## Languages available
 
 | Code | Language  |
@@ -51,14 +81,16 @@ other language is typed against it, so a missing key is a type error rather
 than a silent fallback.
 
 1. Add the locale code to `Locale`, `SUPPORTED_LOCALES`, and `LOCALE_NAMES` in
-   `src/util/i18n/index.ts`. Name the language in itself, the way a reader who
-   does not read the current language would look for it.
+   `src/util/i18n/index.ts`, to `PROMPT_LANGUAGES` in `src/service/prompts.ts`,
+   and to `LOCALE_PACKS` in `scripts/build.js`. Name the language in itself,
+   the way a reader who does not read the current language would look for it.
 2. Create `src/util/i18n/<code>/` by copying `src/util/i18n/ko/`. Each file
    covers one area of the code (`text.ts`, `keybinding.ts`, `settings.ts`, …)
    and is typed `satisfies Partial<Record<MessageKey, string>>`; the
    `index.ts` that merges them is typed `Record<MessageKey, string>`, which is
    what makes an omission fail `npm run type-check`.
-3. Register the dictionary in `MESSAGES` in `src/util/i18n/index.ts`.
+3. Add the pack entry `src/locale/<code>.ts` (copy `src/locale/ko.ts`) and
+   import it from `src/locale/all.ts`; list the pack in `cdnjs/maidr.json`.
 4. Translate every value. Placeholders such as `{label}` and `{index}` are
    filled at render time; keep them, and reorder them freely to suit the
    language's word order.

--- a/e2e_tests/specs/languageAutoDetect.spec.ts
+++ b/e2e_tests/specs/languageAutoDetect.spec.ts
@@ -9,23 +9,31 @@ import { BarPlotPage } from '../page-objects/plots/barplot-page';
  * the wrapper should declare that language so the screen reader switches
  * voice. Nothing is stored in these tests: the language comes from the
  * browser alone.
+ *
+ * The example pages load `maidr.js` alone, so every language but English
+ * arrives through the locale pack MAIDR fetches from beside the bundle. The
+ * article's `lang` flips the moment the language is chosen, and the label
+ * follows once the pack registers, so both are awaited rather than read.
  */
 
 /**
- * What a screen reader meets before activation: the wrapper's accessible name
- * and the language the article declares.
+ * Opens the bar chart and waits for its language to settle.
  * @param page - The Playwright page
- * @returns The pre-activation instruction and the article's `lang`
+ * @param lang - The language the page is expected to settle on
+ * @returns The wrapper's pre-activation instruction in that language
  */
-async function preActivationState(page: Page): Promise<{ instruction: string; lang: string }> {
+async function preActivationInstruction(page: Page, lang: string): Promise<string> {
   const barPlotPage = new BarPlotPage(page);
   await barPlotPage.navigateToBarPlot();
-  const wrapper = page.locator('article[id^="maidr-article"] figure > div[tabindex="0"]').first();
-  await expect(wrapper).toHaveAttribute('aria-label', /.+/);
-  return {
-    instruction: (await wrapper.getAttribute('aria-label')) ?? '',
-    lang: (await page.locator('article[id^="maidr-article"]').first().getAttribute('lang')) ?? '',
-  };
+  const article = page.locator('article[id^="maidr-article"]').first();
+  const wrapper = article.locator('figure > div[tabindex="0"]').first();
+  await expect(article).toHaveAttribute('lang', lang);
+  if (lang === 'en') {
+    await expect(wrapper).toHaveAttribute('aria-label', /This is a maidr plot/);
+  } else {
+    await expect(wrapper).not.toHaveAttribute('aria-label', /This is a maidr plot/);
+  }
+  return (await wrapper.getAttribute('aria-label')) ?? '';
 }
 
 test.describe('language from the browser', () => {
@@ -33,22 +41,21 @@ test.describe('language from the browser', () => {
     test.use({ locale: 'ko-KR' });
 
     test('loads in Korean before the chart is activated', async ({ page }) => {
-      const { instruction, lang } = await preActivationState(page);
+      const instruction = await preActivationInstruction(page, 'ko');
 
-      expect(lang).toBe('ko');
       expect(instruction).toContain('maidr 그래프입니다');
-      expect(instruction).not.toContain('This is a maidr plot');
     });
 
     test('announces the first data point in Korean', async ({ page }) => {
+      await preActivationInstruction(page, 'ko');
       const barPlotPage = new BarPlotPage(page);
-      await barPlotPage.navigateToBarPlot();
       await barPlotPage.activateMaidr();
 
       await page.keyboard.press('ArrowRight');
 
-      await expect(page.locator('[id^="maidr-text-container"]').first()).toContainText(/은|는/);
-      await expect(page.locator('[id^="maidr-text-container"]').first()).not.toContainText(' is ');
+      const text = page.locator('[id^="maidr-text-container"]').first();
+      await expect(text).toContainText(/은|는/);
+      await expect(text).not.toContainText(' is ');
     });
   });
 
@@ -65,10 +72,8 @@ test.describe('language from the browser', () => {
       test.use({ locale: browserLocale });
 
       test(`loads in ${lang} before the chart is activated`, async ({ page }) => {
-        const { instruction, lang: declared } = await preActivationState(page);
+        const instruction = await preActivationInstruction(page, lang);
 
-        expect(declared).toBe(lang);
-        expect(instruction).not.toContain('This is a maidr plot');
         expect(instruction.length).toBeGreaterThan(20);
       });
     });
@@ -78,10 +83,9 @@ test.describe('language from the browser', () => {
     test.use({ locale: 'en-US' });
 
     test('loads in English', async ({ page }) => {
-      const { instruction, lang } = await preActivationState(page);
+      const instruction = await preActivationInstruction(page, 'en');
 
-      expect(lang).toBe('en');
-      expect(instruction).toContain('This is a maidr plot');
+      expect(instruction).toContain('This is a maidr plot of type: vertical bar.');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
       "import": "./dist/recharts.mjs",
       "default": "./dist/recharts.mjs"
     },
+    "./locale/*": {
+      "import": "./dist/locale-*.mjs",
+      "default": "./dist/locale-*.js"
+    },
     "./vegalite": {
       "types": "./dist/vegalite.d.mts",
       "import": "./dist/vegalite.mjs",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -635,6 +635,21 @@ async function runParallel(selected, jobs, outDir) {
  * @param {typeof builds} configs Entries to check.
  * @throws {Error} If any entry maps two formats onto the same filename.
  */
+/**
+ * Turns the bundle names on the command line into build names.
+ *
+ * `locales` stands for every locale pack, so a caller that needs the packs
+ * beside the core -- the E2E job, which serves the example pages from `dist`
+ * -- does not have to repeat the list and fall behind it when a language is
+ * added. Any other name is passed through to be checked against `builds`.
+ * @param {string[]} requested - The names as typed
+ * @returns {string[]} The build names they mean
+ */
+export function expandBuildNames(requested) {
+  return requested.flatMap(name =>
+    name === 'locales' ? LOCALE_PACKS.map(locale => `locale-${locale}`) : [name]);
+}
+
 export function assertUniqueOutputFilenames(configs) {
   for (const config of configs) {
     // Vite's lib-mode default when `name` is set. Every entry declares
@@ -703,7 +718,8 @@ async function main() {
     process.exit(1);
   }
 
-  const unknown = requested.filter(name => !builds.some(b => b.name === name));
+  const requestedBuilds = expandBuildNames(requested);
+  const unknown = requestedBuilds.filter(name => !builds.some(b => b.name === name));
   if (unknown.length > 0) {
     console.error(`Unknown bundle name(s): ${unknown.join(', ')}`);
     console.error(`Available: ${builds.map(b => b.name).join(', ')}`);
@@ -724,7 +740,7 @@ async function main() {
 
   const selected = requested.length > 0
     ? builds
-        .filter(b => requested.includes(b.name))
+        .filter(b => requestedBuilds.includes(b.name))
         // Selective builds must not wipe the other bundles from dist.
         .map(b => ({ ...b, emptyOutDir: false }))
     : builds;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -144,6 +144,38 @@ function onWarn(warning, warn) {
  * Exported so the build-config test can assert against the real array rather
  * than a fixture that could drift away from it.
  */
+/**
+ * The locales that ship as packs beside `maidr.js`, one classic script and one
+ * ES module each. English lives in the core bundle, so it is not here. Keep in
+ * step with `SUPPORTED_LOCALES` in `src/util/i18n/index.ts`; the pack entry
+ * files under `src/locale/` are what the list points at.
+ */
+export const LOCALE_PACKS = ['ko', 'ja', 'zh', 'es', 'de', 'fr', 'it', 'hi'];
+
+/**
+ * A pack is a side-effect entry with no exports and no React, so it needs no
+ * declaration file. Flat filenames rather than a `locale/` directory: each
+ * pack builds in its own worker, and the merge step treats a directory two
+ * workers both emit as a collision.
+ * @param locale - The pack's locale code
+ * @returns The build configuration for that pack
+ */
+function localePackBuild(locale) {
+  const capitalised = locale.charAt(0).toUpperCase() + locale.slice(1);
+  return {
+    name: `locale-${locale}`,
+    entry: `src/locale/${locale}.ts`,
+    libName: `maidrLocale${capitalised}`,
+    formats: ['es', 'umd'],
+    fileName: format => format === 'es' ? `locale-${locale}.mjs` : `locale-${locale}.js`,
+    emptyOutDir: false,
+    external: [],
+    useReact: false,
+    useDts: false,
+    aliases: baseAliases,
+  };
+}
+
 export const builds = [
   {
     name: 'core',
@@ -365,6 +397,7 @@ export const builds = [
     useDts: true,
     aliases: adapterAliases,
   },
+  ...LOCALE_PACKS.map(localePackBuild),
 ];
 
 export function createViteConfig(config) {

--- a/src/locale/all.ts
+++ b/src/locale/all.ts
@@ -1,0 +1,13 @@
+/**
+ * Every locale pack at once, for a page that would rather load one file than
+ * pick languages. Costs the size of every dictionary; prefer the per-language
+ * packs where the reader's languages are known.
+ */
+import './de';
+import './es';
+import './fr';
+import './hi';
+import './it';
+import './ja';
+import './ko';
+import './zh';

--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -1,0 +1,4 @@
+import { de } from '@util/i18n/de';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('de', de);

--- a/src/locale/es.ts
+++ b/src/locale/es.ts
@@ -1,0 +1,4 @@
+import { es } from '@util/i18n/es';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('es', es);

--- a/src/locale/fr.ts
+++ b/src/locale/fr.ts
@@ -1,0 +1,4 @@
+import { fr } from '@util/i18n/fr';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('fr', fr);

--- a/src/locale/hi.ts
+++ b/src/locale/hi.ts
@@ -1,0 +1,4 @@
+import { hi } from '@util/i18n/hi';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('hi', hi);

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -1,0 +1,4 @@
+import { it } from '@util/i18n/it';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('it', it);

--- a/src/locale/ja.ts
+++ b/src/locale/ja.ts
@@ -1,0 +1,4 @@
+import { ja } from '@util/i18n/ja';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('ja', ja);

--- a/src/locale/ko.ts
+++ b/src/locale/ko.ts
@@ -1,0 +1,4 @@
+import { ko } from '@util/i18n/ko';
+import { registerLocalePack } from '@util/i18n/pack';
+
+registerLocalePack('ko', ko);

--- a/src/locale/zh.ts
+++ b/src/locale/zh.ts
@@ -1,0 +1,4 @@
+import { registerLocalePack } from '@util/i18n/pack';
+import { zh } from '@util/i18n/zh';
+
+registerLocalePack('zh', zh);

--- a/src/maidr-component.tsx
+++ b/src/maidr-component.tsx
@@ -125,14 +125,14 @@ export function Maidr({ data, children }: MaidrProps): JSX.Element {
   const store = storeRef.current;
 
   const { plotRef, figureRef, contextValue, onFocusIn, onFocusOut } = useMaidrController(data, store);
-  const { locale } = useLocale();
+  const { locale, revision } = useLocale();
 
   // Compute the initial instruction once so the plot is discoverable by screen
   // readers (role="img" + aria-label) before any user interaction.
-  // `locale` is a dependency because the instruction is built from translated
-  // messages: without it the pre-activation label would keep the language the
-  // chart first rendered in.
-  const initialInstruction = useMemo(() => getInitialInstruction(data), [data, locale]);
+  // `revision` is a dependency because the instruction is built from
+  // translated messages: it advances on a language change and when the
+  // language's pack arrives, which leaves `locale` itself unchanged.
+  const initialInstruction = useMemo(() => getInitialInstruction(data), [data, revision]);
 
   // Click-to-activate shim: most chart libraries render the plot as inert SVG
   // children of our `tabIndex={0}` wrapper. Browsers do NOT auto-focus a

--- a/src/service/localePack.ts
+++ b/src/service/localePack.ts
@@ -43,19 +43,39 @@ export function resolveLocalePackUrl(locale: Locale): string | null {
 const inFlight = new Map<Locale, Promise<boolean>>();
 
 /**
- * Whether a script for this URL is already on the page, from the author or
- * from an earlier call, so it is never added twice.
+ * The script for this URL already on the page, from the author or from an
+ * earlier call, so it is never added twice.
  * @param url - The pack's absolute URL
- * @returns True when a matching script element exists
+ * @returns The matching script element, or null
  */
-function alreadyOnPage(url: string): boolean {
+function alreadyOnPage(url: string): HTMLScriptElement | null {
   const scripts = document.querySelectorAll<HTMLScriptElement>('script[src]');
   for (const script of scripts) {
     if (script.src === url) {
-      return true;
+      return script;
     }
   }
-  return false;
+  return null;
+}
+
+/**
+ * Settles once a pack script has loaded or failed.
+ *
+ * Used for the author's own tag as much as for one added here: a tag that is
+ * on the page but still downloading has not registered anything yet, and
+ * answering "not loaded" for it would be wrong the moment it finishes.
+ * @param script - The pack's script element
+ * @param locale - The locale it carries
+ * @returns Whether the locale is loaded once the script has settled
+ */
+function settled(script: HTMLScriptElement, locale: Locale): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    script.addEventListener('load', () => resolve(isLocaleLoaded(locale)), { once: true });
+    script.addEventListener('error', () => {
+      console.warn(`[maidr] Could not load the locale pack at ${script.src}; announcements stay in English.`);
+      resolve(false);
+    }, { once: true });
+  });
 }
 
 /**
@@ -82,22 +102,14 @@ export function ensureLocalePack(locale: Locale): Promise<boolean> {
     console.warn(`[maidr] Cannot locate the locale pack for "${locale}"; add <script src="…/${localePackFilename(locale)}"> or set window.maidrLocaleBaseUrl.`);
     return Promise.resolve(false);
   }
-  const attempt = new Promise<boolean>((resolve) => {
-    if (alreadyOnPage(url)) {
-      // The author's own tag will register it; nothing to wait on here.
-      resolve(isLocaleLoaded(locale));
-      return;
-    }
-    const script = document.createElement('script');
+  let script = alreadyOnPage(url);
+  if (!script) {
+    script = document.createElement('script');
     script.src = url;
     script.async = true;
-    script.onload = () => resolve(isLocaleLoaded(locale));
-    script.onerror = () => {
-      console.warn(`[maidr] Could not load the locale pack at ${url}; announcements stay in English.`);
-      resolve(false);
-    };
     document.head.appendChild(script);
-  }).finally(() => inFlight.delete(locale));
+  }
+  const attempt = settled(script, locale).finally(() => inFlight.delete(locale));
   inFlight.set(locale, attempt);
   return attempt;
 }

--- a/src/service/localePack.ts
+++ b/src/service/localePack.ts
@@ -1,0 +1,103 @@
+import type { Locale } from '@util/i18n';
+import { detectMaidrSource } from '@util/diagnostics';
+import { isLocaleLoaded } from '@util/i18n';
+
+declare global {
+  interface Window {
+    /**
+     * Where the locale packs are served from, for a page that does not keep
+     * them beside `maidr.js`. A directory URL; `locale-<code>.js` is appended.
+     */
+    maidrLocaleBaseUrl?: string;
+  }
+}
+
+/** The pack that carries a locale, relative to the directory `maidr.js` is in. */
+export function localePackFilename(locale: Locale): string {
+  return `locale-${locale}.js`;
+}
+
+/**
+ * Works out where a locale's pack is served from.
+ *
+ * The packs ship beside `maidr.js`, so wherever the page loaded that from — a
+ * CDN, its own assets, a `file://` export — locates them. An explicit
+ * `window.maidrLocaleBaseUrl` wins, for the pages where the bundle's own URL
+ * cannot be found or the packs live elsewhere.
+ * @param locale - The locale whose pack to locate
+ * @returns The pack's absolute URL, or null when nothing locates it
+ */
+export function resolveLocalePackUrl(locale: Locale): string | null {
+  const override = typeof window === 'undefined' ? undefined : window.maidrLocaleBaseUrl;
+  const base = override ? `${override.replace(/\/?$/, '/')}` : detectMaidrSource().url;
+  if (!base) {
+    return null;
+  }
+  try {
+    return new URL(localePackFilename(locale), base).href;
+  } catch {
+    return null;
+  }
+}
+
+const inFlight = new Map<Locale, Promise<boolean>>();
+
+/**
+ * Whether a script for this URL is already on the page, from the author or
+ * from an earlier call, so it is never added twice.
+ * @param url - The pack's absolute URL
+ * @returns True when a matching script element exists
+ */
+function alreadyOnPage(url: string): boolean {
+  const scripts = document.querySelectorAll<HTMLScriptElement>('script[src]');
+  for (const script of scripts) {
+    if (script.src === url) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Loads a locale's pack if the page has not, so a reader who chose a language
+ * hears it without the page author having added a script tag.
+ *
+ * English needs no pack. A pack already registered, in flight, or present as
+ * a script tag is not fetched again. Resolves to whether the locale is loaded
+ * once the attempt settles; a page with no locatable pack directory resolves
+ * false with one warning, and MAIDR keeps speaking English.
+ * @param locale - The locale to make available
+ * @returns Whether the locale's dictionary is loaded
+ */
+export function ensureLocalePack(locale: Locale): Promise<boolean> {
+  if (locale === 'en' || isLocaleLoaded(locale)) {
+    return Promise.resolve(true);
+  }
+  const pending = inFlight.get(locale);
+  if (pending) {
+    return pending;
+  }
+  const url = typeof document === 'undefined' ? null : resolveLocalePackUrl(locale);
+  if (!url) {
+    console.warn(`[maidr] Cannot locate the locale pack for "${locale}"; add <script src="…/${localePackFilename(locale)}"> or set window.maidrLocaleBaseUrl.`);
+    return Promise.resolve(false);
+  }
+  const attempt = new Promise<boolean>((resolve) => {
+    if (alreadyOnPage(url)) {
+      // The author's own tag will register it; nothing to wait on here.
+      resolve(isLocaleLoaded(locale));
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = true;
+    script.onload = () => resolve(isLocaleLoaded(locale));
+    script.onerror = () => {
+      console.warn(`[maidr] Could not load the locale pack at ${url}; announcements stay in English.`);
+      resolve(false);
+    };
+    document.head.appendChild(script);
+  }).finally(() => inFlight.delete(locale));
+  inFlight.set(locale, attempt);
+  return attempt;
+}

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -4,11 +4,13 @@ import type { Disposable } from '@type/disposable';
 import type { Event } from '@type/event';
 import type { Observer } from '@type/observable';
 import type { Settings } from '@type/settings';
+import type { Locale } from '@util/i18n';
 import { Emitter, Scope } from '@type/event';
 import { DEFAULT_SETTINGS } from '@type/settings';
 import { normalizeBrailleDisplay } from '@util/braillePreset';
 import { deepMerge } from '@util/deepMerge';
 import { isLanguageSetting, resolveLocale, setLocale } from '@util/i18n';
+import { ensureLocalePack } from './localePack';
 
 export const SETTINGS_KEY = 'maidr-settings';
 
@@ -58,9 +60,21 @@ class SettingsChangedEvent {
 export function applyStoredLanguage(storage: StorageService): void {
   const saved = storage.load<{ general?: { language?: unknown } }>(SETTINGS_KEY);
   const language = saved?.general?.language;
-  setLocale(resolveLocale(
+  speak(resolveLocale(
     isLanguageSetting(language) ? language : DEFAULT_SETTINGS.general.language,
   ));
+}
+
+/**
+ * Makes a locale the active one and fetches its pack if the page lacks it.
+ *
+ * The switch is immediate so nothing waits on the network: until the pack
+ * registers, messages render in English, and registration re-renders them.
+ * @param locale - The locale to speak
+ */
+function speak(locale: Locale): void {
+  setLocale(locale);
+  void ensureLocalePack(locale);
 }
 
 export class SettingsService implements Disposable {
@@ -104,7 +118,7 @@ export class SettingsService implements Disposable {
    * who picks a language hears the next announcement in it.
    */
   private applyLanguage(): void {
-    setLocale(resolveLocale(this.currentSettings.general.language));
+    speak(resolveLocale(this.currentSettings.general.language));
   }
 
   public dispose(): void {

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS } from '@type/settings';
 import { normalizeBrailleDisplay } from '@util/braillePreset';
 import { deepMerge } from '@util/deepMerge';
 import { isLanguageSetting, resolveLocale, setLocale } from '@util/i18n';
-import { ensureLocalePack } from './localePack';
+import { ensureLocalePack } from '@util/i18n/localePack';
 
 export const SETTINGS_KEY = 'maidr-settings';
 

--- a/src/state/hook/useLocale.ts
+++ b/src/state/hook/useLocale.ts
@@ -1,5 +1,5 @@
 import type { Locale, MessageKey, MessageParams } from '@util/i18n';
-import { getLocale, onLocaleChange, t } from '@util/i18n';
+import { getLocale, getLocaleRevision, onLocaleChange, t } from '@util/i18n';
 import { useCallback, useSyncExternalStore } from 'react';
 
 /**
@@ -18,6 +18,12 @@ function subscribe(onStoreChange: () => void): () => void {
 export interface LocaleApi {
   /** The active locale, for `lang` attributes and locale-aware formatting. */
   locale: Locale;
+  /**
+   * Advances whenever `t` would render differently: on a locale switch, and
+   * when the active locale's pack arrives. A memo that caches rendered text
+   * keys on this rather than on `locale`, which a late pack leaves unchanged.
+   */
+  revision: number;
   /** Renders a message in the active locale; see `t` in `@util/i18n`. */
   t: (key: MessageKey, params?: MessageParams) => string;
 }
@@ -31,11 +37,14 @@ export interface LocaleApi {
  * @returns The active locale and its `t`
  */
 export function useLocale(): LocaleApi {
-  const locale = useSyncExternalStore(subscribe, getLocale, getLocale);
-  // Bound to `locale` so memoised callers see a new function per language.
+  // The revision is the snapshot, not the locale: a pack registering for the
+  // active locale changes every message without changing the locale string,
+  // and a subscription keyed on the string would not re-render for it.
+  const revision = useSyncExternalStore(subscribe, getLocaleRevision, getLocaleRevision);
+  // Bound to `revision` so memoised callers see a new function per change.
   const translate = useCallback(
     (key: MessageKey, params?: MessageParams) => t(key, params),
-    [locale],
+    [revision],
   );
-  return { locale, t: translate };
+  return { locale: getLocale(), revision, t: translate };
 }

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -38,6 +38,11 @@ export interface Diagnostics {
  * or at a bundled copy — report the tag that loaded maidr.js. Module scripts
  * report `null`, which the DOM scan in {@link findMaidrScriptUrl} covers.
  *
+ * Both globals are checked, not only `document`: a test can stand up a
+ * `document` without the element constructors beside it, and this module is
+ * now on the path every chart takes (the locale pack loader reads the bundle
+ * URL from here), so its evaluation must not throw in a partial DOM.
+ *
  * This carries a load-order assumption worth stating: it holds only while this
  * module is evaluated as part of the bundle's initial synchronous execution,
  * which is true of every build target today because none of them code-split.
@@ -47,7 +52,9 @@ export interface Diagnostics {
  * than reading the tag that actually loaded the bundle.
  */
 const loadingScript: HTMLScriptElement | null
-  = typeof document !== 'undefined' && document.currentScript instanceof HTMLScriptElement
+  = typeof document !== 'undefined'
+    && typeof HTMLScriptElement !== 'undefined'
+    && document.currentScript instanceof HTMLScriptElement
     ? document.currentScript
     : null;
 

--- a/src/util/i18n/index.ts
+++ b/src/util/i18n/index.ts
@@ -1,23 +1,26 @@
 import type { Disposable } from '@type/disposable';
-import { de } from './de';
 import { en } from './en';
-import { es } from './es';
-import { fr } from './fr';
-import { hi } from './hi';
-import { it } from './it';
-import { ja } from './ja';
 import { attachJosa, isJosaPair } from './josa';
-import { ko } from './ko';
-import { zh } from './zh';
+import { adoptLocalePacks } from './pack';
 
 /**
  * A language MAIDR can speak. Every dictionary under `src/util/i18n/` has an
  * entry for every key of the English one, so any locale can render any
  * message.
+ *
+ * English ships inside the core bundle. Every other dictionary is a locale
+ * pack — `dist/locale-ko.js`, or `maidr/locale/ko` from npm — registered
+ * through {@link registerLocale}, so adding a language costs nothing to a
+ * page that does not load it. A locale that is active but not registered
+ * renders in English until its pack arrives.
  */
 export type Locale = 'en' | 'ko' | 'ja' | 'zh' | 'es' | 'de' | 'fr' | 'it' | 'hi';
 
-/** The locales offered, in the order the settings dialog lists them. */
+/**
+ * The locales MAIDR knows a dictionary for, in the order the settings dialog
+ * lists them. Knowing one is not the same as having it loaded; see
+ * {@link isLocaleLoaded}.
+ */
 export const SUPPORTED_LOCALES: readonly Locale[] = ['en', 'ko', 'ja', 'zh', 'es', 'de', 'fr', 'it', 'hi'];
 
 /** The language before a preference is set and when the browser's is unknown. */
@@ -51,10 +54,65 @@ export type MessageKey = keyof typeof en;
 /** Values substituted into a message's `{placeholders}`. */
 export type MessageParams = Record<string, string | number | undefined>;
 
-const MESSAGES: Record<Locale, Record<MessageKey, string>> = { en, ko, ja, zh, es, de, fr, it, hi };
+const MESSAGES: Partial<Record<Locale, Readonly<Record<MessageKey, string>>>> = { en };
 
 let activeLocale: Locale = DEFAULT_LOCALE;
+let revision = 0;
 const listeners = new Set<(locale: Locale) => void>();
+
+function notify(): void {
+  revision += 1;
+  for (const listener of listeners) {
+    listener(activeLocale);
+  }
+}
+
+/**
+ * A counter that advances every time what {@link t} would render changes:
+ * on a locale switch, and when the active locale's pack registers.
+ *
+ * The locale alone is not enough for a subscriber to key on. A pack arriving
+ * for the locale already active changes every message and leaves the locale
+ * string as it was, so a React subscription keyed on the locale would see
+ * nothing to re-render.
+ * @returns The current revision
+ */
+export function getLocaleRevision(): number {
+  return revision;
+}
+
+/**
+ * Whether a locale's dictionary is present, so {@link t} can render it.
+ * @param locale - The locale to check
+ * @returns True for English and for any registered pack
+ */
+export function isLocaleLoaded(locale: Locale): boolean {
+  return MESSAGES[locale] !== undefined;
+}
+
+/**
+ * Adds a dictionary to the registry.
+ *
+ * When the dictionary is the one the active locale has been waiting for,
+ * listeners are told, so every open dialog and the pre-activation
+ * instruction re-render out of English and into the reader's language.
+ * A dictionary for a locale MAIDR does not know is ignored with a warning
+ * rather than thrown, since it arrives from a script the page author chose.
+ * @param locale - The locale the dictionary speaks
+ * @param messages - Its messages, one per English key
+ */
+export function registerLocale(locale: Locale, messages: Readonly<Record<MessageKey, string>>): void {
+  if (!isLocale(locale)) {
+    console.warn(`[maidr] Ignoring a locale pack for an unknown locale: ${String(locale)}`);
+    return;
+  }
+  MESSAGES[locale] = messages;
+  if (locale === activeLocale) {
+    notify();
+  }
+}
+
+adoptLocalePacks(registerLocale);
 
 /**
  * Whether a value names a supported locale.
@@ -126,7 +184,7 @@ export function resolveLocale(
  * @param locale - The locale whose dictionary to read
  * @returns The locale's templates by key
  */
-export function dictionary(locale: Locale): Readonly<Record<MessageKey, string>> {
+export function dictionary(locale: Locale): Readonly<Record<MessageKey, string>> | undefined {
   return MESSAGES[locale];
 }
 
@@ -150,9 +208,7 @@ export function setLocale(locale: Locale): void {
     return;
   }
   activeLocale = locale;
-  for (const listener of listeners) {
-    listener(locale);
-  }
+  notify();
 }
 
 /**
@@ -192,15 +248,14 @@ export function interpolate(template: string, params: MessageParams = {}): strin
 /**
  * Renders a message in the active locale.
  *
- * A key the active dictionary lacks — which the types prevent, but a locale
- * loaded at runtime could omit — falls back to English rather than to the
- * key, so the reader always hears words.
+ * A locale whose pack has not arrived, or a key a pack lacks, falls back to
+ * English rather than to the key, so the reader always hears words.
  * @param key - The message key
  * @param params - Values for the message's placeholders
  * @returns The rendered message
  */
 export function t(key: MessageKey, params?: MessageParams): string {
-  const template = MESSAGES[activeLocale][key] ?? en[key];
+  const template = MESSAGES[activeLocale]?.[key] ?? en[key];
   return interpolate(template, params);
 }
 
@@ -215,6 +270,6 @@ export function t(key: MessageKey, params?: MessageParams): string {
  * @returns The rendered message
  */
 export function tIn(locale: Locale, key: MessageKey, params?: MessageParams): string {
-  const template = MESSAGES[locale][key] ?? en[key];
+  const template = MESSAGES[locale]?.[key] ?? en[key];
   return interpolate(template, params);
 }

--- a/src/util/i18n/localePack.ts
+++ b/src/util/i18n/localePack.ts
@@ -1,6 +1,6 @@
-import type { Locale } from '@util/i18n';
+import type { Locale } from './index';
 import { detectMaidrSource } from '@util/diagnostics';
-import { isLocaleLoaded } from '@util/i18n';
+import { isLocaleLoaded } from './index';
 
 declare global {
   interface Window {
@@ -29,7 +29,7 @@ export function localePackFilename(locale: Locale): string {
  */
 export function resolveLocalePackUrl(locale: Locale): string | null {
   const override = typeof window === 'undefined' ? undefined : window.maidrLocaleBaseUrl;
-  const base = override ? `${override.replace(/\/?$/, '/')}` : detectMaidrSource().url;
+  const base = override ? override.replace(/\/?$/, '/') : detectMaidrSource().url;
   if (!base) {
     return null;
   }

--- a/src/util/i18n/pack.ts
+++ b/src/util/i18n/pack.ts
@@ -1,0 +1,70 @@
+import type { Locale, MessageKey } from './index';
+
+/**
+ * A dictionary handed to MAIDR from outside the core bundle: the locale it
+ * speaks and its messages, keyed like the English dictionary.
+ */
+export type LocalePack = readonly [locale: Locale, messages: Readonly<Record<MessageKey, string>>];
+
+/** Where packs register, once the core bundle has adopted the queue. */
+interface LocalePackQueue {
+  push: (...packs: LocalePack[]) => number;
+}
+
+/**
+ * The global the packs and the core bundle meet at.
+ *
+ * A locale pack is its own script, built and loaded apart from `maidr.js`, so
+ * the two share no module instance. They share this global instead, the way a
+ * `dataLayer` works: before the core bundle runs, it is a plain array the packs
+ * push into; when the core runs it drains the array and swaps in an object
+ * whose `push` registers immediately. Either load order therefore works.
+ */
+type LocalePackGlobal = LocalePack[] | LocalePackQueue;
+
+const GLOBAL_KEY = 'maidrLocales';
+
+function packGlobal(): { [GLOBAL_KEY]?: LocalePackGlobal } {
+  return globalThis as unknown as { [GLOBAL_KEY]?: LocalePackGlobal };
+}
+
+/**
+ * Offers a dictionary to whichever MAIDR bundle is on the page, now or later.
+ *
+ * This is the whole of what a locale pack does. It imports nothing from the
+ * core bundle, which is what keeps a pack to the size of its dictionary.
+ * @param locale - The locale the dictionary speaks
+ * @param messages - Its messages, one per English key
+ */
+export function registerLocalePack(locale: Locale, messages: Readonly<Record<MessageKey, string>>): void {
+  const holder = packGlobal();
+  holder[GLOBAL_KEY] ??= [];
+  holder[GLOBAL_KEY].push([locale, messages]);
+}
+
+/**
+ * Takes over the pack queue for a registry.
+ *
+ * Packs queued before this call are handed to `register` at once; packs pushed
+ * afterwards go straight through. A second bundle adopting the queue chains
+ * onto the first, so two MAIDR bundles on one page both hear every pack.
+ * @param register - Where a pack's dictionary goes
+ */
+export function adoptLocalePacks(register: (locale: Locale, messages: Readonly<Record<MessageKey, string>>) => void): void {
+  const holder = packGlobal();
+  const previous = holder[GLOBAL_KEY];
+  const queued = Array.isArray(previous) ? previous : [];
+  const forward = !Array.isArray(previous) && previous ? previous.push.bind(previous) : null;
+  holder[GLOBAL_KEY] = {
+    push: (...packs: LocalePack[]): number => {
+      for (const [locale, messages] of packs) {
+        register(locale, messages);
+      }
+      forward?.(...packs);
+      return packs.length;
+    },
+  };
+  for (const [locale, messages] of queued) {
+    register(locale, messages);
+  }
+}

--- a/src/util/i18n/pack.ts
+++ b/src/util/i18n/pack.ts
@@ -9,6 +9,8 @@ export type LocalePack = readonly [locale: Locale, messages: Readonly<Record<Mes
 /** Where packs register, once the core bundle has adopted the queue. */
 interface LocalePackQueue {
   push: (...packs: LocalePack[]) => number;
+  /** Every pack seen so far, so a bundle adopting later can catch up. */
+  readonly seen: readonly LocalePack[];
 }
 
 /**
@@ -46,21 +48,25 @@ export function registerLocalePack(locale: Locale, messages: Readonly<Record<Mes
  * Takes over the pack queue for a registry.
  *
  * Packs queued before this call are handed to `register` at once; packs pushed
- * afterwards go straight through. A second bundle adopting the queue chains
- * onto the first, so two MAIDR bundles on one page both hear every pack.
+ * afterwards go straight through. A second bundle adopting the queue receives
+ * every pack the first already took, and chains onto it for the rest, so two
+ * MAIDR bundles on one page both hear every pack whenever it arrived.
  * @param register - Where a pack's dictionary goes
  */
 export function adoptLocalePacks(register: (locale: Locale, messages: Readonly<Record<MessageKey, string>>) => void): void {
   const holder = packGlobal();
   const previous = holder[GLOBAL_KEY];
-  const queued = Array.isArray(previous) ? previous : [];
-  const forward = !Array.isArray(previous) && previous ? previous.push.bind(previous) : null;
+  const earlier = !Array.isArray(previous) && previous ? previous : null;
+  const queued: LocalePack[] = Array.isArray(previous) ? previous : [...(earlier?.seen ?? [])];
+  const seen: LocalePack[] = [...queued];
   holder[GLOBAL_KEY] = {
+    seen,
     push: (...packs: LocalePack[]): number => {
-      for (const [locale, messages] of packs) {
-        register(locale, messages);
+      for (const pack of packs) {
+        seen.push(pack);
+        register(pack[0], pack[1]);
       }
-      forward?.(...packs);
+      earlier?.push(...packs);
       return packs.length;
     },
   };

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -65,6 +65,8 @@ interface BuildOutputs {
   coreStylesheet: string;
   /** The KaTeX stylesheet `maidr.js` fetches on demand. */
   mathStylesheet: string;
+  /** The classic-script locale packs, `locale-ko.js` and its siblings. */
+  localePacks: string[];
   /** Every filename any bundle writes, adapters included. */
   all: string[];
 }
@@ -108,6 +110,9 @@ function readBuildOutputs(): BuildOutputs {
 
     process.stdout.write(JSON.stringify({
       core: namesOf(builds.find(build => build.name === 'core')),
+      localePacks: builds
+        .filter(build => build.name.startsWith('locale-'))
+        .map(build => build.fileName('umd', entryNameOf(build))),
       coreStylesheet: CORE_STYLESHEET_FILENAME,
       mathStylesheet: MATH_STYLESHEET_FILENAME,
       all: builds.flatMap(namesOf),
@@ -226,11 +231,20 @@ describe('cdnjs auto-update', () => {
 
 describe('cdnjs file map', () => {
   it('should only mirror files the build emits', () => {
-    const emitted = [...outputs.core, outputs.coreStylesheet, outputs.mathStylesheet];
+    const emitted = [...outputs.core, ...outputs.localePacks, outputs.coreStylesheet, outputs.mathStylesheet];
 
     expect(mirrored.length).toBeGreaterThan(0);
     for (const file of mirrored) {
       expect(emitted).toContain(file);
+    }
+  });
+
+  // The packs are fetched at runtime by src/service/localePack.ts, resolved
+  // against the URL maidr.js was loaded from, the same way as the maths
+  // stylesheet. A pack left unmirrored is a language cdnjs pages cannot speak.
+  it('should mirror every locale pack maidr.js fetches at runtime', () => {
+    for (const pack of outputs.localePacks) {
+      expect(mirrored).toContain(pack);
     }
   });
 
@@ -251,7 +265,9 @@ describe('cdnjs file map', () => {
   });
 
   it('should not mirror sourcemaps or adapter bundles', () => {
-    const adapters = outputs.all.filter(name => !outputs.core.includes(name));
+    const adapters = outputs.all.filter(
+      name => !outputs.core.includes(name) && !outputs.localePacks.includes(name),
+    );
 
     for (const file of mirrored) {
       expect(file).not.toMatch(/\.map$/);

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -239,7 +239,7 @@ describe('cdnjs file map', () => {
     }
   });
 
-  // The packs are fetched at runtime by src/service/localePack.ts, resolved
+  // The packs are fetched at runtime by src/util/i18n/localePack.ts, resolved
   // against the URL maidr.js was loaded from, the same way as the maths
   // stylesheet. A pack left unmirrored is a language cdnjs pages cannot speak.
   it('should mirror every locale pack maidr.js fetches at runtime', () => {

--- a/test/model/instructionKorean.test.ts
+++ b/test/model/instructionKorean.test.ts
@@ -6,6 +6,8 @@ import { Context } from '@model/context';
 import { Figure } from '@model/plot';
 import { TraceType } from '@type/grammar';
 import { setLocale } from '@util/i18n';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 /**
  * The model layer speaks: everything a reader hears before they touch a chart

--- a/test/scripts/buildLocaleAlias.test.ts
+++ b/test/scripts/buildLocaleAlias.test.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * `scripts/build.js` is plain ESM and `allowJs` is false, so its facts are
+ * read out of a node subprocess, as `buildOutputFilenames.test.ts` does.
+ */
+const ROOT = resolve(__dirname, '../..');
+const BUILD_SCRIPT = pathToFileURL(resolve(ROOT, 'scripts/build.js')).href;
+
+function expand(names: string[]): string[] {
+  const source = `
+    import { expandBuildNames } from ${JSON.stringify(BUILD_SCRIPT)};
+    process.stdout.write(JSON.stringify(expandBuildNames(${JSON.stringify(names)})));
+  `;
+  const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', source], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return JSON.parse(stdout) as string[];
+}
+
+describe('build name shorthand', () => {
+  it('should expand locales to every locale pack build', () => {
+    const names = expand(['core', 'locales']);
+
+    expect(names[0]).toBe('core');
+    expect(names.slice(1)).toEqual(['ko', 'ja', 'zh', 'es', 'de', 'fr', 'it', 'hi'].map(code => `locale-${code}`));
+  });
+
+  it('should pass any other name through', () => {
+    expect(expand(['react', 'locale-ko'])).toEqual(['react', 'locale-ko']);
+  });
+});

--- a/test/service/help.test.ts
+++ b/test/service/help.test.ts
@@ -5,6 +5,8 @@ import { HelpService } from '@service/help';
 import { getKeymapForScope } from '@service/keybinding';
 import { Scope } from '@type/event';
 import { setLocale, tIn } from '@util/i18n';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 /**
  * Scopes the user can open the help menu from, paired with the label scope

--- a/test/service/localePack.test.ts
+++ b/test/service/localePack.test.ts
@@ -76,15 +76,18 @@ describe('locale pack loading', () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  it('should not fetch a pack the author already put on the page', async () => {
+  it('should wait for a pack the author already put on the page rather than fetch it again', async () => {
     loadedFrom(CDN);
     const own = document.createElement('script');
     own.src = `${CDN}locale-fr.js`;
     document.head.appendChild(own);
 
-    await ensureLocalePack('fr');
-
+    const attempt = ensureLocalePack('fr');
     expect(packScripts()).toHaveLength(1);
+    registerLocale('fr', en);
+    own.dispatchEvent(new Event('load'));
+
+    await expect(attempt).resolves.toBe(true);
   });
 
   it('should warn once and stay English when the bundle location is unknown', async () => {

--- a/test/service/localePack.test.ts
+++ b/test/service/localePack.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ensureLocalePack, resolveLocalePackUrl } from '@service/localePack';
+import { registerLocale, setLocale } from '@util/i18n';
+import { en } from '@util/i18n/en';
+
+const CDN = 'https://cdn.example.test/npm/maidr@5.0.0/dist/';
+
+/**
+ * Pretends the page loaded maidr.js from a directory, the way the diagnostics
+ * find it: from a script tag whose URL names the bundle.
+ * @param base - The directory the bundle came from
+ */
+function loadedFrom(base: string): void {
+  const script = document.createElement('script');
+  script.src = `${base}maidr.js`;
+  document.head.appendChild(script);
+}
+
+function packScripts(): HTMLScriptElement[] {
+  return [...document.querySelectorAll<HTMLScriptElement>('script[src*="locale-"]')];
+}
+
+describe('locale pack loading', () => {
+  let warn: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    delete window.maidrLocaleBaseUrl;
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    setLocale('en');
+  });
+
+  it('should locate a pack beside the bundle the page loaded', () => {
+    loadedFrom(CDN);
+
+    expect(resolveLocalePackUrl('ko')).toBe(`${CDN}locale-ko.js`);
+  });
+
+  it('should prefer an explicit base URL', () => {
+    loadedFrom(CDN);
+    window.maidrLocaleBaseUrl = 'https://assets.example.test/maidr';
+
+    expect(resolveLocalePackUrl('ja')).toBe('https://assets.example.test/maidr/locale-ja.js');
+  });
+
+  it('should add one script for a locale and resolve when it registers', async () => {
+    loadedFrom(CDN);
+
+    const first = ensureLocalePack('es');
+    const second = ensureLocalePack('es');
+    const [script] = packScripts();
+    expect(packScripts()).toHaveLength(1);
+    expect(script.src).toBe(`${CDN}locale-es.js`);
+    registerLocale('es', en);
+    script.dispatchEvent(new Event('load'));
+
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it('should report failure and keep English when the pack cannot load', async () => {
+    loadedFrom(CDN);
+
+    const attempt = ensureLocalePack('de');
+    packScripts()[0].dispatchEvent(new Event('error'));
+
+    await expect(attempt).resolves.toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not fetch a pack the author already put on the page', async () => {
+    loadedFrom(CDN);
+    const own = document.createElement('script');
+    own.src = `${CDN}locale-fr.js`;
+    document.head.appendChild(own);
+
+    await ensureLocalePack('fr');
+
+    expect(packScripts()).toHaveLength(1);
+  });
+
+  it('should warn once and stay English when the bundle location is unknown', async () => {
+    await expect(ensureLocalePack('it')).resolves.toBe(false);
+
+    expect(packScripts()).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should need no pack for English or a loaded locale', async () => {
+    registerLocale('hi', en);
+
+    await expect(ensureLocalePack('en')).resolves.toBe(true);
+    await expect(ensureLocalePack('hi')).resolves.toBe(true);
+    expect(packScripts()).toHaveLength(0);
+  });
+});

--- a/test/service/settingsLanguage.test.ts
+++ b/test/service/settingsLanguage.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 import { applyStoredLanguage, SETTINGS_KEY, SettingsService } from '@service/settings';
 import { DEFAULT_SETTINGS } from '@type/settings';
 import { getLocale, setLocale } from '@util/i18n';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 // `jest-environment-jsdom` does not expose `structuredClone`, which
 // `SettingsService` uses to clone the default settings.

--- a/test/service/settingsLanguage.test.ts
+++ b/test/service/settingsLanguage.test.ts
@@ -1,10 +1,11 @@
 import type { DisplayService } from '@service/display';
 import type { StorageService } from '@service/storage';
 import type { Settings } from '@type/settings';
-import { afterEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { applyStoredLanguage, SETTINGS_KEY, SettingsService } from '@service/settings';
 import { DEFAULT_SETTINGS } from '@type/settings';
 import { getLocale, setLocale } from '@util/i18n';
+import { stubNavigatorLanguages } from '../util/i18n/navigatorLanguages';
 // The Korean dictionary is a locale pack, not part of the core, so load it.
 import '../../src/locale/ko';
 
@@ -39,7 +40,16 @@ function withLanguage(language: string): Settings {
 }
 
 describe('SettingsService language', () => {
+  // `auto` follows the browser, and the machine running this may well be set
+  // to Korean; pin an English one so the expectations below hold anywhere.
+  let restoreNavigator: () => void = () => {};
+
+  beforeEach(() => {
+    restoreNavigator = stubNavigatorLanguages(['en-US']);
+  });
+
   afterEach(() => {
+    restoreNavigator();
     setLocale('en');
   });
 

--- a/test/service/textKorean.test.ts
+++ b/test/service/textKorean.test.ts
@@ -7,6 +7,8 @@ import { TraceFactory } from '@model/factory';
 import { TextService } from '@service/text';
 import { TraceType } from '@type/grammar';
 import { setLocale } from '@util/i18n';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 /**
  * The text service is the surface a reader hears on every arrow key, so it is

--- a/test/state/hook/useLocale.test.tsx
+++ b/test/state/hook/useLocale.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { MessageKey } from '@util/i18n';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { useLocale } from '@state/hook/useLocale';
+import { act, render, screen } from '@testing-library/react';
+import { registerLocale, setLocale } from '@util/i18n';
+import { en } from '@util/i18n/en';
+import React from 'react';
+// The `/jest-globals` entry point augments the imported `expect`.
+import '@testing-library/jest-dom/jest-globals';
+
+/**
+ * A dictionary that answers every key with a marker.
+ * @param marker - What every message renders as
+ * @returns A complete dictionary
+ */
+function stub(marker: string): Readonly<Record<MessageKey, string>> {
+  return Object.fromEntries(Object.keys(en).map(key => [key, marker])) as Readonly<Record<MessageKey, string>>;
+}
+
+const Title: React.FC = () => {
+  const { locale, t } = useLocale();
+  return <h1 lang={locale}>{t('settings.title')}</h1>;
+};
+
+describe('useLocale', () => {
+  afterEach(() => {
+    setLocale('en');
+  });
+
+  it('should re-render when the language changes', () => {
+    render(<Title />);
+    expect(screen.getByRole('heading')).toHaveTextContent(en['settings.title']);
+
+    act(() => setLocale('ko'));
+
+    expect(screen.getByRole('heading').getAttribute('lang')).toBe('ko');
+  });
+
+  it('should re-render when the active language\'s pack arrives', () => {
+    act(() => setLocale('it'));
+    render(<Title />);
+    // The pack is not here yet, so the heading is still English.
+    expect(screen.getByRole('heading')).toHaveTextContent(en['settings.title']);
+
+    act(() => registerLocale('it', stub('Impostazioni')));
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Impostazioni');
+    expect(screen.getByRole('heading').getAttribute('lang')).toBe('it');
+  });
+});

--- a/test/ui/descriptionKorean.test.tsx
+++ b/test/ui/descriptionKorean.test.tsx
@@ -26,6 +26,8 @@ import Description from '@ui/component/Description';
 import { DEFAULT_LOCALE, setLocale } from '@util/i18n';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom/jest-globals';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 const DESCRIPTION_DATA: DescriptionState = {
   chartType: 'Bar Chart',

--- a/test/ui/initialInstructionLanguage.esm-test.tsx
+++ b/test/ui/initialInstructionLanguage.esm-test.tsx
@@ -17,6 +17,8 @@ import { TraceType } from '@type/grammar';
 import { setLocale } from '@util/i18n';
 import { renderToString } from 'react-dom/server.node';
 import { Maidr } from '../../src/maidr-component';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 const data: MaidrData = {
   id: 'language-test',

--- a/test/ui/settings.language.test.tsx
+++ b/test/ui/settings.language.test.tsx
@@ -32,6 +32,8 @@ import { setLocale } from '@util/i18n';
 // The `/jest-globals` entry point augments the imported `expect`; the bare
 // one only augments the ambient global.
 import '@testing-library/jest-dom/jest-globals';
+// The Korean dictionary is a locale pack, not part of the core, so load it.
+import '../../src/locale/ko';
 
 /** The `SettingsViewModel` surface `Settings` actually calls. */
 type SettingsStub = Pick<

--- a/test/util/i18n/dictionaries.test.ts
+++ b/test/util/i18n/dictionaries.test.ts
@@ -1,5 +1,7 @@
 import { dictionary, SUPPORTED_LOCALES } from '@util/i18n';
 import { en } from '@util/i18n/en';
+// Every dictionary is a locale pack, not part of the core, so load them all.
+import '../../../src/locale/all';
 
 type Dictionary = Record<string, string>;
 
@@ -9,7 +11,7 @@ type Dictionary = Record<string, string>;
  * @returns Each supported locale with its dictionary
  */
 function dictionaries(): Array<[string, Dictionary]> {
-  return SUPPORTED_LOCALES.map(locale => [locale, dictionary(locale) as Dictionary]);
+  return SUPPORTED_LOCALES.map(locale => [locale, (dictionary(locale) ?? {}) as Dictionary]);
 }
 
 /**
@@ -23,6 +25,10 @@ function placeholders(template: string): string[] {
 
 describe('dictionaries', () => {
   const english = en as Dictionary;
+
+  it('should have every known locale loaded', () => {
+    expect(SUPPORTED_LOCALES.filter(locale => dictionary(locale) === undefined)).toEqual([]);
+  });
 
   describe.each(dictionaries())('%s', (locale, dictionary) => {
     // A placeholder the English fills may be dropped where the language says

--- a/test/util/i18n/i18n.test.ts
+++ b/test/util/i18n/i18n.test.ts
@@ -11,6 +11,7 @@ import {
   setLocale,
   SUPPORTED_LOCALES,
 } from '@util/i18n';
+import { stubNavigatorLanguages } from './navigatorLanguages';
 // Every dictionary is a locale pack, not part of the core, so load them all.
 import '../../../src/locale/all';
 
@@ -75,15 +76,14 @@ describe('i18n', () => {
   });
 
   describe('browserLanguages', () => {
-    const original = Object.getOwnPropertyDescriptors(navigator);
+    let restoreNavigator: () => void = () => {};
 
     function stubNavigator(languages: readonly string[] | undefined, language: string): void {
-      Object.defineProperty(navigator, 'languages', { value: languages, configurable: true });
-      Object.defineProperty(navigator, 'language', { value: language, configurable: true });
+      restoreNavigator = stubNavigatorLanguages(languages, language);
     }
 
     afterEach(() => {
-      Object.defineProperties(navigator, original);
+      restoreNavigator();
     });
 
     it('should prefer the full preference list', () => {

--- a/test/util/i18n/i18n.test.ts
+++ b/test/util/i18n/i18n.test.ts
@@ -11,6 +11,8 @@ import {
   setLocale,
   SUPPORTED_LOCALES,
 } from '@util/i18n';
+// Every dictionary is a locale pack, not part of the core, so load them all.
+import '../../../src/locale/all';
 
 describe('i18n', () => {
   afterEach(() => {

--- a/test/util/i18n/localePack.test.ts
+++ b/test/util/i18n/localePack.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { ensureLocalePack, resolveLocalePackUrl } from '@service/localePack';
 import { registerLocale, setLocale } from '@util/i18n';
 import { en } from '@util/i18n/en';
+import { ensureLocalePack, resolveLocalePackUrl } from '@util/i18n/localePack';
 
 const CDN = 'https://cdn.example.test/npm/maidr@5.0.0/dist/';
 

--- a/test/util/i18n/navigatorLanguages.ts
+++ b/test/util/i18n/navigatorLanguages.ts
@@ -1,0 +1,36 @@
+/**
+ * Stubs the languages `navigator` reports, for tests of anything that follows
+ * the browser's language.
+ *
+ * Jest's node environment hands every test file in a worker the outer realm's
+ * one `navigator`, so a stub left on it is seen by whichever file runs next in
+ * that worker — and `Object.getOwnPropertyDescriptors` is no help for undoing
+ * one: `languages` and `language` live on `Navigator.prototype`, so there is
+ * no own descriptor to capture, and re-defining an empty set leaves the stub
+ * in place. The restore returned here deletes the own properties instead,
+ * which uncovers the prototype's getters again.
+ * @param languages - What `navigator.languages` reports; `undefined` mimics a browser without the list
+ * @param language - What `navigator.language` reports; the first of `languages` by default
+ * @returns Puts the original values back
+ */
+export function stubNavigatorLanguages(
+  languages: readonly string[] | undefined,
+  language: string = languages?.[0] ?? '',
+): () => void {
+  const original = {
+    languages: Object.getOwnPropertyDescriptor(navigator, 'languages'),
+    language: Object.getOwnPropertyDescriptor(navigator, 'language'),
+  };
+  Object.defineProperty(navigator, 'languages', { value: languages, configurable: true });
+  Object.defineProperty(navigator, 'language', { value: language, configurable: true });
+  return () => {
+    for (const key of ['languages', 'language'] as const) {
+      const descriptor = original[key];
+      if (descriptor) {
+        Object.defineProperty(navigator, key, descriptor);
+      } else {
+        Reflect.deleteProperty(navigator, key);
+      }
+    }
+  };
+}

--- a/test/util/i18n/pack.test.ts
+++ b/test/util/i18n/pack.test.ts
@@ -1,0 +1,96 @@
+import type { MessageKey } from '@util/i18n';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { en } from '@util/i18n/en';
+
+type Messages = Readonly<Record<MessageKey, string>>;
+
+const GLOBAL = globalThis as unknown as { maidrLocales?: unknown };
+
+/**
+ * A dictionary that answers every key with a marker, enough to tell one
+ * registration from another.
+ * @param marker - The text every message renders as
+ * @returns A complete dictionary
+ */
+function stub(marker: string): Messages {
+  return Object.fromEntries(Object.keys(en).map(key => [key, marker])) as Messages;
+}
+
+describe('locale packs', () => {
+  afterEach(() => {
+    jest.resetModules();
+    delete GLOBAL.maidrLocales;
+  });
+
+  it('should register a pack queued before the core bundle runs', async () => {
+    const pack = await import('@util/i18n/pack');
+    pack.registerLocalePack('ko', stub('queued'));
+
+    const i18n = await import('@util/i18n');
+
+    expect(i18n.isLocaleLoaded('ko')).toBe(true);
+    expect(i18n.tIn('ko', 'settings.title')).toBe('queued');
+  });
+
+  it('should register a pack pushed after the core bundle runs', async () => {
+    const i18n = await import('@util/i18n');
+    const pack = await import('@util/i18n/pack');
+    expect(i18n.isLocaleLoaded('ja')).toBe(false);
+
+    pack.registerLocalePack('ja', stub('late'));
+
+    expect(i18n.isLocaleLoaded('ja')).toBe(true);
+    expect(i18n.tIn('ja', 'settings.title')).toBe('late');
+  });
+
+  it('should speak English until the active locale has a pack, then switch', async () => {
+    const i18n = await import('@util/i18n');
+    const pack = await import('@util/i18n/pack');
+    const listener = jest.fn();
+    i18n.onLocaleChange(listener);
+    i18n.setLocale('fr');
+
+    expect(i18n.t('settings.title')).toBe(en['settings.title']);
+
+    pack.registerLocalePack('fr', stub('bonjour'));
+
+    expect(i18n.t('settings.title')).toBe('bonjour');
+    expect(listener).toHaveBeenLastCalledWith('fr');
+    i18n.setLocale('en');
+  });
+
+  it('should not notify listeners for a pack the reader is not using', async () => {
+    const i18n = await import('@util/i18n');
+    const pack = await import('@util/i18n/pack');
+    const listener = jest.fn();
+    i18n.onLocaleChange(listener);
+
+    pack.registerLocalePack('de', stub('hallo'));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should ignore a pack for a locale it does not know', async () => {
+    const i18n = await import('@util/i18n');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    i18n.registerLocale('tlh' as never, stub('nuqneH'));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(i18n.dictionary('tlh' as never)).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  it('should hand packs to every bundle that adopts the queue', async () => {
+    const pack = await import('@util/i18n/pack');
+    const first = jest.fn();
+    const second = jest.fn();
+    pack.adoptLocalePacks(first);
+    pack.adoptLocalePacks(second);
+
+    pack.registerLocalePack('it', stub('ciao'));
+
+    expect(first).toHaveBeenCalledWith('it', expect.anything());
+    expect(second).toHaveBeenCalledWith('it', expect.anything());
+  });
+});

--- a/test/util/i18n/pack.test.ts
+++ b/test/util/i18n/pack.test.ts
@@ -93,4 +93,18 @@ describe('locale packs', () => {
     expect(first).toHaveBeenCalledWith('it', expect.anything());
     expect(second).toHaveBeenCalledWith('it', expect.anything());
   });
+
+  it('should catch a later bundle up on packs an earlier one already took', async () => {
+    const pack = await import('@util/i18n/pack');
+    const first = jest.fn();
+    pack.registerLocalePack('es', stub('hola'));
+    pack.adoptLocalePacks(first);
+    pack.registerLocalePack('de', stub('hallo'));
+    const second = jest.fn();
+
+    pack.adoptLocalePacks(second);
+
+    expect(second.mock.calls.map(([locale]) => locale)).toEqual(['es', 'de']);
+    expect(first).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Each language added in #1246 and #1250 grew `maidr.js` by about 70 KB for every page, whether or not that page ever spoke it. This change moves every dictionary but English out of the core bundle into a **locale pack**, a small file beside `maidr.js`, and has MAIDR fetch a pack itself when a language is chosen and the page has not loaded it.

| Bundle | Before | After |
| ------ | ------ | ----- |
| `dist/maidr.js` | 2.25 MB (nine languages built in) | 1.71 MB (English only) |
| `dist/locale-<code>.js` | — | 58 to 91 KB each, loaded only when needed |

Adding a tenth language now costs nothing to pages that do not use it.

## Related Issues

Follows #1246, #1248, and #1250.

## Changes Made

**Registry** (`src/util/i18n/index.ts`, `src/util/i18n/pack.ts`)
- `MESSAGES` holds English and whatever packs have registered. `registerLocale(locale, messages)` adds a dictionary; `isLocaleLoaded` and `dictionary` report what is present. `t()` for an active locale whose pack has not arrived renders English, and registration re-renders once it does.
- Packs meet the core through `globalThis.maidrLocales`, the `dataLayer` pattern: a plain array before the core runs, an object whose `push` registers immediately after. Either load order works, and a second MAIDR bundle on the same page chains onto the first so both hear every pack.
- `getLocaleRevision()` advances on a locale switch and on a pack registering for the active locale. `useLocale()` subscribes to the revision rather than the locale string, since a late pack changes every message while leaving the locale unchanged; the pre-activation instruction memo keys on it too.

**Loader** (`src/util/i18n/localePack.ts`)
- `ensureLocalePack(locale)` resolves the pack's URL beside `maidr.js` (the same way `maidr-math.css` is found), or from `window.maidrLocaleBaseUrl`, injects one script per locale, and resolves once the pack registers. A pack already registered, in flight, or present as the author's own tag is not fetched again. When no location can be found it warns once and English stays.
- `SettingsService` calls it after every locale switch (page load, save, reset), so the switch never waits on the network.

**Packs** (`src/locale/<code>.ts`, `src/locale/all.ts`)
- Each pack is three lines: import its dictionary, register it. It imports nothing from the core, which is what keeps it to the size of its dictionary. `all.ts` loads every pack for a page that would rather have one file.

**Build and publishing** (`scripts/build.js`, `package.json`, `cdnjs/maidr.json`)
- `LOCALE_PACKS` generates a build per language emitting `locale-<code>.js` (classic script) and `locale-<code>.mjs`. Flat names rather than a `locale/` directory because each pack builds in its own worker and the merge step treats a directory two workers both emit as a collision. npm exports `maidr/locale/*`; cdnjs mirrors the eight classic-script packs.

**Tests**
- `test/util/i18n/pack.test.ts`: packs queued before or pushed after the core, English until the active pack arrives then a switch with listeners told, no notification for an unused locale, unknown locales ignored with a warning, two adopters both served.
- `test/util/i18n/localePack.test.ts`: URL resolution beside the bundle and from the override, one script per locale, resolution on load, failure on error, no refetch of an author's tag, warning when the bundle cannot be located.
- `test/state/hook/useLocale.test.tsx`: a component re-renders on a locale change and when the active locale's pack arrives.
- Existing Korean and multi-language tests load the packs they need; `dictionaries.test.ts` loads all of them and asserts every known locale is present.
- `e2e_tests/specs/languageAutoDetect.spec.ts` now exercises the runtime path the example pages take: `maidr.js` alone, then the pack fetched from beside it, for all nine browser locales.
- `test/cdnjs/manifest.test.ts` checks every pack is mirrored by name.
- `test/util/i18n/navigatorLanguages.ts`: a shared stub for the browser's languages whose restore removes the own properties it added, since Jest's node environment shares one `navigator` across the files in a worker; the i18n and settings language suites use it.

**Docs**: `docs/LOCALIZATION.md` explains the packs, both load orders, `window.maidrLocaleBaseUrl`, and the steps to add a language; the README mentions the packs.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- Behaviour change to be aware of: a page that loads only `maidr.js` now hears one English announcement cycle before the fetched pack registers. A page that wants the very first announcement in the reader's language loads the pack itself (`<script src=".../locale-ko.js">` before or after the bundle, or `import 'maidr/locale/ko'`); `test/ui/initialInstructionLanguage.esm-test.tsx` pins that case.
- Key compaction (packing dictionaries as arrays aligned to the English key order) was considered and left out: with packs opt-in it saves only a few KB gzipped per language, and it would couple each pack to the exact key order of one core version, so a CDN serving a newer core with an older pack would render the wrong strings.
- Verified locally: `npm run lint:fix` and `npm run type-check` clean; the i18n, pack, loader, hook, Korean, cdnjs, and build-config suites pass; `languageAutoDetect` and `dialogAccessibility` E2E specs pass in Chromium against a fresh core and pack build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117eUjVDozabMwNNBBVmigY

---
_Generated by [Claude Code](https://claude.ai/code/session_0117eUjVDozabMwNNBBVmigY)_