### PR TITLE
refactor(service): identify rotor modes by a key instead of their label

### DIFF
--- a/src/service/rotor.ts
+++ b/src/service/rotor.ts
@@ -7,6 +7,35 @@ import { isGridNavigable, isPointNavigable } from '@type/navigation';
 import { t } from '@util/i18n';
 
 /**
+ * What identifies a rotor mode: the six built-in modes by name, and a
+ * trace's own filter units by their {@link RotorFilterUnit.key}.
+ */
+export type RotorModeKey
+  = | 'data'
+    | 'lower'
+    | 'higher'
+    | 'grid'
+    | 'point'
+    | 'intersection'
+    | `filter:${string}`;
+
+/**
+ * A mode the rotor can cycle to.
+ *
+ * `key` is the mode's identity and is what every dispatch compares on;
+ * `label` is only what gets announced. Keeping them apart means two modes
+ * whose names happen to render alike in some language stay two modes, and
+ * a keystroke never has to render a name to find out where it is.
+ */
+export interface RotorMode {
+  key: RotorModeKey;
+  label: string;
+}
+
+/** What a filter unit's key is prefixed with to become a rotor mode key. */
+const FILTER_PREFIX = 'filter:';
+
+/**
  * Manages rotor-based navigation for the active trace via alt+shift+up and alt+shift+down
  *
  * Purpose:
@@ -94,8 +123,8 @@ export class RotorNavigationService {
    * For other modes, returns the mode name.
    */
   private formatModeDisplay(): string {
-    const mode = this.getMode();
-    if (mode === t('rotor.gridMode')) {
+    const mode = this.activeMode();
+    if (mode.key === 'grid') {
       const activeTrace = this.context.active;
       if (isGridNavigable(activeTrace)) {
         const dims = activeTrace.getGridDimensions();
@@ -104,7 +133,7 @@ export class RotorNavigationService {
         }
       }
     }
-    return mode;
+    return mode.label;
   }
 
   /**
@@ -153,17 +182,17 @@ export class RotorNavigationService {
    * @returns Error message if move failed, null otherwise
    */
   public moveUp(): string | null {
-    // Resolve the current rotor mode once. getMode() walks the capability
+    // Resolve the current rotor mode once. activeMode() walks the capability
     // list via getAvailableModes(), so caching it here avoids doing that
     // twice per keystroke when dispatching to GRID_MODE / INTERSECTION_MODE.
-    const mode = this.getMode();
-    if (mode === t('rotor.gridMode')) {
+    const mode = this.activeMode();
+    if (mode.key === 'grid') {
       return this.moveGrid('up');
     }
-    if (mode === t('rotor.pointMode')) {
+    if (mode.key === 'point') {
       return this.movePoint('up');
     }
-    if (mode === t('rotor.intersectionMode')) {
+    if (mode.key === 'intersection') {
       // The model is intentionally NOT moved here — vertical navigation is
       // unavailable in intersection mode. We still must push the message
       // through notification.notify so the text alert region re-mounts and
@@ -201,14 +230,14 @@ export class RotorNavigationService {
    * @returns Error message if move failed, null otherwise
    */
   public moveDown(): string | null {
-    const mode = this.getMode();
-    if (mode === t('rotor.gridMode')) {
+    const mode = this.activeMode();
+    if (mode.key === 'grid') {
       return this.moveGrid('down');
     }
-    if (mode === t('rotor.pointMode')) {
+    if (mode.key === 'point') {
       return this.movePoint('down');
     }
-    if (mode === t('rotor.intersectionMode')) {
+    if (mode.key === 'intersection') {
       // See moveUp() — model not moved; route through notification so the
       // alert region re-mounts and the SR re-announces on repeat presses.
       return this.announceRotorMessage(this.getIntersectionVerticalUnavailableMessage());
@@ -242,14 +271,14 @@ export class RotorNavigationService {
    * @returns Error message if move failed, null otherwise
    */
   public moveLeft(): string | null {
-    const mode = this.getMode();
-    if (mode === t('rotor.gridMode')) {
+    const mode = this.activeMode();
+    if (mode.key === 'grid') {
       return this.moveGrid('left');
     }
-    if (mode === t('rotor.pointMode')) {
+    if (mode.key === 'point') {
       return this.movePoint('left');
     }
-    if (mode === t('rotor.intersectionMode')) {
+    if (mode.key === 'intersection') {
       return this.moveIntersection('left');
     }
 
@@ -281,14 +310,14 @@ export class RotorNavigationService {
    * @returns Error message if move failed, null otherwise
    */
   public moveRight(): string | null {
-    const mode = this.getMode();
-    if (mode === t('rotor.gridMode')) {
+    const mode = this.activeMode();
+    if (mode.key === 'grid') {
       return this.moveGrid('right');
     }
-    if (mode === t('rotor.pointMode')) {
+    if (mode.key === 'point') {
       return this.movePoint('right');
     }
-    if (mode === t('rotor.intersectionMode')) {
+    if (mode.key === 'intersection') {
       return this.moveIntersection('right');
     }
 
@@ -318,8 +347,8 @@ export class RotorNavigationService {
    * Sets the rotor mode based on the current index and updates context state.
    */
   public setMode(): void {
-    const currMode = this.getMode();
-    if (this.isDataMode(currMode)) {
+    const mode = this.activeMode();
+    if (mode.key === 'data') {
       this.context.setRotorEnabled(false);
       this.notifyGridMode(false);
       this.notifyPointMode(false);
@@ -339,9 +368,9 @@ export class RotorNavigationService {
     this.notifyGridMode(false);
     this.notifyPointMode(false);
     this.notifyIntersectionMode(false);
-    this.notifyGridMode(currMode === t('rotor.gridMode'));
-    this.notifyPointMode(currMode === t('rotor.pointMode'));
-    this.notifyIntersectionMode(currMode === t('rotor.intersectionMode'));
+    this.notifyGridMode(mode.key === 'grid');
+    this.notifyPointMode(mode.key === 'point');
+    this.notifyIntersectionMode(mode.key === 'intersection');
   }
 
   /**
@@ -358,10 +387,17 @@ export class RotorNavigationService {
    * @returns The display name of the current rotor mode
    */
   public getMode(): string {
+    return this.activeMode().label;
+  }
+
+  /**
+   * The mode the rotor index points at, with its key.
+   * @returns The current rotor mode
+   */
+  private activeMode(): RotorMode {
     const modes = this.getAvailableModes();
     // Clamp index in case modes list changed between cycles
-    const idx = this.rotorIndex % modes.length;
-    return modes[idx];
+    return modes[this.rotorIndex % modes.length];
   }
 
   /**
@@ -386,14 +422,7 @@ export class RotorNavigationService {
    * @returns 'lower' or 'higher' based on the current mode
    */
   public getCompareType(): 'lower' | 'higher' {
-    const info = this.getCompareInfo();
-    const currMode = this.getMode();
-    if (currMode === info.higher.label) {
-      return 'higher';
-    } else if (currMode === info.lower.label) {
-      return 'lower';
-    }
-    return 'lower'; // fallback
+    return this.activeMode().key === 'higher' ? 'higher' : 'lower';
   }
 
   /**
@@ -451,55 +480,56 @@ export class RotorNavigationService {
    *   6. INTERSECTION_MODE  (if supportsIntersectionMode — e.g. multiline lines)
    *   7. Filter units       (getRotorFilterUnits — e.g. candlestick trend filters)
    */
-  private getAvailableModes(): string[] {
+  private getAvailableModes(): RotorMode[] {
     const activeTrace = this.context.active;
-    const modes: string[] = [];
+    const modes: RotorMode[] = [];
 
     if (activeTrace instanceof AbstractTrace) {
-      modes.push(activeTrace.dataModeName());
+      modes.push({ key: 'data', label: activeTrace.dataModeName() });
 
       if (activeTrace.supportsCompareMode()) {
         const compareInfo = activeTrace.compareModeInfo();
-        modes.push(compareInfo.lower.label);
-        modes.push(compareInfo.higher.label);
+        modes.push({ key: 'lower', label: compareInfo.lower.label });
+        modes.push({ key: 'higher', label: compareInfo.higher.label });
       }
 
       if (isGridNavigable(activeTrace) && activeTrace.supportsGridMode()) {
-        modes.push(t('rotor.gridMode'));
+        modes.push({ key: 'grid', label: t('rotor.gridMode') });
       }
 
       if (activeTrace.supportsPointMode()) {
-        modes.push(t('rotor.pointMode'));
+        modes.push({ key: 'point', label: t('rotor.pointMode') });
       }
 
       if (activeTrace.supportsIntersectionMode()) {
-        modes.push(t('rotor.intersectionMode'));
+        modes.push({ key: 'intersection', label: t('rotor.intersectionMode') });
       }
 
       for (const unit of activeTrace.getRotorFilterUnits()) {
-        modes.push(unit.label);
+        modes.push({ key: `${FILTER_PREFIX}${unit.key}`, label: unit.label });
       }
     } else {
-      modes.push(t('rotor.dataMode'));
+      modes.push({ key: 'data', label: t('rotor.dataMode') });
     }
 
     return modes;
   }
 
   /**
-   * Resolves the trace's rotor filter unit matching the current mode, or null
-   * when the current mode is a built-in (data/compare/grid/intersection) mode.
-   * Filter units are matched by label, the same string cycled through the
-   * rotor, so a stale index from a previous trace cannot resolve to the wrong
-   * unit.
+   * Resolves the trace's rotor filter unit behind a mode, or null when the
+   * mode is a built-in (data/compare/grid/point/intersection) one. Units are
+   * matched on the key the trace gave them, read back out of the mode's key,
+   * so a stale index from a previous trace cannot resolve to the wrong unit.
+   * @param mode - The current rotor mode
    * @returns The active filter unit, or null
    */
-  private getActiveFilterUnit(mode: string): RotorFilterUnit | null {
+  private getActiveFilterUnit(mode: RotorMode): RotorFilterUnit | null {
     const activeTrace = this.context.active;
-    if (!(activeTrace instanceof AbstractTrace)) {
+    if (!(activeTrace instanceof AbstractTrace) || !mode.key.startsWith(FILTER_PREFIX)) {
       return null;
     }
-    return activeTrace.getRotorFilterUnits().find(unit => unit.label === mode) ?? null;
+    const key = mode.key.slice(FILTER_PREFIX.length);
+    return activeTrace.getRotorFilterUnits().find(unit => unit.key === key) ?? null;
   }
 
   /**
@@ -556,19 +586,6 @@ export class RotorNavigationService {
       t('rotor.filterVerticalUnavailableTerse', { noun: unit.noun }),
       t('rotor.filterVerticalUnavailableVerbose', { noun: unit.noun }),
     );
-  }
-
-  /**
-   * Checks if the given mode name is a data mode. Besides the two classic
-   * names, the active trace's own dataModeName() counts — traces like the
-   * candlestick delta layer rename their default unit.
-   */
-  private isDataMode(mode: string): boolean {
-    if (mode === t('rotor.dataMode') || mode === t('rotor.rowColMode')) {
-      return true;
-    }
-    const activeTrace = this.context.active;
-    return activeTrace instanceof AbstractTrace && mode === activeTrace.dataModeName();
   }
 
   /**

--- a/test/service/rotor.test.ts
+++ b/test/service/rotor.test.ts
@@ -620,3 +620,52 @@ describe('RotorNavigationService point mode', () => {
     expect(second.moveOnce('FORWARD')).toBe(true);
   });
 });
+
+describe('RotorNavigationService mode identity', () => {
+  // A mode is identified by its key, never by the name it is announced under.
+  // Names are translated, and nothing stops two of them rendering the same in
+  // some language; two modes with one name must still be two modes.
+
+  test('tells the two compare modes apart when their labels render the same', () => {
+    const trace = createTraceWithIntersections();
+    jest.spyOn(trace, 'compareModeInfo').mockReturnValue({
+      lower: { label: 'SAME NAME', noun: 'lower' },
+      higher: { label: 'SAME NAME', noun: 'higher' },
+    });
+    const service = new RotorNavigationService(
+      createMockContext(trace),
+      createMockTextService(),
+      createMockNotificationService(),
+    );
+
+    service.moveToNextRotorUnit();
+    const first = service.getCompareType();
+    service.moveToNextRotorUnit();
+    const second = service.getCompareType();
+
+    expect([first, second]).toEqual(['lower', 'higher']);
+  });
+
+  test('keeps a filter unit apart from the data mode when their labels collide', () => {
+    const trace = createTraceWithIntersections();
+    jest.spyOn(trace, 'getRotorFilterUnits').mockReturnValue([
+      { key: 'twin', label: trace.dataModeName(), noun: 'twin' },
+    ]);
+    const moveToRotorFilter = jest.spyOn(trace, 'moveToRotorFilter').mockReturnValue(true);
+    const context = createMockContext(trace);
+    const service = new RotorNavigationService(
+      context,
+      createMockTextService(),
+      createMockNotificationService(),
+    );
+
+    // data → lower → higher → intersection → the filter unit
+    for (let i = 0; i < 4; i++) {
+      service.moveToNextRotorUnit();
+    }
+    service.moveRight();
+
+    expect(context.setRotorEnabled).toHaveBeenLastCalledWith(true);
+    expect(moveToRotorFilter).toHaveBeenCalledWith('twin', 'right');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`RotorNavigationService` found its active mode by comparing the announced name: every dispatch read `mode === t('rotor.gridMode')`, `getCompareType` compared against the compare labels, `isDataMode` against three data-mode names, and filter units were matched by `unit.label === mode`. Since #1246 those names are translated, so a display string was doing the job of an identity. Two modes rendering alike in some language would silently merge (a filter unit named like the data mode would disable the rotor), and every arrow keystroke rendered up to seven names to find out where the rotor was.

Each mode now carries a stable key beside its label, and the service compares on the key everywhere. Only announcements read the label.

## Related Issues

Closes #1247

## Changes Made

**Service** (`src/service/rotor.ts`)
- `RotorMode { key, label }` and `RotorModeKey`: the six built-in modes by name (`data`, `lower`, `higher`, `grid`, `point`, `intersection`) and a trace's filter units as `filter:<unit.key>`.
- `getAvailableModes()` returns `RotorMode[]`; a private `activeMode()` resolves the current one. `getMode()` keeps returning the label, so its callers and the display path are unchanged.
- Every dispatch in `moveUp/Down/Left/Right`, `formatModeDisplay`, and `setMode` compares `mode.key`. `getCompareType` reads the key; `getActiveFilterUnit` reads the unit key back out of the mode key and matches on `unit.key`. `isDataMode` is gone: the data mode is the mode whose key is `data`, whatever a trace names it.
- No model change: `RotorFilterUnit` already carried a `key`, and `dataModeName()` / `compareModeInfo()` keep supplying labels.

**Tests** (`test/service/rotor.test.ts`)
- Two compare modes whose labels render the same are still told apart (`lower`, then `higher`). A filter unit whose label collides with the data mode's still enables the rotor and routes moves to `moveToRotorFilter` with its key. Both fail on the previous service and pass on this one.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- Verified locally: `npm run lint:fix` and `npm run type-check` clean; the rotor, candlestick rotor, candlestick delta, rotor view model, and rotor-reset command suites pass (9 suites, 112 tests). CI runs the full set.
- Behaviour for readers is unchanged: the same modes are offered in the same order under the same names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117eUjVDozabMwNNBBVmigY

---
_Generated by [Claude Code](https://claude.ai/code/session_0117eUjVDozabMwNNBBVmigY)_